### PR TITLE
Fixing getting-started (?)

### DIFF
--- a/docs/getting-started/rbac/admin-role.yaml
+++ b/docs/getting-started/rbac/admin-role.yaml
@@ -18,6 +18,7 @@ rules:
   - tekton.dev
   resources:
   - pipelineruns
+  - pipelineresources
   verbs:
   - create
 ---

--- a/docs/getting-started/triggers.yaml
+++ b/docs/getting-started/triggers.yaml
@@ -73,11 +73,11 @@ metadata:
 spec:
   params:
     - name: gitrevision
-      value: $(event.head_commit.id)
+      value: $(body.head_commit.id)
     - name: namespace
       value: getting-started
     - name: gitrepositoryurl
-      value: $(event.head_commit.url)
+      value: "https://github.com/$(body.repository.full_name)"
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: EventListener


### PR DESCRIPTION
# Changes

The getting started example(s) make triggers create a
PipelineRun *and* a PipelineResource. But the role it runs with
doesn't allow to create Pipelineresource. This fixes that :)

Also fixes variable interpolation

/cc @dibyom @vtereso 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._
