### PR TITLE
Support more JSON array query syntax for the body

### DIFF
--- a/docs/triggerbindings.md
+++ b/docs/triggerbindings.md
@@ -29,12 +29,12 @@ spec:
 
 ## Event Variable Interpolation
 
-In order to parse generic events as efficiently as possible, [GJSON](https://github.com/tidwall/gjson) 
+In order to parse generic events as efficiently as possible, [GJSON](https://github.com/tidwall/gjson)
 is used internally. As a result, the binding [path syntax](https://github.com/tidwall/gjson#path-syntax)
 differs slightly from standard JSON. As of now, the following patterns are
 supported within `TriggerBinding` parameter value interpolation:
-- `$(body(.[0-9A-Za-z_-]+)*)`
-- `$(header(.[0-9A-Za-z_-]+)?)`
+- `\$\(body(\.[[:alnum:]/_\-\.\\]+|\.#\([[:alnum:]=<>%!"\*_-]+\)#??)*\)`
+- `\$\(header(\.[[:alnum:]_\-]+)?\)`
 
 ### Body
 HTTP Post request body data can be referenced using variable interpolation.

--- a/pkg/template/event.go
+++ b/pkg/template/event.go
@@ -27,8 +27,14 @@ import (
 )
 
 // bodyPathVarRegex determines valid body path variables
-var bodyPathVarRegex = regexp.MustCompile(`\$\(body(.[0-9A-Za-z_-]+)*\)`)
-var headerVarRegex = regexp.MustCompile(`\$\(header(.[0-9A-Za-z_-]+)?\)`)
+// The body regular expression allows for a subset of GJSON syntax, the mininum
+// required to navigate through dictionaries, query arrays and support
+// namespaced label names e.g. tekton.dev/eventlistener
+var bodyPathVarRegex = regexp.MustCompile(`\$\(body(\.[[:alnum:]/_\-\.\\]+|\.#\([[:alnum:]=<>%!"\*_-]+\)#??)*\)`)
+
+// The headers regular expression allows for simple navigation down a hierarchy
+// of dictionaries
+var headerVarRegex = regexp.MustCompile(`\$\(header(\.[[:alnum:]_\-]+)?\)`)
 
 // getBodyPathFromVar returns the body path given an body path variable
 // $(body.my.path) -> my.path

--- a/pkg/template/event_test.go
+++ b/pkg/template/event_test.go
@@ -41,6 +41,11 @@ func Test_BodyPathVarRegex(t *testing.T) {
 		"$(body.a1)",
 		"$(body.a.b)",
 		"$(body.a.b.c)",
+		"$(body.1.b.c\\.e/f)",
+		"$(body.#(a==b))",
+		"$(body.#(a>1)#)",
+		"$(body.#(a%\"D*\")#.c)",
+		"$(body.#(a!%\"D*\").c)",
 	}
 	for _, bodyPathVar := range tests {
 		t.Run(bodyPathVar, func(t *testing.T) {
@@ -57,8 +62,10 @@ func Test_BodyPathVarRegex_invalid(t *testing.T) {
 		"$[body]",
 		"${body}",
 		"$(body.)",
-		"$(body..)",
+		"$(body.@)",
 		"$(body.$a)",
+		"$(body#a)",
+		"$(body@#)",
 		"body.a",
 		"body",
 		"${{body}",


### PR DESCRIPTION
Extend the supported filtering syntax to include queries on arrays,
which can be useful when dealing with JSON that describes
k8s resources.

This adds the bare minimum from GJSON syntax to support array
queries, trying to avoid exposing too much of GJSON syntax.

Out of the full syntax defined in https://github.com/tidwall/gjson/blob/master/SYNTAX.md
we would have the following support list:
- Basic: already supported
- Queries: support added here, but no nested queries
- Wildcards: support added here, but only for array filtering (needed for the % operator)
- Escape character: not supported
- Arrays: not supported
- Dot vs Pipe: not supported (only pipe)
- Modifiers: not supported
- Multipaths: not supported

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
