### PR TITLE
add log entry for each generated resource

### DIFF
--- a/pkg/sink/sink.go
+++ b/pkg/sink/sink.go
@@ -173,6 +173,10 @@ func createResource(rt json.RawMessage, restClient restclient.Interface, discove
 		return err
 	}
 
+	resourcename := gjson.GetBytes(rt, "metadata.name")
+	resourcekind := gjson.GetBytes(rt, "kind")
+	log.Printf("Generating resource: kind: %v, name: %v ", resourcekind, resourcename)
+
 	uri := createRequestURI(apiVersion, apiResource.Name, namespace, apiResource.Namespaced)
 	result := restClient.Post().
 		RequestURI(uri).


### PR DESCRIPTION
# Changes

This PR is for issue https://github.com/tektoncd/triggers/issues/112

Added log entry for each resource generation during event handling. If it fails, the error log entry follows the log entry.

```
2019/10/30 19:38:11 Generating resource: kind: PipelineResource, name: source-repo-jgcpl 
2019/10/30 19:38:11 Generating resource: kind: PipelineResource, name: image-source-jgcpl 
2019/10/30 19:38:11 Generating resource: kind: Task, name: devopsascode-task-jgcpl 
2019/10/30 19:38:11 Generating resource: kind: TaskRun, name: devopsascode-taskrun-1 
2019/10/30 19:38:11 taskruns.tekton.dev "devopsascode-taskrun-1" already exists
```
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
