### PR TITLE
Move validate from example to validate-event.md

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -20,11 +20,4 @@ spec:
         name: pipeline-binding
       template:
         name: pipeline-template
-      validate:
-        taskRef:
-          name: validateTaskName
-        serviceAccountName: saName
-        params:
-        - name: paramName
-          value: paramValue
 ```

--- a/docs/validate-event.md
+++ b/docs/validate-event.md
@@ -6,3 +6,27 @@ EventListener passes event body as `EventBody` and headers encoded to json as `E
 Additionally, if any Parameters are defined as part of `validate` under `event-listener`, they are also provided to taskrun during execution.
 
 Sample Task provided for [`validate-github-event`](validate-github-event.yaml) has been provided.
+
+Here is an example `validate` syntax within an EventListener:
+
+```YAML
+apiVersion: tekton.dev/v1alpha1
+kind: EventListener
+metadata:
+  name: listener
+spec:
+  serviceAccountName: tekton-triggers-example-sa
+  triggers:
+    - binding:
+        name: pipeline-binding
+      template:
+        name: pipeline-template
+      validate:
+        taskRef:
+          name: validateTaskName
+        serviceAccountName: saName
+        params:
+        - name: paramName
+          value: paramValue
+
+```

--- a/examples/eventlisteners/eventlistener.yaml
+++ b/examples/eventlisteners/eventlistener.yaml
@@ -9,10 +9,3 @@ spec:
         name: pipeline-binding
       template:
         name: pipeline-template
-      validate:
-        taskRef:
-          name: validateTaskName
-        serviceAccountName: saName
-        params:
-        - name: paramName
-          value: paramValue


### PR DESCRIPTION
# Changes
- Move the `validate` portion of the example `eventlistener.yaml` to `validate-event.md`

The `validate` portion of the `eventlistener.yaml` file was causing the
example to fail. This change fixes the failure.

The `validate` example was moved to `validate-event.md` so users still have
a reference for proper `validate` syntax.

I created issue https://github.com/tektoncd/triggers/issues/117 for creating a working example with Validation.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._
