### PR TITLE
 Update EventListener generated resource names

### DIFF
--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
@@ -24,7 +24,6 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/tektoncd/pipeline/pkg/names"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	listers "github.com/tektoncd/triggers/pkg/client/listers/triggers/v1alpha1"
 	"github.com/tektoncd/triggers/pkg/reconciler"
@@ -46,6 +45,9 @@ const (
 	eventListenerControllerName = "EventListener"
 	// Port defines the port for the EventListener to listen on
 	Port = 8080
+	// GeneratedResourcePrefix is the name prefix for resources generated in the
+	// EventListener reconciler
+	GeneratedResourcePrefix = "el-"
 )
 
 var (
@@ -104,7 +106,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) (returnError err
 	// Initial reconciliation
 	if equality.Semantic.DeepEqual(el.Status, v1alpha1.EventListenerStatus{}) {
 		el.Status.InitializeConditions()
-		el.Status.Configuration.GeneratedResourceName = names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(el.Name)
+		el.Status.Configuration.GeneratedResourceName = fmt.Sprintf("%s-%s", GeneratedResourcePrefix, el.Name)
 	}
 
 	// Reconcile this copy of the EventListener and then write back any status

--- a/test/eventlistener_test.go
+++ b/test/eventlistener_test.go
@@ -284,13 +284,13 @@ func TestEventListenerCreate(t *testing.T) {
 	t.Log("Deleted EventListener")
 
 	// Verify the EventListener's Deployment is deleted
-	if err = WaitFor(deploymentNotExist(t, c, namespace, el.Name)); err != nil {
+	if err = WaitFor(deploymentNotExist(t, c, namespace, fmt.Sprintf("%s-%s", eventReconciler.GeneratedResourcePrefix, el.Name))); err != nil {
 		t.Fatalf("Failed to delete EventListener Deployment: %s", err)
 	}
 	t.Log("EventListener's Deployment was deleted")
 
 	// Verify the EventListener's Service is deleted
-	if err = WaitFor(serviceNotExist(t, c, namespace, el.Name)); err != nil {
+	if err = WaitFor(serviceNotExist(t, c, namespace, fmt.Sprintf("%s-%s", eventReconciler.GeneratedResourcePrefix, el.Name))); err != nil {
 		t.Fatalf("Failed to delete EventListener Service: %s", err)
 	}
 	t.Log("EventListener's Service was deleted")


### PR DESCRIPTION
# Changes
Fixes: https://github.com/tektoncd/triggers/issues/145
Use static prefix instead of randomly generated postfix.
Update e2e test to check for correct deployment/service

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)