### PR TITLE
Set github webhook secret

### DIFF
--- a/docs/create-webhook.yaml
+++ b/docs/create-webhook.yaml
@@ -33,8 +33,17 @@ spec:
       description: The github repo name 
       default: "repo"
     - name: GithubSecretName
-      description: The secret name for github access token 
+      description: The secret name for github 
       default: "githubsecret"
+    - name: GithubAccessTokenKey
+      description: The key name for access token 
+      default: "accessToken"
+    - name: GithubUserNameKey
+      description: The key name for github user name 
+      default: "userName"
+    - name: GithubSecretStringKey
+      description: The key name for github secret string 
+      default: "secretString"
     - name: GithubUrl
       description: The url of git hub 
       default: "github.com"
@@ -50,9 +59,12 @@ spec:
     - name: TriggerServiceAccount
       description: The Trigger service account 
       default: "default"
+    - name: ValidateTaskName
+      description: The event validation task name 
+      default: "validate-github-event"
   steps:
   - name: generate-certificate
-    image: ibmcom/microclimate-utils:1905
+    image: frapsoft/openssl
     command:
     - sh
     args:
@@ -65,12 +77,33 @@ spec:
       then
         exit 0
       fi
-      mkdir /var/tmp/ingress
-      openssl genrsa -des3 -out /var/tmp/ingress/key.pem -passout pass:$(inputs.params.CertificateKeyPassphrase) 2048
-      openssl req -x509 -new -nodes -key /var/tmp/ingress/key.pem -sha256 -days 1825 -out /var/tmp/ingress/certificate.pem -passin pass:$(inputs.params.CertificateKeyPassphrase) -subj /CN=$(inputs.params.ExternalUrl)
-      openssl rsa -in /var/tmp/ingress/key.pem -out /var/tmp/ingress/key.pem -passin pass:$(inputs.params.CertificateKeyPassphrase)
-      kubectl create secret tls $(inputs.params.CertificateSecretName) --cert=/var/tmp/ingress/certificate.pem --key=/var/tmp/ingress/key.pem 
+      mkdir /var/tmp/work/ingress
+      openssl genrsa -des3 -out /var/tmp/work/ingress/key.pem -passout pass:$(inputs.params.CertificateKeyPassphrase) 2048
+      openssl req -x509 -new -nodes -key /var/tmp/work/ingress/key.pem -sha256 -days 1825 -out /var/tmp/work/ingress/certificate.pem -passin pass:$(inputs.params.CertificateKeyPassphrase) -subj /CN=$(inputs.params.ExternalUrl)
+      openssl rsa -in /var/tmp/work/ingress/key.pem -out /var/tmp/work/ingress/key.pem -passin pass:$(inputs.params.CertificateKeyPassphrase)
       EOF
+    volumeMounts:
+    - name: work
+      mountPath: /var/tmp/work
+  - name: create-certificate-secret
+    image: lachlanevenson/k8s-kubectl:latest
+    command:
+    - sh
+    args:
+    - -ce
+    - |
+      set -e
+      cat <<EOF | sh
+      #!/bin/sh
+      if [ $(inputs.params.CreateCertificate) = "false" ]
+      then
+        exit 0
+      fi
+      kubectl create secret tls $(inputs.params.CertificateSecretName) --cert=/var/tmp/work/ingress/certificate.pem --key=/var/tmp/work/ingress/key.pem 
+      EOF
+    volumeMounts:
+    - name: work
+      mountPath: /var/tmp/work
   - name: create-ingress
     image: lachlanevenson/k8s-kubectl:latest
     command:
@@ -116,9 +149,9 @@ spec:
       echo "Create Webhook"
       if [ $(inputs.params.GithubUrl) = "github.com" ]
       then
-      curl -d "{\"name\": \"web\",\"active\": true,\"events\": [\"push\",\"pull_request\"],\"config\": {\"url\": \"https://$(inputs.params.ExternalUrl)/\",\"content_type\": \"json\",\"insecure_ssl\": \"1\"}}" -X POST -u $(cat /var/secret/userName):$(cat /var/secret/accessToken) -L https://api.github.com/repos/$(inputs.params.GithubOwner)/$(inputs.params.GithubRepo)/hooks
+      curl -d "{\"name\": \"web\",\"active\": true,\"events\": [\"push\",\"pull_request\"],\"config\": {\"url\": \"https://$(inputs.params.ExternalUrl)/\",\"content_type\": \"json\",\"insecure_ssl\": \"1\" ,\"secret\": \"$(cat /var/secret/$(inputs.params.GithubSecretStringKey))\"}}" -X POST -u $(cat /var/secret/$(inputs.params.GithubUserNameKey)):$(cat /var/secret/$(inputs.params.GithubAccessTokenKey)) -L https://api.github.com/repos/$(inputs.params.GithubOwner)/$(inputs.params.GithubRepo)/hooks
       else
-      curl -d "{\"name\": \"web\",\"active\": true,\"events\": [\"push\",\"pull_request\"],\"config\": {\"url\": \"https://$(inputs.params.ExternalUrl)/\",\"content_type\": \"json\",\"insecure_ssl\": \"1\"}}" -X POST -u $(cat /var/secret/userName):$(cat /var/secret/accessToken) -L https://$(inputs.params.GithubUrl)/api/v3/repos/$(inputs.params.GithubOwner)/$(inputs.params.GithubRepo)/hooks
+      curl -d "{\"name\": \"web\",\"active\": true,\"events\": [\"push\",\"pull_request\"],\"config\": {\"url\": \"https://$(inputs.params.ExternalUrl)/\",\"content_type\": \"json\",\"insecure_ssl\": \"1\" ,\"secret\": \"$(cat /var/secret/$(inputs.params.GithubSecretStringKey))\"}}" -X POST -u $(cat /var/secret/$(inputs.params.GithubUserNameKey)):$(cat /var/secret/$(inputs.params.GithubAccessTokenKey)) -L https://$(inputs.params.GithubUrl)/api/v3/repos/$(inputs.params.GithubOwner)/$(inputs.params.GithubRepo)/hooks
       fi
     volumeMounts:
     - name: github-secret
@@ -147,9 +180,20 @@ spec:
             name: $(inputs.params.TriggerBinding)
           template:
             name: $(inputs.params.TriggerTemplate)
+          validate:
+            taskRef:
+              name: $(inputs.params.ValidateTaskName)
+            serviceAccountName: $(inputs.params.TriggerServiceAccount)
+            params:
+            - name: Github-Secret
+              value: $(inputs.params.GithubSecretName)
+            - name: Github-Secret-Key
+              value: $(inputs.params.GithubSecretStringKey)
+
       EOF
   volumes:
   - name: github-secret
     secret:
       secretName: $(inputs.params.GithubSecretName) 
-
+  - name: work
+    emptyDir: {}

--- a/docs/createwebhook.md
+++ b/docs/createwebhook.md
@@ -82,7 +82,7 @@ These are the task parms to manage the task execution
   This param is the github repo name (github.com/onwer/**repo**)
   - value: string
 - name: `GithubSecretName`
-  This param is the secret name for github access token. The key **userName** must have the github user name and **accessToken** must have the github access token  
+  This param is the secret name for github access token. The key **userName** must have the github user name and **accessToken** must have the github access token.  If the secret has the key **secretString**, the value is set to the `Secret` in the github webhook.  
   - value: kubernetes secret name string
 - name: `GithubUrl`
   This param is the github side address.  The defult value **github.com** works for the public git hub.  For the github enterprize, this param have to have the site address.  Example: **github.yourcompany.com**   


### PR DESCRIPTION
# Changes

This PR adds function to set the secret string into the github webhook in the Create-Webhook tekton task.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

When the secret specified in the GithubSecretName has the "secretString" key, the value is set to the github webhook secret.  This secret is used when the issue https://github.com/tektoncd/triggers/issues/45 is implemented.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

