### PR TITLE
Fix interceptor headers to be a deepcopy

### DIFF
--- a/pkg/sink/interceptors.go
+++ b/pkg/sink/interceptors.go
@@ -49,17 +49,18 @@ func createOutgoingRequest(ctx context.Context, original *http.Request, url *url
 	r.RequestURI = ""
 	r.URL = url
 
-	headers := make(map[string][]string)
+	headers := make(map[string][]string, len(original.Header))
 	for k, v := range original.Header {
 		v2 := make([]string, len(v))
 		copy(v2, v)
 		headers[k] = v2
 	}
+	r.Header = headers
 
 	if s := original.TransferEncoding; s != nil {
 		s2 := make([]string, len(s))
 		copy(s2, s)
-		original.TransferEncoding = s
+		r.TransferEncoding = s
 	}
 
 	r.Body = ioutil.NopCloser(bytes.NewBuffer(payload))

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -547,6 +547,12 @@ func TestResource_processEvent(t *testing.T) {
 			},
 		},
 	}
+	requestHeader := make(http.Header, len(req.Header))
+	for k, v := range req.Header {
+		v2 := make([]string, len(v))
+		copy(v2, v)
+		requestHeader[k] = v2
+	}
 	resPayload, err := r.processEvent(interceptorURL, req, payload, params)
 
 	if err != nil {
@@ -555,6 +561,11 @@ func TestResource_processEvent(t *testing.T) {
 
 	if diff := cmp.Diff(payload, resPayload); diff != "" {
 		t.Errorf("Did not get expected payload back: %s", diff)
+	}
+
+	// Verify that the parameter header was not added to the request header
+	if diff := cmp.Diff(req.Header, requestHeader); diff != "" {
+		t.Errorf("processEvent() changed request header unexpectedly: %s", diff)
 	}
 }
 


### PR DESCRIPTION
# Changes

The interceptor code was doing a shallowcopy of the headers, so when a
header parameter was added to the interceptor, it would persist in the
request processed by the sink after the interceptor.

I added a test to verify that the original request headers are not
modified by the interceptor parameters.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._
