### PR TITLE
Use clusterIP as the default service type

### DIFF
--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
@@ -174,7 +174,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{"app": el.Name},
-			Type:     corev1.ServiceTypeLoadBalancer,
+			Type:     corev1.ServiceTypeClusterIP,
 			Ports: []corev1.ServicePort{{
 				Protocol: corev1.ProtocolTCP,
 				Port:     int32(Port),

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
@@ -104,7 +104,7 @@ func TestReconcile(t *testing.T) {
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: labels,
-			Type:     corev1.ServiceTypeLoadBalancer,
+			Type:     corev1.ServiceTypeClusterIP,
 			Ports: []corev1.ServicePort{
 				{
 					Protocol: corev1.ProtocolTCP,
@@ -122,7 +122,7 @@ func TestReconcile(t *testing.T) {
 		},
 		Spec: corev1.ServiceSpec{
 			Selector:  labels,
-			Type:      corev1.ServiceTypeLoadBalancer,
+			Type:      corev1.ServiceTypeClusterIP,
 			ClusterIP: "some_ip_address",
 			Ports: []corev1.ServicePort{
 				{


### PR DESCRIPTION
# Changes

Using `LoadBalancer` as the default service type
can have unintended effects e.g. in GCP it will
automatically expose a public IP.

Addresses #114 
