### PR TITLE
Adding create-webhook tekton task

### DIFF
--- a/docs/create-webhook-run.yaml
+++ b/docs/create-webhook-run.yaml
@@ -1,0 +1,39 @@
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: create-webhook
+spec:
+  taskRef:
+    name: create-webhook
+  inputs:
+    params:
+    - name: CreateCertificate
+      value: "false"
+    - name: CreateIngress
+      value: "false"
+    - name: CreateWebhook
+      value: "false"
+    - name: CreateEventListener
+      value: "false"
+    - name: EventListenerName
+      value: listener
+    - name: CertificateKeyPassphrase
+      value: pass1
+    - name: CertificateSecretName
+      value: secret1
+    - name: ExternalUrl
+      value: listener.192.168.0.1.nip.io
+    - name: GithubOwner
+      value: tektoncd
+    - name: GithubRepo
+      value: trigger
+    - name: GithubSecretName
+      value: ghe-secret
+    - name: GithubUrl
+      value: github.com
+    - name: TriggerBinding
+      value: pipeline-binding
+    - name: TriggerTemplate
+      value: pipeline-template
+  timeout: 1000s
+  serviceAccount: tekton-pipelines-controller

--- a/docs/create-webhook.yaml
+++ b/docs/create-webhook.yaml
@@ -1,0 +1,155 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: create-webhook
+spec:
+  inputs:
+    params:
+    - name: CreateCertificate
+      description: Create certificate 
+      default: "true"
+    - name: CreateIngress
+      description: Create ingress 
+      default: "true"
+    - name: CreateWebhook
+      description: Create webhook 
+      default: "true"
+    - name: CreateEventListener
+      description: Create event listener 
+      default: "true"
+    - name: CertificateKeyPassphrase
+      description: The phrase that protects private key 
+      default: "phrase1"
+    - name: CertificateSecretName
+      description: The secret name for ingress certificate 
+      default: "secret1"
+    - name: ExternalUrl
+      description: The external access URl 
+      default: "https://$(inputs.params.EventListenerName).PROXYIP.nip.io"
+    - name: GithubOwner
+      description: The github owner name
+      default: "owner"
+    - name: GithubRepo
+      description: The github repo name 
+      default: "repo"
+    - name: GithubSecretName
+      description: The secret name for github access token 
+      default: "githubsecret"
+    - name: GithubUrl
+      description: The url of git hub 
+      default: "github.com"
+    - name: EventListenerName
+      description: The event listener name 
+      default: "eventlistener"
+    - name: TriggerBinding
+      description: The Trigger binding 
+      default: "triggerbinding"
+    - name: TriggerTemplate
+      description: The Trigger Template 
+      default: "triggertemplate"
+    - name: TriggerServiceAccount
+      description: The Trigger service account 
+      default: "default"
+  steps:
+  - name: generate-certificate
+    image: ibmcom/microclimate-utils:1905
+    command:
+    - sh
+    args:
+    - -ce
+    - |
+      set -e
+      cat <<EOF | sh
+      #!/bin/sh
+      if [ $(inputs.params.CreateCertificate) = "false" ]
+      then
+        exit 0
+      fi
+      mkdir /var/tmp/ingress
+      openssl genrsa -des3 -out /var/tmp/ingress/key.pem -passout pass:$(inputs.params.CertificateKeyPassphrase) 2048
+      openssl req -x509 -new -nodes -key /var/tmp/ingress/key.pem -sha256 -days 1825 -out /var/tmp/ingress/certificate.pem -passin pass:$(inputs.params.CertificateKeyPassphrase) -subj /CN=$(inputs.params.ExternalUrl)
+      openssl rsa -in /var/tmp/ingress/key.pem -out /var/tmp/ingress/key.pem -passin pass:$(inputs.params.CertificateKeyPassphrase)
+      kubectl create secret tls $(inputs.params.CertificateSecretName) --cert=/var/tmp/ingress/certificate.pem --key=/var/tmp/ingress/key.pem -n tekton-pipelines
+      EOF
+  - name: create-ingress
+    image: lachlanevenson/k8s-kubectl:latest
+    command:
+    - sh
+    args:
+    - -ce
+    - |
+      set -e
+      if [ $(inputs.params.CreateIngress) = "false" ]
+      then
+        exit 0
+      fi
+      cat <<EOF | kubectl apply -f -
+      apiVersion: extensions/v1beta1
+      kind: Ingress
+      metadata:
+        name: $(inputs.params.EventListenerName)
+      spec:
+        tls:
+        - hosts:
+          - $(inputs.params.ExternalUrl)
+          secretName: $(inputs.params.CertificateSecretName)
+        rules:
+        - host: $(inputs.params.ExternalUrl)
+          http:
+            paths:
+            - backend:
+                serviceName: $(inputs.params.EventListenerName)
+                servicePort: 8082
+      EOF
+  - name: create-webhook
+    image: pstauffer/curl:latest
+    command:
+    - sh
+    args:
+    - -ce
+    - |
+      set -e
+      if [ $(inputs.params.CreateWebhook) = "false" ]
+      then
+        exit 0
+      fi
+      echo "Create Webhook"
+      if [ $(inputs.params.GithubUrl) = "github.com" ]
+      then
+      curl -d "{\"name\": \"web\",\"active\": true,\"events\": [\"push\",\"pull_request\"],\"config\": {\"url\": \"https://$(inputs.params.ExternalUrl)/\",\"content_type\": \"json\",\"insecure_ssl\": \"1\"}}" -X POST -u $(cat /var/secret/userName):$(cat /var/secret/accessToken) -L https://api.github.com/repos/$(inputs.params.GithubOwner)/$(inputs.params.GithubRepo)/hooks
+      else
+      curl -d "{\"name\": \"web\",\"active\": true,\"events\": [\"push\",\"pull_request\"],\"config\": {\"url\": \"https://$(inputs.params.ExternalUrl)/\",\"content_type\": \"json\",\"insecure_ssl\": \"1\"}}" -X POST -u $(cat /var/secret/userName):$(cat /var/secret/accessToken) -L https://$(inputs.params.GithubUrl)/api/v3/repos/$(inputs.params.GithubOwner)/$(inputs.params.GithubRepo)/hooks
+      fi
+    volumeMounts:
+    - name: github-secret
+      mountPath: /var/secret
+  - name: create-eventlistener
+    image: lachlanevenson/k8s-kubectl:latest
+    command:
+    - sh
+    args:
+    - -ce
+    - |
+      set -e
+      if [ $(inputs.params.CreateEventListener) = "false" ]
+      then
+        exit 0
+      fi
+      cat <<EOF | kubectl apply -f -
+      apiVersion: tekton.dev/v1alpha1
+      kind: EventListener
+      metadata:
+        name: $(inputs.params.EventListenerName)
+      spec:
+        serviceAccountName: $(inputs.params.TriggerServiceAccount)
+        triggers:
+        - binding:
+            name: $(inputs.params.TriggerBinding)
+          template:
+            name: $(inputs.params.TriggerTemplate)
+      EOF
+  volumes:
+  - name: github-secret
+    secret:
+      secretName: $(inputs.params.GithubSecretName) 
+

--- a/docs/createwebhook.md
+++ b/docs/createwebhook.md
@@ -1,0 +1,167 @@
+# Create Webhook Tekton Task
+The create webhook task configures necessary componetns for the github webhook sending event to the event listener.
+It configures following compoments:
+
+1. The github webhook
+1. Tekton event listener
+1. Ingress for the event listener
+1. Selfsigned certificate for the ingress
+
+There are options to enable / disable the configuration of the components.
+This task requires the following permissions to execute.  The clusterrole with these permissions must be bound to the service account used to run this task (taskrun).
+
+```
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - tekton.dev
+  resources:
+  - eventlisteners
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - get
+  - list
+  - delete
+  - update
+```
+
+## Task params
+
+These are the task parms to manage the task execution
+
+- name: `CreateCertificate`
+  This param enables / disables the creation of the selfsigned certificate for the ingress
+  - value: "true" / "false"
+  - default: "true"
+- name: `CreateIngress`
+  This param enables / disables the creation of the ingress for the event listener
+  - value: "true" / "false"
+  - default: "true"
+- name: `CreateWebhook`
+  This param enables / disables the creation of the webhook configuration in the github repo
+  - value: "true" / "false"
+  - default: "true"
+- name: `CreateEventListener`
+  This param enables / disables the creation of the event listener
+  - value: "true" / "false"
+  - default: "true"
+- name: `CertificateKeyPassphrase`
+  This param is the phrase that protects private key.  This must be provided when the selfsigned certificate is created. 
+  - value: any string  
+- name: `CertificateSecretName`
+  This param is the secret name for ingress certificate.  The secret with this name should not exist if the selfsigned certificate creation is enabled.  
+  - value: valid kubernates identifier string
+- name: `ExternalUrl`
+  This param is the external access URl for the event listener.  Examble: eventlistener1.xx.yy.zz.aa.nip.io 
+  - value: valid ip address
+- name: `GithubOwner`
+  This param is the github owner name (github.com/**onwer**/repo) 
+  - value: string
+- name: `GithubRepo`
+  This param is the github repo name (github.com/onwer/**repo**)
+  - value: string
+- name: `GithubSecretName`
+  This param is the secret name for github access token. The key **userName** must have the github user name and **accessToken** must have the github access token  
+  - value: kubernetes secret name string
+- name: `GithubUrl`
+  This param is the github side address.  The defult value **github.com** works for the public git hub.  For the github enterprize, this param have to have the site address.  Example: **github.yourcompany.com**   
+  - value: github site address string
+  - default: "github.com"
+- name: `EventListenerName`
+  This param has the event listener name 
+  - value: valid kubernates identifier string
+- name: `TriggerBinding`
+  This param is the trigger binding set in the event listener 
+  - value: triggerbinding CR instance name
+- name: `TriggerTemplate`
+  This param has the trigger template set in the event listener 
+  - value: triggertemplate CR instance name
+- name: `TriggerServiceAccount`
+  This param is the service account name set in the event listener 
+  - value: service account name
+
+### Create Certificate
+
+The github sends events to the event listner ingress.  It is configured to use the TLS to make the transport secure.  The ingress must have the certifiate to establish the TLS connection.  Ideally the certificate signed by the CA is used.  If the CA singed certificate is not available, the selfsigned certificate can be used.  The create webhook task creates the selfsigned certificate and sets it in the kubeernetes secret to make it available for the use of the ingress.
+
+The following task params must be set for the creation of the certificate.
+
+- `CreateCertificate`
+  value: "true"
+- `CertificateKeyPassphrase`
+  value: any passphrase string  
+- `CertificateSecretName`
+  value: valid kubernates identifier string. (unused name) 
+- `ExternalUrl`
+  value: IP address for the identity for the site (event listener)
+
+### Create Ingress
+
+The ingress exposes the event listener to the outside of the cluster.
+
+The following task params must be set for the creation of the ingress.
+
+- `CreateIngress`
+  value: "true"
+- `ExternalUrl`
+  value: External IP address for the event listener. Example: eventlistener1.xx.yy.zz.aa.nip.io
+- `EventListenerName`
+  value: The name of the event listener to be exposed
+- `CertificateSecretName`
+  value: The secret name of the certifiate
+
+### Create Webhook
+
+The webhook in the github repo sends the event to the event listener.
+
+The following task params must be set for the configuration of the webhook.
+
+- `CreateWebhook`
+  value: "true"
+- `ExternalUrl`
+  value: The event listener ingress address
+- `GithubOwner`
+  value: github owner string
+- `GithubRepo`
+  value: github repo string
+- `GithubSecretName`
+  value: kubernetes secret name string that has the user name and the access token for the github
+- `GithubUrl`
+  value: only necessary for the github enterprize. github site address string
+
+### Create Event Listener
+
+The event listner receives the webhook event and invokes the pipelinerun based on the trigger binding and trigger template.  This task creates the eventlistener with only one pair of the triggerbinding and trigger template.
+
+The following task params must be set for the creation of the event listener.
+
+- `CreateEventListener`
+  value: "true"
+- `EventListenerName`
+  This param has the event listener name
+  value: event listener name
+- `TriggerBinding`
+  This param is the trigger binding set in the event listener
+  value: triggerbinding CR instance name
+- `TriggerTemplate`
+  value: triggertemplate CR instnace name
+- `TriggerServiceAccount`
+  value: the service account name used for the event listener


### PR DESCRIPTION
This PR is for the issue https://github.com/tektoncd/triggers/issues/80.  

This task configures components necessary for the github event processing.
The compoments are:

1. Selfsigned certificate for the Ingress
2. Ingress with TLS for the event listener
3. Github (or Github enterprize) webhook
4. Event listener

All componet configurations are optional.  They can be truned off
by the parameter in the taskrun.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
