### PR TITLE
Update EventListener Addressable to include port

### DIFF
--- a/pkg/apis/triggers/v1alpha1/event_listener_types.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_types.go
@@ -227,12 +227,11 @@ func (els *EventListenerStatus) SetAddress(hostname string) {
 		els.Address = &duckv1alpha1.Addressable{}
 	}
 	if hostname != "" {
-		els.Address.Hostname = hostname
-		if u, err := apis.ParseURL(fmt.Sprintf("http://%s/", hostname)); err != nil {
-			els.Address.URL = u
+		els.Address.URL = &apis.URL{
+			Scheme: "http",
+			Host:   hostname,
 		}
 	} else {
-		els.Address.Hostname = ""
 		els.Address.URL = nil
 	}
 }

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
@@ -195,7 +195,7 @@ func (c *Reconciler) reconcileService(el *v1alpha1.EventListener) error {
 			c.Logger.Errorf("Error creating EventListener Service: %s", err)
 			return err
 		}
-		el.Status.SetAddress(listenerHostname(service.Name, el.Namespace))
+		el.Status.SetAddress(listenerHostname(service.Name, el.Namespace, Port))
 		c.Logger.Infof("Created EventListener Service %s in Namespace %s", service.Name, el.Namespace)
 	default:
 		c.Logger.Error(err)
@@ -359,6 +359,6 @@ func wrapError(err1, err2 error) error {
 }
 
 // listenerHostname returns the intended hostname for the EventListener service.
-func listenerHostname(name, namespace string) string {
-	return fmt.Sprintf("%s.%s.svc.cluster.local", name, namespace)
+func listenerHostname(name, namespace string, port int) string {
+	return fmt.Sprintf("%s.%s.svc.cluster.local:%d", name, namespace, port)
 }

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
@@ -119,8 +119,10 @@ func getEventListenerTestAssets(t *testing.T, r test.TestResources) (test.TestAs
 func Test_reconcileService(t *testing.T) {
 	eventListener1 := eventListener0.DeepCopy()
 	eventListener1.Status.SetExistsCondition(v1alpha1.ServiceExists, nil)
-	eventListener1.Status.Address = &duckv1alpha1.Addressable{
-		Hostname: listenerHostname(generatedResourceName, namespace),
+	eventListener1.Status.Address = &duckv1alpha1.Addressable{}
+	eventListener1.Status.Address.URL = &apis.URL{
+		Scheme: "http",
+		Host:   listenerHostname(generatedResourceName, namespace, Port),
 	}
 
 	eventListener2 := eventListener1.DeepCopy()
@@ -428,7 +430,7 @@ func TestReconcile(t *testing.T) {
 		),
 		bldr.EventListenerStatus(
 			bldr.EventListenerConfig(generatedResourceName),
-			bldr.EventListenerAddress(listenerHostname(generatedResourceName, namespace)),
+			bldr.EventListenerAddress(listenerHostname(generatedResourceName, namespace, Port)),
 			bldr.EventListenerCondition(
 				v1alpha1.ServiceExists,
 				corev1.ConditionTrue,

--- a/test/builder/eventlistener.go
+++ b/test/builder/eventlistener.go
@@ -127,10 +127,17 @@ func EventListenerConfig(generatedResourceName string) EventListenerStatusOp {
 // EventListenerAddress sets the EventListenerAddress on the EventListenerStatus
 func EventListenerAddress(hostname string) EventListenerStatusOp {
 	return func(e *v1alpha1.EventListenerStatus) {
-		e.Address = &duckv1alpha1.Addressable{
-			Hostname: hostname,
-		}
+		e.Address = NewAddressable(hostname)
 	}
+}
+
+func NewAddressable(hostname string) *duckv1alpha1.Addressable {
+	addressable := &duckv1alpha1.Addressable{}
+	addressable.URL = &apis.URL{
+		Scheme: "http",
+		Host:   hostname,
+	}
+	return addressable
 }
 
 // Trigger creates an EventListenerTrigger. Any number of EventListenerTriggerOp

--- a/test/builder/eventlistener_test.go
+++ b/test/builder/eventlistener_test.go
@@ -57,9 +57,7 @@ func TestEventListenerBuilder(t *testing.T) {
 			},
 			Status: v1alpha1.EventListenerStatus{
 				AddressStatus: duckv1alpha1.AddressStatus{
-					Address: &duckv1alpha1.Addressable{
-						Hostname: "hostname",
-					},
+					Address: NewAddressable("hostname"),
 				},
 				Configuration: v1alpha1.EventListenerConfig{
 					GeneratedResourceName: "generatedName",


### PR DESCRIPTION
# Changes
Previously the EventListener did not include the port information for its addressable contract. As a result, the EventListener could not be used as a Sink for Knative Eventing as the EventListener pod listens on 8080 however Knative assumed 80.

# Release Notes

```
Update the EventListener Addressable to include the correct port information for use as a Knative Sink using the `Status.Address.URL field`  

```
