### PR TITLE
Eventlistener response code change

### DIFF
--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -490,6 +490,9 @@ func Test_HandleEvent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating Post request: %s", err)
 	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("Response code doesn't match: %v", resp.Status)
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("Error reading response body: %s", err)


### PR DESCRIPTION
# Changes

This PR is for issue https://github.com/tektoncd/triggers/issues/111

The eventlistener waits until all the trigger executions (up-to the creation of the resources) and only when at least one of the execution completed successfully, it returns response code 201(Accepted) otherwise it returns 202 (Created).

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
