### PR TITLE
Access headers within TriggerBinding

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -21,10 +21,10 @@ does what has been specified in the corresponding
 ## Event Interceptors
 
 Triggers within an `EventListener` can optionally specify an interceptor field
-which contains an [`ObjectReference`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#objectreference-v1-core) to a Kubernetes Service. If an interceptor 
-is specified, the `EventListener` sink will forward incoming events to the 
-service referenced by the interceptor over HTTP. The service is expected to 
-process the event and return a response back. The status code of the response 
+which contains an [`ObjectReference`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#objectreference-v1-core) to a Kubernetes Service. If an interceptor
+is specified, the `EventListener` sink will forward incoming events to the
+service referenced by the interceptor over HTTP. The service is expected to
+process the event and return a response back. The status code of the response
 determines if the processing is successful and the returned body is used as
 the new event payload by the EventListener and passed on the `TriggerBinding`.
 
@@ -33,19 +33,18 @@ the new event payload by the EventListener and passed on the `TriggerBinding`.
 To be an Event Interceptor, a Kubernetes object should:
 * Be fronted by a regular Kubernetes v1 Service over port 80
 * Accept JSON payloads over HTTP
-* Return a HTTP 200 OK Status if the EventListener should continue processing 
+* Return a HTTP 200 OK Status if the EventListener should continue processing
   the event
 * Return a JSON body back. This will be used by the EventListener as the event
   payload for any further processing. If the interceptor does not need to modify
   the body, it can simply return the body that it received.
 
-
-<!-- FILE: examples/eventlisteners/eventlistener.yaml -->
+<!-- FILE: examples/eventlisteners/eventlistener-interceptor.yaml -->
 ```YAML
 apiVersion: tekton.dev/v1alpha1
 kind: EventListener
 metadata:
-  name: listener
+  name: listener-interceptor
 spec:
   serviceAccountName: tekton-triggers-example-sa
   triggers:
@@ -62,4 +61,5 @@ spec:
         name: pipeline-template
       params:
       - name: message
-        value: Hello from the Triggers EventListener!```
+        value: Hello from the Triggers EventListener!
+```

--- a/docs/triggerbindings.md
+++ b/docs/triggerbindings.md
@@ -13,9 +13,11 @@ metadata:
 spec:
   params:
   - name: gitrevision
-    value: $(event.head_commit.id)
+    value: $(body.head_commit.id)
   - name: gitrepositoryurl
-    value: $(event.repository.url)
+    value: $(body.repository.url)
+  - name: contenttype
+    value: $(header.Content-Type)
 ```
 
 `TriggerBinding`s are connected to `TriggerTemplate`s within an [`EventListener`](eventlisteners.md), which is where the pod is actually instantiated that "listens" for the respective events.
@@ -23,3 +25,39 @@ spec:
 ## Parameters
 `TriggerBinding`s can provide `params` which are passed to a
 `TriggerTemplate`. Each parameter has a `name` and a `value`.
+
+
+## Event Variable Interpolation
+
+### Body
+HTTP Post request body data can be referenced using variable interpolation.
+Text in the form of `$(body.X.Y.Z)` is replaced by the body data at JSON path
+`X.Y.Z`.
+
+`$(body)` is replaced by the entire body.
+
+The following are some example variable interpolation replacements:
+```
+$(body) -> {"key1": "value1", "key2": {"key3": "value3"}}
+
+$(body.key1) -> "value1"
+
+$(body.key2) -> {"key3": "value3"}
+
+$(body.key2.key3) -> "value3"
+```
+
+### Header
+HTTP Post request header data can be referenced using variable interpolation.
+Text in the form of `$(header.X)` is replaced by the event's header named `X`.
+
+`$(header)` is replaced by all of the headers from the event.
+
+The following are some example variable interpolation replacements:
+```
+$(header) -> {"One":["one"], "Two":["one","two","three"]}
+
+$(header.One) -> one
+
+$(header.Two) -> one two three
+```

--- a/docs/triggertemplates.md
+++ b/docs/triggertemplates.md
@@ -19,6 +19,8 @@ spec:
   - name: message
     description: The message to print
     default: This is the default message
+  - name: contenttype
+    description: The Content-Type of the event
   resourcetemplates:
   - apiVersion: tekton.dev/v1alpha1
     kind: PipelineResource
@@ -41,6 +43,8 @@ spec:
       params:
       - name: message
         value: $(params.message)
+      - name: contenttype
+        value: $(params.contenttype)
       resources:
       - name: git-source
         resourceRef:

--- a/examples/README.md
+++ b/examples/README.md
@@ -45,7 +45,7 @@ This is intentionally very simple and operates on a created Git resource. The tr
 
 4. Send a payload to the listener
 
-Assuming we have a listener available at `localhost:8080` (and port-forwarded for this example, with `kubectl port-forward $(kubectl get pod -o=name -l app=listener) 8080`), run the following command in your shell of choice or using Postman:
+Assuming we have a listener available at `localhost:8080` (and port-forwarded for this example, with `kubectl port-forward $(kubectl get pod -o=name -l eventlistener=listener) 8080`), run the following command in your shell of choice or using Postman:
 
 ```bash
 curl -X POST \

--- a/examples/eventlisteners/eventlistener-interceptor.yaml
+++ b/examples/eventlisteners/eventlistener-interceptor.yaml
@@ -1,11 +1,17 @@
 apiVersion: tekton.dev/v1alpha1
 kind: EventListener
 metadata:
-  name: listener
+  name: listener-interceptor
 spec:
   serviceAccountName: tekton-triggers-example-sa
   triggers:
     - name: foo-trig
+      interceptor:
+        objectRef:
+          kind: Service
+          name: gh-validate
+          apiVersion: v1
+          namespace: default
       binding:
         name: pipeline-binding
       template:

--- a/examples/example-pipeline.yaml
+++ b/examples/example-pipeline.yaml
@@ -4,6 +4,10 @@ metadata:
   name: say-hello
 spec:
   inputs:
+    params:
+    - name: contenttype
+      description: The Content-Type of the event
+      type: string
     resources:
       - name: git-source
         type: git
@@ -12,7 +16,7 @@ spec:
     image: bash
     command: ["bash", "-c"]
     args:
-      - echo 'Hello Triggers!'
+      - echo -e 'Hello Triggers!\nContent-Type is $(inputs.params.contenttype)'
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: Task
@@ -61,6 +65,9 @@ spec:
     description: The message to print
     default: This is the default message
     type: string
+  - name: contenttype
+    description: The Content-Type of the event
+    type: string
   resources:
   - name: git-source
     type: git
@@ -68,6 +75,9 @@ spec:
   - name: say-hello
     taskRef:
       name: say-hello
+    params:
+    - name: contenttype
+      value: $(params.contenttype)
     resources:
       inputs:
       - name: git-source

--- a/examples/triggerbindings/triggerbinding.yaml
+++ b/examples/triggerbindings/triggerbinding.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   params:
   - name: gitrevision
-    value: $(event.head_commit.id)
+    value: $(body.head_commit.id)
   - name: gitrepositoryurl
-    value: $(event.repository.url)
+    value: $(body.repository.url)
+  - name: contenttype
+    value: $(header.Content-Type)

--- a/examples/triggertemplates/triggertemplate.yaml
+++ b/examples/triggertemplates/triggertemplate.yaml
@@ -12,6 +12,8 @@ spec:
   - name: message
     description: The message to print
     default: This is the default message
+  - name: contenttype
+    description: The Content-Type of the event
   resourcetemplates:
   - apiVersion: tekton.dev/v1alpha1
     kind: PipelineResource
@@ -34,6 +36,8 @@ spec:
       params:
       - name: message
         value: $(params.message)
+      - name: contenttype
+        value: $(params.contenttype)
       resources:
       - name: git-source
         resourceRef:

--- a/pkg/apis/triggers/v1alpha1/trigger_binding_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_binding_validation_test.go
@@ -37,18 +37,18 @@ func Test_TriggerBindingValidate(t *testing.T) {
 			name: "multiple params",
 			tb: bldr.TriggerBinding("name", "namespace",
 				bldr.TriggerBindingSpec(
-					bldr.TriggerBindingParam("param1", "$(event.input1)"),
-					bldr.TriggerBindingParam("param2", "$(event.input2)"),
-					bldr.TriggerBindingParam("param3", "$(event.input3)"),
+					bldr.TriggerBindingParam("param1", "$(body.input1)"),
+					bldr.TriggerBindingParam("param2", "$(body.input2)"),
+					bldr.TriggerBindingParam("param3", "$(body.input3)"),
 				)),
 		},
 		{
 			name: "multiple params case sensitive",
 			tb: bldr.TriggerBinding("name", "namespace",
 				bldr.TriggerBindingSpec(
-					bldr.TriggerBindingParam("param1", "$(event.input1)"),
-					bldr.TriggerBindingParam("PARAM1", "$(event.input2)"),
-					bldr.TriggerBindingParam("Param1", "$(event.input3)"),
+					bldr.TriggerBindingParam("param1", "$(body.input1)"),
+					bldr.TriggerBindingParam("PARAM1", "$(body.input2)"),
+					bldr.TriggerBindingParam("Param1", "$(body.input3)"),
 				)),
 		},
 	}
@@ -70,9 +70,9 @@ func Test_TriggerBindingValidate_error(t *testing.T) {
 			name: "duplicate params",
 			tb: bldr.TriggerBinding("name", "namespace",
 				bldr.TriggerBindingSpec(
-					bldr.TriggerBindingParam("param1", "$(event.param1)"),
-					bldr.TriggerBindingParam("param1", "$(event.param1)"),
-					bldr.TriggerBindingParam("param3", "$(event.param1)"),
+					bldr.TriggerBindingParam("param1", "$(body.param1)"),
+					bldr.TriggerBindingParam("param1", "$(body.param1)"),
+					bldr.TriggerBindingParam("param3", "$(body.param1)"),
 				)),
 		},
 	}

--- a/pkg/sink/sink.go
+++ b/pkg/sink/sink.go
@@ -101,7 +101,7 @@ func (r Resource) executeTrigger(payload []byte, request *http.Request, trigger 
 		log.Print(err)
 		return
 	}
-	resources, err := template.NewResources(payload, trigger.Params, binding)
+	resources, err := template.NewResources(payload, request.Header, trigger.Params, binding)
 	if err != nil {
 		log.Print(err)
 		return

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -366,6 +366,7 @@ func Test_HandleEvent(t *testing.T) {
 			Params: []pipelinev1.ResourceParam{
 				{Name: "url", Value: "$(params.url)"},
 				{Name: "revision", Value: "$(params.revision)"},
+				{Name: "contenttype", Value: "$(params.contenttype)"},
 			},
 		},
 	}
@@ -384,6 +385,7 @@ func Test_HandleEvent(t *testing.T) {
 			Params: []pipelinev1.ResourceParam{
 				{Name: "url", Value: "testurl"},
 				{Name: "revision", Value: "testrevision"},
+				{Name: "contenttype", Value: "application/json"},
 			},
 		},
 	}
@@ -398,12 +400,14 @@ func Test_HandleEvent(t *testing.T) {
 			bldr.TriggerTemplateParam("url", "", ""),
 			bldr.TriggerTemplateParam("revision", "", ""),
 			bldr.TriggerTemplateParam("appLabel", "", ""),
+			bldr.TriggerTemplateParam("contenttype", "", ""),
 			bldr.TriggerResourceTemplate(json.RawMessage(pipelineResourceBytes)),
 		))
 	tb := bldr.TriggerBinding("my-triggerbinding", namespace,
 		bldr.TriggerBindingSpec(
-			bldr.TriggerBindingParam("url", "$(event.repository.url)"),
-			bldr.TriggerBindingParam("revision", "$(event.head_commit.id)"),
+			bldr.TriggerBindingParam("url", "$(body.repository.url)"),
+			bldr.TriggerBindingParam("revision", "$(body.head_commit.id)"),
+			bldr.TriggerBindingParam("contenttype", "$(header.Content-Type)"),
 		))
 	el := bldr.EventListener("my-eventlistener", namespace,
 		bldr.EventListenerSpec(


### PR DESCRIPTION
# Changes

- Added `$(header)` and `$(header.X)` as interpolation variables that will be
substituted for header values from the event.
- Changed `event` interpolation variable keyword to `body`.
  - `$(event)` and `$(event.X.Y.Z)` interpolation variables are now `$(body)` and `$(body.X.Y.Z)`.
- Escape `"` with `\"` in `body` and `header` interpolation variables.
  - This fixes a bug I found where resource templates failed to be created when JSON objects were substituted for interpolation variables; for example, when `$(event)` is used.
  - Added an e2e test to cover passing JSON objects as parameters.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Add $(header.X) variable interpolation for TriggerBindings.
$(event) and $(event.X.Y.Z) interpolation variables are now $(body) and $(body.X.Y.Z)
```
