### PR TITLE
Make EventListener an Addressable

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1274,6 +1274,7 @@
   packages = [
     "apis",
     "apis/duck",
+    "apis/duck/v1alpha1",
     "apis/duck/v1beta1",
     "changeset",
     "codegen/cmd/injection-gen",
@@ -1384,6 +1385,7 @@
     "knative.dev/caching/pkg/apis/caching",
     "knative.dev/caching/pkg/client/clientset/versioned",
     "knative.dev/pkg/apis",
+    "knative.dev/pkg/apis/duck/v1alpha1",
     "knative.dev/pkg/apis/duck/v1beta1",
     "knative.dev/pkg/codegen/cmd/injection-gen",
     "knative.dev/pkg/configmap",

--- a/pkg/apis/triggers/v1alpha1/event_listener_types_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_types_test.go
@@ -41,7 +41,7 @@ func TestSetGetCondition(t *testing.T) {
 		{
 			name: "One condition",
 			conditions: []*apis.Condition{
-				&apis.Condition{
+				{
 					Type:    "Some Type",
 					Status:  corev1.ConditionTrue,
 					Message: "Message",
@@ -52,12 +52,12 @@ func TestSetGetCondition(t *testing.T) {
 		{
 			name: "Two conditions",
 			conditions: []*apis.Condition{
-				&apis.Condition{
+				{
 					Type:    "Some Type1",
 					Status:  corev1.ConditionTrue,
 					Message: "Message1",
 				},
-				&apis.Condition{
+				{
 					Type:    "Some Type2",
 					Status:  corev1.ConditionFalse,
 					Message: "Message2",
@@ -68,22 +68,22 @@ func TestSetGetCondition(t *testing.T) {
 		{
 			name: "Two conditions repeated",
 			conditions: []*apis.Condition{
-				&apis.Condition{
+				{
 					Type:    "Some Type1",
 					Status:  corev1.ConditionTrue,
 					Message: "Message1",
 				},
-				&apis.Condition{
+				{
 					Type:    "Some Type1",
 					Status:  corev1.ConditionFalse,
 					Message: "Message2",
 				},
-				&apis.Condition{
+				{
 					Type:    "Some Type2",
 					Status:  corev1.ConditionTrue,
 					Message: "Message1",
 				},
-				&apis.Condition{
+				{
 					Type:    "Some Type2",
 					Status:  corev1.ConditionFalse,
 					Message: "Message2",
@@ -183,7 +183,7 @@ func TestSetDeploymentConditions(t *testing.T) {
 		{
 			name: "One Deployment Condition",
 			deploymentConditions: []appsv1.DeploymentCondition{
-				appsv1.DeploymentCondition{
+				{
 					Type:    appsv1.DeploymentAvailable,
 					Status:  corev1.ConditionTrue,
 					Reason:  "Reason",
@@ -207,13 +207,13 @@ func TestSetDeploymentConditions(t *testing.T) {
 		{
 			name: "Two Deployment Conditions",
 			deploymentConditions: []appsv1.DeploymentCondition{
-				appsv1.DeploymentCondition{
+				{
 					Type:    appsv1.DeploymentAvailable,
 					Status:  corev1.ConditionTrue,
 					Reason:  "Reason",
 					Message: "Message",
 				},
-				appsv1.DeploymentCondition{
+				{
 					Type:    appsv1.DeploymentProgressing,
 					Status:  corev1.ConditionTrue,
 					Reason:  "Reason",
@@ -243,13 +243,13 @@ func TestSetDeploymentConditions(t *testing.T) {
 		{
 			name: "Update Replica Condition",
 			deploymentConditions: []appsv1.DeploymentCondition{
-				appsv1.DeploymentCondition{
+				{
 					Type:    appsv1.DeploymentAvailable,
 					Status:  corev1.ConditionTrue,
 					Reason:  "Reason",
 					Message: "Message",
 				},
-				appsv1.DeploymentCondition{
+				{
 					Type:    appsv1.DeploymentProgressing,
 					Status:  corev1.ConditionTrue,
 					Reason:  "Reason",

--- a/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
@@ -147,6 +147,7 @@ func (in *EventListenerSpec) DeepCopy() *EventListenerSpec {
 func (in *EventListenerStatus) DeepCopyInto(out *EventListenerStatus) {
 	*out = *in
 	in.Status.DeepCopyInto(&out.Status)
+	in.AddressStatus.DeepCopyInto(&out.AddressStatus)
 	out.Configuration = in.Configuration
 	return
 }

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
@@ -187,7 +187,7 @@ func (c *Reconciler) reconcileService(el *v1alpha1.EventListener) error {
 			c.Logger.Errorf("Error creating EventListener Service: %s", err)
 			return err
 		} else {
-			el.Status.Configuration.Hostname = listenerHostname(service.Name, el.Namespace)
+			el.Status.SetAddress(listenerHostname(service.Name, el.Namespace))
 			c.Logger.Infof("Created EventListener Service %s in Namespace %s", service.Name, el.Namespace)
 		}
 	default:

--- a/test/builder/eventlistener.go
+++ b/test/builder/eventlistener.go
@@ -6,6 +6,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
+	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
 )
 
 // EventListenerOp is an operation which modifies the EventListener.
@@ -117,10 +118,18 @@ func EventListenerCondition(t apis.ConditionType, status corev1.ConditionStatus,
 }
 
 // EventListenerConfig sets the EventListenerConfiguration on the EventListenerStatus.
-func EventListenerConfig(generatedResourceName, hostname string) EventListenerStatusOp {
+func EventListenerConfig(generatedResourceName string) EventListenerStatusOp {
 	return func(e *v1alpha1.EventListenerStatus) {
 		e.Configuration.GeneratedResourceName = generatedResourceName
-		e.Configuration.Hostname = hostname
+	}
+}
+
+// EventListenerAddress sets the EventListenerAddress on the EventListenerStatus
+func EventListenerAddress(hostname string) EventListenerStatusOp {
+	return func(e *v1alpha1.EventListenerStatus) {
+		e.Address = &duckv1alpha1.Addressable{
+			Hostname: hostname,
+		}
 	}
 }
 

--- a/test/builder/eventlistener_test.go
+++ b/test/builder/eventlistener_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
+	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
 
@@ -18,378 +19,354 @@ func TestEventListenerBuilder(t *testing.T) {
 		name    string
 		normal  *v1alpha1.EventListener
 		builder *v1alpha1.EventListener
-	}{
-		{
-			name:    "Empty",
-			normal:  &v1alpha1.EventListener{},
-			builder: EventListener("", ""),
-		},
-		{
-			name: "Name and Namespace",
-			normal: &v1alpha1.EventListener{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "name",
-					Namespace: "namespace",
-				},
+	}{{
+		name:    "Empty",
+		normal:  &v1alpha1.EventListener{},
+		builder: EventListener("", ""),
+	}, {
+		name: "Name and Namespace",
+		normal: &v1alpha1.EventListener{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
 			},
-			builder: EventListener("name", "namespace"),
 		},
-		{
-			name: "No Triggers",
-			normal: &v1alpha1.EventListener{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "name",
-					Namespace: "namespace",
-				},
-				Spec: v1alpha1.EventListenerSpec{
-					ServiceAccountName: "serviceAccount",
-				},
+		builder: EventListener("name", "namespace"),
+	}, {
+		name: "No Triggers",
+		normal: &v1alpha1.EventListener{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
 			},
-			builder: EventListener("name", "namespace",
-				EventListenerSpec(
-					EventListenerServiceAccount("serviceAccount"),
-				),
+			Spec: v1alpha1.EventListenerSpec{
+				ServiceAccountName: "serviceAccount",
+			},
+		},
+		builder: EventListener("name", "namespace",
+			EventListenerSpec(
+				EventListenerServiceAccount("serviceAccount"),
 			),
-		},
-		{
-			name: "Status configuration",
-			normal: &v1alpha1.EventListener{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "name",
-					Namespace: "namespace",
-				},
-				Status: v1alpha1.EventListenerStatus{
-					Configuration: v1alpha1.EventListenerConfig{
-						GeneratedResourceName: "generatedName",
-						Hostname:              "hostname",
+		),
+	}, {
+		name: "Status configuration",
+		normal: &v1alpha1.EventListener{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Status: v1alpha1.EventListenerStatus{
+				AddressStatus: duckv1alpha1.AddressStatus{
+					Address: &duckv1alpha1.Addressable{
+						Hostname: "hostname",
 					},
 				},
+				Configuration: v1alpha1.EventListenerConfig{
+					GeneratedResourceName: "generatedName",
+				},
 			},
-			builder: EventListener("name", "namespace",
-				EventListenerStatus(
-					EventListenerConfig("generatedName", "hostname"),
+		},
+		builder: EventListener("name", "namespace",
+			EventListenerStatus(
+				EventListenerConfig("generatedName"),
+				EventListenerAddress("hostname"),
+			),
+		),
+	}, {
+		name: "One Condition",
+		normal: &v1alpha1.EventListener{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Status: v1alpha1.EventListenerStatus{
+				Status: duckv1beta1.Status{
+					Conditions: []apis.Condition{{
+						Type:    v1alpha1.ServiceExists,
+						Status:  corev1.ConditionTrue,
+						Message: "Service exists",
+					}},
+				},
+			},
+		},
+		builder: EventListener("name", "namespace",
+			EventListenerStatus(
+				EventListenerCondition(
+					v1alpha1.ServiceExists,
+					corev1.ConditionTrue,
+					"Service exists", "",
 				),
 			),
-		},
-		{
-			name: "One Condition",
-			normal: &v1alpha1.EventListener{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "name",
-					Namespace: "namespace",
+		),
+	}, {
+		name: "Two Condition",
+		normal: &v1alpha1.EventListener{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Status: v1alpha1.EventListenerStatus{
+				Status: duckv1beta1.Status{
+					Conditions: []apis.Condition{{
+						Type:    v1alpha1.DeploymentExists,
+						Status:  corev1.ConditionTrue,
+						Message: "Deployment exists",
+					}, {
+						Type:    v1alpha1.ServiceExists,
+						Status:  corev1.ConditionTrue,
+						Message: "Service exists",
+					}},
 				},
-				Status: v1alpha1.EventListenerStatus{
-					Status: duckv1beta1.Status{
-						Conditions: []apis.Condition{
-							apis.Condition{
-								Type:    v1alpha1.ServiceExists,
-								Status:  corev1.ConditionTrue,
-								Message: "Service exists",
+			},
+		},
+		builder: EventListener("name", "namespace",
+			EventListenerStatus(
+				EventListenerCondition(
+					v1alpha1.ServiceExists,
+					corev1.ConditionTrue,
+					"Service exists", "",
+				),
+				EventListenerCondition(
+					v1alpha1.DeploymentExists,
+					corev1.ConditionTrue,
+					"Deployment exists", "",
+				),
+			),
+		),
+	}, {
+		name: "One Trigger",
+		normal: &v1alpha1.EventListener{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Spec: v1alpha1.EventListenerSpec{
+				ServiceAccountName: "serviceAccount",
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					Binding: v1alpha1.EventListenerBinding{
+						Name:       "tb1",
+						APIVersion: "v1alpha1",
+					},
+					Template: v1alpha1.EventListenerTemplate{
+						Name:       "tt1",
+						APIVersion: "v1alpha1",
+					},
+				}},
+			},
+		},
+		builder: EventListener("name", "namespace",
+			EventListenerSpec(
+				EventListenerServiceAccount("serviceAccount"),
+				EventListenerTrigger("tb1", "tt1", "v1alpha1"),
+			),
+		),
+	}, {
+		name: "One Trigger with One Param",
+		normal: &v1alpha1.EventListener{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Spec: v1alpha1.EventListenerSpec{
+				ServiceAccountName: "serviceAccount",
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					Binding: v1alpha1.EventListenerBinding{
+						Name:       "tb1",
+						APIVersion: "v1alpha1",
+					},
+					Template: v1alpha1.EventListenerTemplate{
+						Name:       "tt1",
+						APIVersion: "v1alpha1",
+					},
+					Params: []pipelinev1.Param{
+						{
+							Name: "param1",
+							Value: pipelinev1.ArrayOrString{
+								StringVal: "value1",
+								Type:      pipelinev1.ParamTypeString,
+							},
+						},
+					},
+				}},
+			},
+		},
+		builder: EventListener("name", "namespace",
+			EventListenerSpec(
+				EventListenerServiceAccount("serviceAccount"),
+				EventListenerTrigger("tb1", "tt1", "v1alpha1",
+					EventListenerTriggerParam("param1", "value1"),
+				),
+			),
+		),
+	}, {
+		name: "One Trigger with Two Params",
+		normal: &v1alpha1.EventListener{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Spec: v1alpha1.EventListenerSpec{
+				ServiceAccountName: "serviceAccount",
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					Binding: v1alpha1.EventListenerBinding{
+						Name:       "tb1",
+						APIVersion: "v1alpha1",
+					},
+					Template: v1alpha1.EventListenerTemplate{
+						Name:       "tt1",
+						APIVersion: "v1alpha1",
+					},
+					Params: []pipelinev1.Param{
+						{
+							Name: "param1",
+							Value: pipelinev1.ArrayOrString{
+								StringVal: "value1",
+								Type:      pipelinev1.ParamTypeString,
+							},
+						},
+						{
+							Name: "param2",
+							Value: pipelinev1.ArrayOrString{
+								StringVal: "value2",
+								Type:      pipelinev1.ParamTypeString,
 							},
 						},
 					},
 				},
+				},
 			},
-			builder: EventListener("name", "namespace",
-				EventListenerStatus(
-					EventListenerCondition(
-						v1alpha1.ServiceExists,
-						corev1.ConditionTrue,
-						"Service exists", "",
+		},
+		builder: EventListener("name", "namespace",
+			EventListenerSpec(
+				EventListenerServiceAccount("serviceAccount"),
+				EventListenerTrigger("tb1", "tt1", "v1alpha1",
+					EventListenerTriggerParam("param1", "value1"),
+					EventListenerTriggerParam("param2", "value2"),
+				),
+			),
+		),
+	}, {
+		name: "Two Trigger with extra Meta",
+		normal: &v1alpha1.EventListener{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+				Labels: map[string]string{
+					"key": "value",
+				},
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "EventListener",
+				APIVersion: "v1alpha1",
+			},
+			Spec: v1alpha1.EventListenerSpec{
+				ServiceAccountName: "serviceAccount",
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					Binding: v1alpha1.EventListenerBinding{
+						Name:       "tb1",
+						APIVersion: "v1alpha1",
+					},
+					Template: v1alpha1.EventListenerTemplate{
+						Name:       "tt1",
+						APIVersion: "v1alpha1",
+					},
+				}, {
+					Binding: v1alpha1.EventListenerBinding{
+						Name:       "tb2",
+						APIVersion: "v1alpha1",
+					},
+					Template: v1alpha1.EventListenerTemplate{
+						Name:       "tt2",
+						APIVersion: "v1alpha1",
+					},
+				},
+				},
+			},
+		},
+		builder: EventListener("name", "namespace",
+			EventListenerMeta(
+				TypeMeta("EventListener", "v1alpha1"),
+				Label("key", "value"),
+			),
+			EventListenerSpec(
+				EventListenerServiceAccount("serviceAccount"),
+				EventListenerTrigger("tb1", "tt1", "v1alpha1"),
+				EventListenerTrigger("tb2", "tt2", "v1alpha1"),
+			),
+		),
+	}, {
+		name: "One Trigger with Validation & Name",
+		normal: &v1alpha1.EventListener{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Spec: v1alpha1.EventListenerSpec{
+				ServiceAccountName: "serviceAccount",
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					Name: "foo-trig",
+					TriggerValidate: &v1alpha1.TriggerValidate{
+						TaskRef: pipelinev1.TaskRef{
+							Name:       "bar",
+							Kind:       pipelinev1.NamespacedTaskKind,
+							APIVersion: "v1alpha1",
+						},
+						ServiceAccountName: "foo",
+						Params: []pipelinev1.Param{{
+							Name: "Secret",
+							Value: pipelinev1.ArrayOrString{
+								Type:      pipelinev1.ParamTypeString,
+								StringVal: "github-secret",
+							},
+						}, {
+							Name: "Secret-Key",
+							Value: pipelinev1.ArrayOrString{
+								Type:      pipelinev1.ParamTypeString,
+								StringVal: "github-secret-key",
+							},
+						},
+						},
+					},
+					Binding: v1alpha1.EventListenerBinding{
+						Name:       "tb1",
+						APIVersion: "v1alpha1",
+					},
+					Template: v1alpha1.EventListenerTemplate{
+						Name:       "tt1",
+						APIVersion: "v1alpha1",
+					},
+					Params: []pipelinev1.Param{{
+						Name: "param1",
+						Value: pipelinev1.ArrayOrString{
+							StringVal: "value1",
+							Type:      pipelinev1.ParamTypeString,
+						}},
+					},
+				},
+				},
+			},
+		},
+		builder: EventListener("name", "namespace",
+			EventListenerSpec(
+				EventListenerServiceAccount("serviceAccount"),
+				EventListenerTrigger("tb1", "tt1", "v1alpha1",
+					EventListenerTriggerName("foo-trig"),
+					EventListenerTriggerParam("param1", "value1"),
+					EventListenerTriggerValidate(
+						EventListenerTriggerValidateTaskRef("bar", "v1alpha1", pipelinev1.NamespacedTaskKind),
+						EventListenerTriggerValidateServiceAccount("foo"),
+						EventListenerTriggerValidateParam("Secret", "github-secret"),
+						EventListenerTriggerValidateParam("Secret-Key", "github-secret-key"),
 					),
 				),
 			),
-		},
-		{
-			name: "Two Condition",
-			normal: &v1alpha1.EventListener{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "name",
-					Namespace: "namespace",
-				},
-				Status: v1alpha1.EventListenerStatus{
-					Status: duckv1beta1.Status{
-						Conditions: []apis.Condition{
-							apis.Condition{
-								Type:    v1alpha1.DeploymentExists,
-								Status:  corev1.ConditionTrue,
-								Message: "Deployment exists",
-							},
-							apis.Condition{
-								Type:    v1alpha1.ServiceExists,
-								Status:  corev1.ConditionTrue,
-								Message: "Service exists",
-							}},
-					},
-				},
-			},
-			builder: EventListener("name", "namespace",
-				EventListenerStatus(
-					EventListenerCondition(
-						v1alpha1.ServiceExists,
-						corev1.ConditionTrue,
-						"Service exists", "",
-					),
-					EventListenerCondition(
-						v1alpha1.DeploymentExists,
-						corev1.ConditionTrue,
-						"Deployment exists", "",
-					),
-				),
-			),
-		},
-		{
-			name: "One Trigger",
-			normal: &v1alpha1.EventListener{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "name",
-					Namespace: "namespace",
-				},
-				Spec: v1alpha1.EventListenerSpec{
-					ServiceAccountName: "serviceAccount",
-					Triggers: []v1alpha1.EventListenerTrigger{
-						v1alpha1.EventListenerTrigger{
-							Binding: v1alpha1.EventListenerBinding{
-								Name:       "tb1",
-								APIVersion: "v1alpha1",
-							},
-							Template: v1alpha1.EventListenerTemplate{
-								Name:       "tt1",
-								APIVersion: "v1alpha1",
-							},
-						},
-					},
-				},
-			},
-			builder: EventListener("name", "namespace",
-				EventListenerSpec(
-					EventListenerServiceAccount("serviceAccount"),
-					EventListenerTrigger("tb1", "tt1", "v1alpha1"),
-				),
-			),
-		},
-		{
-			name: "One Trigger with One Param",
-			normal: &v1alpha1.EventListener{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "name",
-					Namespace: "namespace",
-				},
-				Spec: v1alpha1.EventListenerSpec{
-					ServiceAccountName: "serviceAccount",
-					Triggers: []v1alpha1.EventListenerTrigger{
-						v1alpha1.EventListenerTrigger{
-							Binding: v1alpha1.EventListenerBinding{
-								Name:       "tb1",
-								APIVersion: "v1alpha1",
-							},
-							Template: v1alpha1.EventListenerTemplate{
-								Name:       "tt1",
-								APIVersion: "v1alpha1",
-							},
-							Params: []pipelinev1.Param{
-								pipelinev1.Param{
-									Name: "param1",
-									Value: pipelinev1.ArrayOrString{
-										StringVal: "value1",
-										Type:      pipelinev1.ParamTypeString,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			builder: EventListener("name", "namespace",
-				EventListenerSpec(
-					EventListenerServiceAccount("serviceAccount"),
-					EventListenerTrigger("tb1", "tt1", "v1alpha1",
-						EventListenerTriggerParam("param1", "value1"),
-					),
-				),
-			),
-		},
-		{
-			name: "One Trigger with Two Params",
-			normal: &v1alpha1.EventListener{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "name",
-					Namespace: "namespace",
-				},
-				Spec: v1alpha1.EventListenerSpec{
-					ServiceAccountName: "serviceAccount",
-					Triggers: []v1alpha1.EventListenerTrigger{
-						v1alpha1.EventListenerTrigger{
-							Binding: v1alpha1.EventListenerBinding{
-								Name:       "tb1",
-								APIVersion: "v1alpha1",
-							},
-							Template: v1alpha1.EventListenerTemplate{
-								Name:       "tt1",
-								APIVersion: "v1alpha1",
-							},
-							Params: []pipelinev1.Param{
-								pipelinev1.Param{
-									Name: "param1",
-									Value: pipelinev1.ArrayOrString{
-										StringVal: "value1",
-										Type:      pipelinev1.ParamTypeString,
-									},
-								},
-								pipelinev1.Param{
-									Name: "param2",
-									Value: pipelinev1.ArrayOrString{
-										StringVal: "value2",
-										Type:      pipelinev1.ParamTypeString,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			builder: EventListener("name", "namespace",
-				EventListenerSpec(
-					EventListenerServiceAccount("serviceAccount"),
-					EventListenerTrigger("tb1", "tt1", "v1alpha1",
-						EventListenerTriggerParam("param1", "value1"),
-						EventListenerTriggerParam("param2", "value2"),
-					),
-				),
-			),
-		},
-		{
-			name: "Two Trigger with extra Meta",
-			normal: &v1alpha1.EventListener{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "name",
-					Namespace: "namespace",
-					Labels: map[string]string{
-						"key": "value",
-					},
-				},
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "EventListener",
-					APIVersion: "v1alpha1",
-				},
-				Spec: v1alpha1.EventListenerSpec{
-					ServiceAccountName: "serviceAccount",
-					Triggers: []v1alpha1.EventListenerTrigger{
-						v1alpha1.EventListenerTrigger{
-							Binding: v1alpha1.EventListenerBinding{
-								Name:       "tb1",
-								APIVersion: "v1alpha1",
-							},
-							Template: v1alpha1.EventListenerTemplate{
-								Name:       "tt1",
-								APIVersion: "v1alpha1",
-							},
-						},
-						v1alpha1.EventListenerTrigger{
-							Binding: v1alpha1.EventListenerBinding{
-								Name:       "tb2",
-								APIVersion: "v1alpha1",
-							},
-							Template: v1alpha1.EventListenerTemplate{
-								Name:       "tt2",
-								APIVersion: "v1alpha1",
-							},
-						},
-					},
-				},
-			},
-			builder: EventListener("name", "namespace",
-				EventListenerMeta(
-					TypeMeta("EventListener", "v1alpha1"),
-					Label("key", "value"),
-				),
-				EventListenerSpec(
-					EventListenerServiceAccount("serviceAccount"),
-					EventListenerTrigger("tb1", "tt1", "v1alpha1"),
-					EventListenerTrigger("tb2", "tt2", "v1alpha1"),
-				),
-			),
-		},
-		{
-			name: "One Trigger with Validation & Name",
-			normal: &v1alpha1.EventListener{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "name",
-					Namespace: "namespace",
-				},
-				Spec: v1alpha1.EventListenerSpec{
-					ServiceAccountName: "serviceAccount",
-					Triggers: []v1alpha1.EventListenerTrigger{
-						v1alpha1.EventListenerTrigger{
-							Name: "foo-trig",
-							TriggerValidate: &v1alpha1.TriggerValidate{
-								TaskRef: pipelinev1.TaskRef{
-									Name:       "bar",
-									Kind:       pipelinev1.NamespacedTaskKind,
-									APIVersion: "v1alpha1",
-								},
-								ServiceAccountName: "foo",
-								Params: []pipelinev1.Param{
-									{
-										Name: "Secret",
-										Value: pipelinev1.ArrayOrString{
-											Type:      pipelinev1.ParamTypeString,
-											StringVal: "github-secret",
-										},
-									},
-									{
-										Name: "Secret-Key",
-										Value: pipelinev1.ArrayOrString{
-											Type:      pipelinev1.ParamTypeString,
-											StringVal: "github-secret-key",
-										},
-									},
-								},
-							},
-							Binding: v1alpha1.EventListenerBinding{
-								Name:       "tb1",
-								APIVersion: "v1alpha1",
-							},
-							Template: v1alpha1.EventListenerTemplate{
-								Name:       "tt1",
-								APIVersion: "v1alpha1",
-							},
-							Params: []pipelinev1.Param{
-								pipelinev1.Param{
-									Name: "param1",
-									Value: pipelinev1.ArrayOrString{
-										StringVal: "value1",
-										Type:      pipelinev1.ParamTypeString,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			builder: EventListener("name", "namespace",
-				EventListenerSpec(
-					EventListenerServiceAccount("serviceAccount"),
-					EventListenerTrigger("tb1", "tt1", "v1alpha1",
-						EventListenerTriggerName("foo-trig"),
-						EventListenerTriggerParam("param1", "value1"),
-						EventListenerTriggerValidate(
-							EventListenerTriggerValidateTaskRef("bar", "v1alpha1", pipelinev1.NamespacedTaskKind),
-							EventListenerTriggerValidateServiceAccount("foo"),
-							EventListenerTriggerValidateParam("Secret", "github-secret"),
-							EventListenerTriggerValidateParam("Secret-Key", "github-secret-key"),
-						),
-					),
-				),
-			),
-		},
+		),
+	},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if !equality.Semantic.DeepEqual(tt.normal, tt.builder) {
-				t.Error("EventListener() builder equality mismatch. Ignore semantic time mismatch")
-				diff := cmp.Diff(tt.normal, tt.builder)
-				t.Errorf("Diff request body: -want +got: %s", diff)
+			if diff := cmp.Diff(tt.normal, tt.builder, cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)); diff != "" {
+				t.Errorf("EventListener() builder equality mismatch. Diff request body: -want +got: %s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
# Changes

An Addressable type needs to have an Address.Hostname/URL.
For EventListeners this should be the address of the EL Sink
service.

Addressable: https://github.com/knative/eventing/blob/master/docs/spec/interfaces.md
Fixes #39 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
The EventListener Status now contains an `Address.Hostname` and `Address.URL` 

```
