### PR TITLE
add logging config to EventListener binary

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -456,7 +456,7 @@
   version = "v1.0.3"
 
 [[projects]]
-  digest = "1:7bfce62685de77102207d140d92b385d88018b13c96d60fcbc033f0da03919a4"
+  digest = "1:b07cb7802c839ecd6108a7f36aa5685a0c4c41244faeb310f89e4bbcceeca766"
   name = "github.com/tektoncd/pipeline"
   packages = [
     "pkg/apis/config",
@@ -470,6 +470,7 @@
     "pkg/client/injection/client",
     "pkg/client/injection/client/fake",
     "pkg/list",
+    "pkg/logging",
     "pkg/names",
     "pkg/system",
   ]
@@ -1243,6 +1244,7 @@
     "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake",
     "github.com/tektoncd/pipeline/pkg/client/injection/client",
     "github.com/tektoncd/pipeline/pkg/client/injection/client/fake",
+    "github.com/tektoncd/pipeline/pkg/logging",
     "github.com/tektoncd/pipeline/pkg/names",
     "github.com/tektoncd/pipeline/pkg/system",
     "github.com/tektoncd/plumbing/scripts",

--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -48,3 +48,4 @@ data:
   # Log level overrides
   loglevel.controller: "info"
   loglevel.webhook: "info"
+  loglevel.eventlistener: "info"

--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -14,6 +14,10 @@ does what has been specified in the corresponding
 services' via their cluster DNS. For external services to connect to your
 cluster (e.g. GitHub sending webhooks), check out the guide on [exposing eventlisteners](./exposing-eventlisteners.md)
 
+When the `EventListener` is created in the different namespace from the trigger component, `config-logging-triggers` ConfigMap
+must be created for the logging configuration in the namespace.  The ConfigMap with the defatul configuration can be created
+by applying [config-logging.yaml](../config/config-logging.yaml)
+
 ## Parameters
 
 `EventListener`s can provide `params` which are merged with the `TriggerBinding`

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
@@ -221,6 +221,22 @@ func (c *Reconciler) reconcileDeployment(el *v1alpha1.EventListener) error {
 			"-el-namespace", el.Namespace,
 			"-port", strconv.Itoa(Port),
 		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "config-logging",
+				MountPath: "/etc/config-logging",
+			},
+		},
+		Env: []corev1.EnvVar{
+			{
+				Name: "SYSTEM_NAMESPACE",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "metadata.namespace",
+					},
+				},
+			},
+		},
 	}
 	deployment := &appsv1.Deployment{
 		ObjectMeta: generateObjectMeta(el),
@@ -236,6 +252,19 @@ func (c *Reconciler) reconcileDeployment(el *v1alpha1.EventListener) error {
 				Spec: corev1.PodSpec{
 					ServiceAccountName: el.Spec.ServiceAccountName,
 					Containers:         []corev1.Container{container},
+
+					Volumes: []corev1.Volume{
+						{
+							Name: "config-logging",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "config-logging-triggers",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
@@ -278,6 +278,34 @@ func Test_reconcileDeployment(t *testing.T) {
 								"-el-namespace", namespace,
 								"-port", strconv.Itoa(Port),
 							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "config-logging",
+									MountPath: "/etc/config-logging",
+								},
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name: "SYSTEM_NAMESPACE",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.namespace",
+										},
+									},
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "config-logging",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "config-logging-triggers",
+									},
+								},
+							},
 						},
 					},
 				},
@@ -491,6 +519,34 @@ func TestReconcile(t *testing.T) {
 								"-el-name", eventListenerName,
 								"-el-namespace", namespace,
 								"-port", strconv.Itoa(Port),
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "config-logging",
+									MountPath: "/etc/config-logging",
+								},
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name: "SYSTEM_NAMESPACE",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.namespace",
+										},
+									},
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "config-logging",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "config-logging-triggers",
+									},
+								},
 							},
 						},
 					},

--- a/vendor/github.com/tektoncd/pipeline/pkg/logging/config.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/logging/config.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	"go.uber.org/zap"
+
+	"knative.dev/pkg/logging"
+)
+
+const (
+	// ConfigName is the name of the ConfigMap that the logging config will be stored in
+	ConfigName = "config-logging"
+)
+
+// NewLogger creates a logger with the supplied configuration.
+// In addition to the logger, it returns AtomicLevel that can
+// be used to change the logging level at runtime.
+// If configuration is empty, a fallback configuration is used.
+// If configuration cannot be used to instantiate a logger,
+// the same fallback configuration is used.
+func NewLogger(configJSON string, levelOverride string) (*zap.SugaredLogger, zap.AtomicLevel) {
+	return logging.NewLogger(configJSON, levelOverride)
+}
+
+// NewLoggerFromConfig creates a logger using the provided Config
+func NewLoggerFromConfig(config *logging.Config, name string) (*zap.SugaredLogger, zap.AtomicLevel) {
+	return logging.NewLoggerFromConfig(config, name)
+}


### PR DESCRIPTION
# Changes
This PR for the issue https://github.com/tektoncd/triggers/issues/76

The logging config is in config-logging.yaml file.  The log component string is `eventlistener`  and the default setting is `info`.  The Logger is set in the sink.Resource so that any member function of the struct can use the logger.
 
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
