### PR TITLE
Correct serviceaccount in example of EventListener

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -11,7 +11,7 @@ metadata:
   name: listener
   namespace: tekton-pipelines
 spec:
-  serviceAccountName: default
+  serviceAccountName: tekton-triggers-controller
   triggers:
     - binding:
         name: pipeline-binding

--- a/examples/eventlisteners/eventlistener.yaml
+++ b/examples/eventlisteners/eventlistener.yaml
@@ -4,7 +4,7 @@ metadata:
   name: listener
   namespace: tekton-pipelines
 spec:
-  serviceAccountName: default
+  serviceAccountName: tekton-triggers-controller
   triggers:
     - binding:
         name: pipeline-binding


### PR DESCRIPTION
Should set it as `tekton-triggers-controller` which initialize setup in `Config/200-serviceaccount.yaml`. or will get permission denied exception in `pod`: listener
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
