### PR TITLE
Listener Response in Json Format

### DIFF
--- a/pkg/sink/sink.go
+++ b/pkg/sink/sink.go
@@ -144,10 +144,26 @@ func (r Sink) HandleEvent(response http.ResponseWriter, request *http.Request) {
 		}
 	}
 
-	// TODO: Do we really need to return the entire body back???
+	js, err := json.Marshal(
+		struct {
+			EventListener string
+			Namespace     string
+			EventID       string
+		}{
+			r.EventListenerName,
+			r.EventListenerNamespace,
+			eventID,
+		},
+	)
+	if err != nil {
+		http.Error(response, "Error Marshaling response"+
+			err.Error(), http.StatusInternalServerError)
+		return
+	}
+
 	response.WriteHeader(code)
-	fmt.Fprintf(response, "EventListener: %s in Namespace: %s handling event (EventID: %s) with payload: %s and header: %v",
-		r.EventListenerName, r.EventListenerNamespace, string(eventID), string(event), request.Header)
+	response.Header().Set("Content-Type", "application/json")
+	response.Write(js)
 }
 
 func (r Sink) createResources(resources []json.RawMessage, triggerName, eventID string) error {


### PR DESCRIPTION
# Changes
EventListener Response is sent in json now
Fixes https://github.com/tektoncd/triggers/issues/194
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Response of EventListener comes in Json format.
```
