### PR TITLE
Owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,9 +2,7 @@
 
 approvers:
 - bobcatfish
-- dibyom
 - dlorenc
-- EliZucker
 - iancoffey
 - ncskier
 - vtereso

--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,7 @@
 
 approvers:
 - bobcatfish
+- dibyom
 - dlorenc
 - iancoffey
 - ncskier


### PR DESCRIPTION
# Changes

There are 2 commits here, one which removes @dibyom as an OWNER, and one which re-adds him formally, the net effect is removing @EliZucker . If folks want to hold off on adding @dibyom as an OWNER for now I can split that into a different PR.

## Commit 1: Make OWNERS list match our policies memo

In #106 @vdemeester made the
OWNERS file in this repo match the settings in GitHub itself, and he
added both @EliZucker and @dibyom as OWNERS, which was because they were
in the maintainers team in GitHub that has write access to the repo. The
only reason they were both in this team was to allow them to have write access
to the ZenHub project
(https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md#zenhub-project)
which the Google Tekton team has been using to do planning.

However they were not formally proposed and approved as OWNERS as per
our process for becoming OWNERS, https://github.com/tektoncd/community/blob/master/process.md#owners
so in this commit I'm removing them and I will follow up with a commit
to propose adding @dibyom as an OWNER officially. (If @EliZucker wants
to become an OWNER we can propose that too, but his internship at Google
ended and he's back at school!)

(Note: i have removed @EliZucker from the maintainers GitHub team also)

## Commit 2: Add @dibyom as an OWNER! :crown:

@dibyom has been working closely with the triggers team for a while now!
He has reviewed 29 PRs to date
(https://tekton.devstats.cd.foundation/d/46/pr-reviews-by-contributor?orgId=1&var-period=d7&var-repo_name=tektoncd%2Ftriggers&var-reviewers="dibyom")
which is 1 short of our OWNER requirements at https://github.com/tektoncd/community/blob/master/process.md#owners
but actually represents nearly 50% of the total PRs so in my opinion
this is close enough!

His first review was ~Sept 4, and the project started on ~June 22, which
makes the project ~3 months old. Our policy
(https://github.com/tektoncd/community/blob/master/process.md#owners)
is that you should be involved in the project for 3 months or half the
lifespan which also makes us a bit short on that mark - happy to wait a
bit longer if folks want to, however I feel like @dibyom's contribution
has been significant and the project itself is so new that I think 1
month vs 1.5 months isn't a huge difference.

/hold

plz approve @iancoffey @ncskier @vtereso 

(@dlorenc is on leave so I think we can skip him!)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._