### PR TITLE
Ignore EventListener service NodePort on reconcile

### DIFF
--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
@@ -20,10 +20,13 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"reflect"
 	"strconv"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	listers "github.com/tektoncd/triggers/pkg/client/listers/triggers/v1alpha1"
 	"github.com/tektoncd/triggers/pkg/reconciler"
@@ -168,7 +171,7 @@ func (c *Reconciler) reconcileService(el *v1alpha1.EventListener) error {
 			existingService.Spec.Selector = service.Spec.Selector
 			updated = true
 		}
-		if !reflect.DeepEqual(existingService.Spec.Ports, service.Spec.Ports) {
+		if !cmp.Equal(existingService.Spec.Ports, service.Spec.Ports, cmpopts.IgnoreFields(corev1.ServicePort{}, "NodePort")) {
 			existingService.Spec.Ports = service.Spec.Ports
 			updated = true
 		}

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
@@ -140,6 +140,9 @@ func Test_reconcileService(t *testing.T) {
 	service2.Labels = mergeLabels(generatedLabels, updateLabel)
 	service2.Spec.Selector = mergeLabels(generatedLabels, updateLabel)
 
+	service3 := service1.DeepCopy()
+	service3.Spec.Ports[0].NodePort = 30000
+
 	tests := []struct {
 		name           string
 		startResources test.TestResources
@@ -179,6 +182,19 @@ func Test_reconcileService(t *testing.T) {
 				Namespaces:     []*corev1.Namespace{namespaceResource},
 				EventListeners: []*v1alpha1.EventListener{eventListener1},
 				Services:       []*corev1.Service{service1},
+			},
+		},
+		{
+			name: "service-nodeport-update",
+			startResources: test.TestResources{
+				Namespaces:     []*corev1.Namespace{namespaceResource},
+				EventListeners: []*v1alpha1.EventListener{eventListener1},
+				Services:       []*corev1.Service{service3},
+			},
+			endResources: test.TestResources{
+				Namespaces:     []*corev1.Namespace{namespaceResource},
+				EventListeners: []*v1alpha1.EventListener{eventListener1},
+				Services:       []*corev1.Service{service3},
 			},
 		},
 	}


### PR DESCRIPTION
# Changes

If the el service type is changed to NodePort (for external
access) the reconciler tries to set back NodePort to the default (0)
whereas kubernetes wants to allocate a port. This goes into a loop when
the NodePort is constantly changing.

This patch fixes this by ignoring the NodePort value of the service when
running the eventlistener reconciliation.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._