### PR TITLE
Introduce EventListener.Spec.ServiceType

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -1,4 +1,5 @@
 # EventListener
+
 `EventListener`s connect `TriggerBinding`s to `TriggerTemplate`s and provide an
 addressable endpoint, which is where webhooks/events are directed.
 
@@ -9,15 +10,19 @@ with.
 When an `EventListener` is successfully created, a service is created that
 references a listener pod. This listener pod accepts the incoming events and
 does what has been specified in the corresponding
-`TriggerBinding`s/`TriggerTemplate`s. The service created is a `ClusterIP` service 
-which means any other pods running in the same Kubernetes cluster can access it via the service's 
-cluster DNS. For external services to connect to your cluster (e.g. GitHub 
-sending webhooks), check out the guide on [exposing eventlisteners](./exposing-eventlisteners.md) 
+`TriggerBinding`s/`TriggerTemplate`s. The service created is a `ClusterIP` service
+which means any other pods running in the same Kubernetes cluster can access it via the service's
+cluster DNS. For external services to connect to your cluster (e.g. GitHub
+sending webhooks), check out the guide on [exposing eventlisteners](./exposing-eventlisteners.md)
 
 ## Parameters
+
 `EventListener`s can provide `params` which are merged with the `TriggerBinding`
 `params` and passed to the `TriggerTemplate`. Each parameter has a `name` and a
 `value`.
+
+`EventListener` `spec.serviceType` can be set to `ClusterIP (default)` | `NodePort` | `LoadBalancer`
+to configure the underlying `Service` resource to make it reachable externally.
 
 ## Event Interceptors
 

--- a/pkg/apis/triggers/v1alpha1/event_listener_types.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_types.go
@@ -54,6 +54,7 @@ type EventListener struct {
 type EventListenerSpec struct {
 	ServiceAccountName string                 `json:"serviceAccountName"`
 	Triggers           []EventListenerTrigger `json:"triggers"`
+	ServiceType        corev1.ServiceType     `json:"serviceType,omitempty"`
 }
 
 // EventListenerTrigger represents a connection between TriggerBinding, Params,


### PR DESCRIPTION
Allows to set the type of the underlying eventlistener service.
If not set k8s will configure the service type to ClusterIP.

Depending on the cloud provider or the ingress controller used
the user might need to set the service type to `NodePort` or
`LoadBalancer` to expose it externally.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
- Add EventListener.Spec.ServiceType attribute
```
