### PR TITLE
Update the create-ingress task

### DIFF
--- a/docs/create-ingress.yaml
+++ b/docs/create-ingress.yaml
@@ -64,7 +64,7 @@ spec:
       if [ $(inputs.params.CreateCertificate) = "false" ];then
         exit 0
       fi
-      kubectl create secret tls $(inputs.params.CertificateSecretName) --cert=/var/tmp/work/ingress/certificate.pem --key=/var/tmp/work/ingress/key.pem 
+      kubectl create secret tls $(inputs.params.CertificateSecretName) --cert=/var/tmp/work/ingress/certificate.pem --key=/var/tmp/work/ingress/key.pem || true
       EOF
   - name: create-ingress
     image: lachlanevenson/k8s-kubectl:latest
@@ -74,8 +74,8 @@ spec:
     - -ce
     - |
       set -e
-      if [ -n $(inputs.params.ServiceUID) ];then
-        cat <<EOF | kubectl create -f -
+      if [ -n "$(inputs.params.ServiceUID)" ];then
+        cat <<EOF | kubectl create -f - || true
         apiVersion: extensions/v1beta1
         kind: Ingress
         metadata:
@@ -99,7 +99,7 @@ spec:
                   servicePort: $(inputs.params.ServicePort)
       EOF
       else
-        cat <<EOF | kubectl create -f -
+        cat <<EOF | kubectl create -f - || true
         apiVersion: extensions/v1beta1
         kind: Ingress
         metadata:


### PR DESCRIPTION
Update the create-ingress task to properly create an Ingress when the serviceUID is not specified
Make the create-ingress task idempotent for the same parameters
- If the secret/ingress already exists, the Task will not error

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
