### PR TITLE
Fix EventListener prefix to be "-" instead of "--"

### DIFF
--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
@@ -47,7 +47,7 @@ const (
 	Port = 8080
 	// GeneratedResourcePrefix is the name prefix for resources generated in the
 	// EventListener reconciler
-	GeneratedResourcePrefix = "el-"
+	GeneratedResourcePrefix = "el"
 )
 
 var (


### PR DESCRIPTION
# Changes
Fix EventListener prefix to be `-` instead of `--`.

I think the EventListener pod prefix was unintentionally using `--`:
```
el--listener-b8d9b4786-tw2bf
```

So, I fixed this to be `-`:
```
el-listener-b8d9b4786-8zmcd
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._