### PR TITLE
Correct the format of variable interpolation from ${} to $()

### DIFF
--- a/docs/triggerbindings.md
+++ b/docs/triggerbindings.md
@@ -20,9 +20,9 @@ spec:
     type: com.github.push
   params:
     - name: gitrevision
-      value: ${event.head_commit.id}
+      value: $(event.head_commit.id)
     - name: gitrepositoryurl
-      value: ${event.repository.url}
+      value: $(event.repository.url)
 ```
 
 One or more `TriggerBindings` are collected together into an [`EventListener`](eventlisteners.md), which is where the pod is actually instantiated that "listens" for the respective events.

--- a/docs/triggertemplates.md
+++ b/docs/triggertemplates.md
@@ -24,16 +24,16 @@ spec:
       kind: PipelineResource
       metadata:
         name: git-source
-        namespace: ${params.namespace}
+        namespace: $(params.namespace)
         labels:
             triggertemplated: true
       spec:
         type: git
         params:
         - name: revision
-          value: ${params.gitrevision}
+          value: $(params.gitrevision)
         - name: url
-          value: ${params.gitrepositoryurl}
+          value: $(params.gitrepositoryurl)
     - apiVersion: tekton.dev/v1alpha1
       kind: PipelineRun
       metadata:


### PR DESCRIPTION
Based on the implementation: https://github.com/tektoncd/triggers/pull/34
and discussion here: https://github.com/tektoncd/pipeline/issues/850
We need correct the type sample here, avoid confuse.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes