### PR TITLE
Update Trigger deployments to use apps/v1 API version

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: tekton-triggers-controller
   namespace: tekton-pipelines
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: tekton-triggers-controller
   template:
     metadata:
       annotations:

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: tekton-triggers-webhook
   namespace: tekton-pipelines
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: tekton-triggers-webhook
   template:
     metadata:
       annotations:


### PR DESCRIPTION
`apps/v1beta1` is deprecated and will be removed in Kubernetes 1.16

Similar to https://github.com/tektoncd/pipeline/pull/1330
