### PR TITLE
fix validation task error

### DIFF
--- a/docs/validate-github-event.yaml
+++ b/docs/validate-github-event.yaml
@@ -24,7 +24,7 @@ spec:
         cat <<EOF | python
         import hashlib, os, hmac, json
         secret = bytes(os.environ.get('GithubSecret'), 'utf-8')
-        payload = bytes("$(inputs.params.EventBody)",'utf-8')
+        payload = bytes('$(inputs.params.EventBody)','utf-8')
         h = json.loads(r'$(inputs.params.EventHeaders)')
         signature = h["X-Hub-Signature"][0]
         expected = hmac.new(secret, payload, hashlib.sha1).hexdigest()


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
The task in docs/validate-github-event.yaml fails with the following error when it gets the github event:

```
kubectl logs validate-github-event65k7w-pod-9107ec -c step-validate
  File "<stdin>", line 3
    payload = bytes("{"action":"closed","number":22,"pull_request":{"url":"http\
s://github.ibm.com/api/v3/repos/akuroda/simple/pulls/22","id":3461135,"node_id"\
:"MDExOlB1bGxSZXF1ZXN0MzQ2MTEzNQ==
.
.
events","type":"User","site_admin":false}}",'utf-8')
                            ^
SyntaxError: invalid syntax
```
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

This change fixes the above error.
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

