### PR TITLE
Add initial list of owners for event triggering ⚡

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,8 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+- iancoffey
+- vtereso
+- ncskier
+- bobcatfish
+- dlorenc


### PR DESCRIPTION
Initial list of owners will be the folks who created the design (see
https://github.com/tektoncd/pipeline/issues/315 for design docs and
discussions)