### PR TITLE
Catch tabs vs spaces with gofmt presubmit linting

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -488,11 +488,11 @@
   revision = "0ee3b1491aa5b38d48b4547eeb4c87d11852b3a3"
 
 [[projects]]
-  digest = "1:5558ceef0c045f9c8a0c08c6e0de89bb0895b1aad69d9722b3748f003564b8cb"
+  digest = "1:b749c54748b755170cecd0bc4099f527d431a7ecd264f680913ce148ee6ee19c"
   name = "github.com/tektoncd/plumbing"
   packages = ["scripts"]
   pruneopts = "UT"
-  revision = "a51e87c5261fdb718470c077c155e070aca690a8"
+  revision = "a268939d0be5ed810f541269f9dd606bb2e66090"
 
 [[projects]]
   digest = "1:cf43b1118f4690d1dbc85392c89a926a89b694d94a9d87a6e6d7f762ba4b8a14"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -57,8 +57,8 @@ required = [
 
 [[constraint]]
   name = "github.com/tektoncd/plumbing"
-  # HEAD as of 2019-06-24
-  revision = "a51e87c5261fdb718470c077c155e070aca690a8"
+  # HEAD as of 2019-07-23
+  revision = "a268939d0be5ed810f541269f9dd606bb2e66090"
 
 [[constraint]]
   name = "github.com/knative/test-infra"

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -99,7 +99,7 @@ func main() {
 			v1alpha1.SchemeGroupVersion.WithKind("TriggerBinding"):  &v1alpha1.TriggerBinding{},
 			v1alpha1.SchemeGroupVersion.WithKind("TriggerTemplate"): &v1alpha1.TriggerTemplate{},
 		},
-		Logger: logger,
+		Logger:                logger,
 		DisallowUnknownFields: true,
 	}
 

--- a/pkg/parse/json/json_test.go
+++ b/pkg/parse/json/json_test.go
@@ -3,10 +3,10 @@ package json_test
 import (
 	"bytes"
 	gojson "encoding/json"
-	"io/ioutil"
 	"fmt"
 	"github.com/tektoncd/triggers/pkg/parse"
 	. "github.com/tektoncd/triggers/pkg/parse/json"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -24,44 +24,44 @@ func TestFieldsFromByteMessage(t *testing.T) {
 			return err
 		}
 		if !info.IsDir() {
-			t.Logf("Reading %s",path)
+			t.Logf("Reading %s", path)
 			b, err := ioutil.ReadFile(path)
 			if err != nil {
 				return err
 			}
-			payloads = append(payloads,b)
-			fileNameTrimmed := strings.TrimSuffix(path,".json")
-			testNames = append(testNames, strings.Replace(strings.Title(fileNameTrimmed),"/","",-1))
+			payloads = append(payloads, b)
+			fileNameTrimmed := strings.TrimSuffix(path, ".json")
+			testNames = append(testNames, strings.Replace(strings.Title(fileNameTrimmed), "/", "", -1))
 		}
 		return nil
 	})
 	if err != nil {
-		t.Fatalf("Unable to load example payloads: %v",err)
+		t.Fatalf("Unable to load example payloads: %v", err)
 	}
 
 	// Validate all fields can be pulled for each respective payload
 	for i := 0; i < len(payloads); i++ {
 		iCopy := i
-		t.Run(testNames[i],func(t *testing.T) {
+		t.Run(testNames[i], func(t *testing.T) {
 			// Grab bindings and expected values
 			eventBindings, expectedValues, err := eventBindingDigger(t, payloads[iCopy], parse.EventInterpolationBase)
 			if err != nil {
-				t.Errorf("Failed to generate event bindings for %s payload",testNames[iCopy])
+				t.Errorf("Failed to generate event bindings for %s payload", testNames[iCopy])
 				return
 			}
 			// Grab actual values
 			actualValues := FieldsFromByteMessage(payloads[iCopy], eventBindings)
 			for j := range actualValues {
-				validationError := fmt.Sprintf("Failed to validate %s binding:",eventBindings[j])
+				validationError := fmt.Sprintf("Failed to validate %s binding:", eventBindings[j])
 				// Remove spacing to normalize both values
 				actualBuffer := new(bytes.Buffer)
 				expectedBuffer := new(bytes.Buffer)
 				if err := gojson.Compact(actualBuffer, []byte(actualValues[j])); err != nil {
-					t.Errorf("%s Unable to compact actual bytes",validationError)
+					t.Errorf("%s Unable to compact actual bytes", validationError)
 					continue
 				}
 				if err := gojson.Compact(expectedBuffer, []byte(expectedValues[j])); err != nil {
-					t.Errorf("%s Unable to compact expected bytes",validationError)
+					t.Errorf("%s Unable to compact expected bytes", validationError)
 					continue
 				}
 				// Grab token to determine value type
@@ -69,12 +69,12 @@ func TestFieldsFromByteMessage(t *testing.T) {
 				decoder := gojson.NewDecoder(expectedBufferCopy)
 				token, err := decoder.Token()
 				if err != nil {
-					t.Errorf("%s Error getting token from expected bytes",validationError)
+					t.Errorf("%s Error getting token from expected bytes", validationError)
 					continue
 				}
 				// Validate the binding maps to the value as intended
 				_, ok := token.(gojson.Delim) // Detect whether the binding is a json structure or primitive
-				if ok { // Compare json structures
+				if ok {                       // Compare json structures
 					var expected, actual interface{}
 					err := gojson.Unmarshal(expectedBuffer.Bytes(), &expected)
 					if err != nil {
@@ -103,45 +103,45 @@ func TestFieldsFromByteMessage(t *testing.T) {
 func TestEventBindingDigger(t *testing.T) {
 	// Small example file/payload used to validate the functionality of eventBindingDigger
 	filePath := "examples/digger/digger.json"
-	t.Logf("Reading %s",filePath)
+	t.Logf("Reading %s", filePath)
 	b, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		t.Error(err)
 	}
 	// Create assertion map
 	// The example digger payload fields have been predefined as space compacted
-	bindingValueMap := map[string]string {
-		parse.Interpolate("event"): string(b),
-		parse.Interpolate("event.a"): `"a"`,
-		parse.Interpolate("event.b"): `true`,
-		parse.Interpolate("event.c"): `30`,
-		parse.Interpolate("event.d"): `[]`,
-		parse.Interpolate("event.e"): `["a"]`,
-		parse.Interpolate("event.f"): `[false]`,
-		parse.Interpolate("event.g"): `[3]`,
-		parse.Interpolate("event.h"): `[{"a":"a"}]`,
-		parse.Interpolate("event.i"): `{"a":"a"}`,
+	bindingValueMap := map[string]string{
+		parse.Interpolate("event"):     string(b),
+		parse.Interpolate("event.a"):   `"a"`,
+		parse.Interpolate("event.b"):   `true`,
+		parse.Interpolate("event.c"):   `30`,
+		parse.Interpolate("event.d"):   `[]`,
+		parse.Interpolate("event.e"):   `["a"]`,
+		parse.Interpolate("event.f"):   `[false]`,
+		parse.Interpolate("event.g"):   `[3]`,
+		parse.Interpolate("event.h"):   `[{"a":"a"}]`,
+		parse.Interpolate("event.i"):   `{"a":"a"}`,
 		parse.Interpolate("event.i.a"): `"a"`,
 	}
 	// Grab values
-	eventBindings, actualValues, err := eventBindingDigger(t,b,parse.EventInterpolationBase)
+	eventBindings, actualValues, err := eventBindingDigger(t, b, parse.EventInterpolationBase)
 	if err != nil {
-		t.Fatalf("Failed to generate event bindings for %s payload",filePath)
+		t.Fatalf("Failed to generate event bindings for %s payload", filePath)
 	}
-	
-	// Ensure sizing is the same 
+
+	// Ensure sizing is the same
 	if len(eventBindings) != len(bindingValueMap) {
-		t.Fatalf("Length of eventBindings[%d] did not match expected[%d]",len(eventBindings),len(bindingValueMap))
+		t.Fatalf("Length of eventBindings[%d] did not match expected[%d]", len(eventBindings), len(bindingValueMap))
 	}
 	if len(actualValues) != len(bindingValueMap) {
-		t.Fatalf("Length of actualValues[%d] did not match expected[%d]",len(actualValues),len(bindingValueMap))
+		t.Fatalf("Length of actualValues[%d] did not match expected[%d]", len(actualValues), len(bindingValueMap))
 	}
 	// Validate against assertion map
-	for i := 0; i< len(eventBindings);i++ {
+	for i := 0; i < len(eventBindings); i++ {
 		expectedValue := bindingValueMap[eventBindings[i]]
 		actualValue := actualValues[i]
 		if actualValue != expectedValue {
-			t.Fatalf("Actual value %s did not match expected %s",actualValue,expectedValue)
+			t.Fatalf("Actual value %s did not match expected %s", actualValue, expectedValue)
 		}
 	}
 }
@@ -169,7 +169,7 @@ func eventBindingDigger(t *testing.T, payload []byte, location string) (eventBin
 		}
 		nestedMap, ok := value.(map[string]interface{})
 		if ok {
-			nestedBytes, _ := gojson.Marshal(&nestedMap) 
+			nestedBytes, _ := gojson.Marshal(&nestedMap)
 			nestedBindings, nestedValues, _ := eventBindingDigger(t, nestedBytes, currentLocation)
 			eventBindings, expectedValues = append(eventBindings, nestedBindings...), append(expectedValues, nestedValues...)
 		} else {

--- a/pkg/parse/validate_test.go
+++ b/pkg/parse/validate_test.go
@@ -8,7 +8,7 @@ import (
 func TestInterpolate(t *testing.T) {
 	binding := "something.something"
 	interpolatedBinding := Interpolate(binding)
-	if interpolatedBinding != fmt.Sprintf("$(%s)",binding) {
+	if interpolatedBinding != fmt.Sprintf("$(%s)", binding) {
 		t.Error("Unexpected interpolated value")
 	}
 }

--- a/vendor/github.com/tektoncd/plumbing/scripts/presubmit-tests.sh
+++ b/vendor/github.com/tektoncd/plumbing/scripts/presubmit-tests.sh
@@ -130,12 +130,20 @@ function markdown_build_tests() {
 }
 
 # Default build test runner that:
+# * check go code style with gofmt
 # * check markdown files
 # * `go build` on the entire repo
 # * run `/hack/verify-codegen.sh` (if it exists)
 # * check licenses in all go packages
 function default_build_test_runner() {
   local failed=0
+  # Check go code style with gofmt; exclude vendor/ files
+  subheader "Checking go code style with gofmt"
+  gofmt_out=$(gofmt -d $(find * -name '*.go' ! -path 'vendor/*'))
+  if [[ -n "$gofmt_out" ]]; then
+    failed=1
+  fi
+  echo "$gofmt_out"
   # Perform markdown build checks first
   markdown_build_tests || failed=1
   # For documentation PRs, just check the md files


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Fixes issue https://github.com/tektoncd/triggers/issues/28.

- Update vendor plumbing repo to use gofmt presubmit linting
- Fix go files with inconsistent spacing

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._