### PR TITLE
add logging library to EventListener

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -456,7 +456,7 @@
   version = "v1.0.3"
 
 [[projects]]
-  digest = "1:7bfce62685de77102207d140d92b385d88018b13c96d60fcbc033f0da03919a4"
+  digest = "1:b07cb7802c839ecd6108a7f36aa5685a0c4c41244faeb310f89e4bbcceeca766"
   name = "github.com/tektoncd/pipeline"
   packages = [
     "pkg/apis/config",
@@ -470,6 +470,7 @@
     "pkg/client/injection/client",
     "pkg/client/injection/client/fake",
     "pkg/list",
+    "pkg/logging",
     "pkg/names",
     "pkg/system",
   ]
@@ -1243,6 +1244,7 @@
     "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake",
     "github.com/tektoncd/pipeline/pkg/client/injection/client",
     "github.com/tektoncd/pipeline/pkg/client/injection/client/fake",
+    "github.com/tektoncd/pipeline/pkg/logging",
     "github.com/tektoncd/pipeline/pkg/names",
     "github.com/tektoncd/pipeline/pkg/system",
     "github.com/tektoncd/plumbing/scripts",

--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -48,3 +48,4 @@ data:
   # Log level overrides
   loglevel.controller: "info"
   loglevel.webhook: "info"
+  loglevel.eventlistener: "info"

--- a/examples/role-resources/role.yaml
+++ b/examples/role-resources/role.yaml
@@ -3,9 +3,14 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: tekton-triggers-example-minimal
 rules:
+# Permissions for every EventListener deployment to function
 - apiGroups: ["tekton.dev"]
   resources: ["eventlisteners", "triggerbindings", "triggertemplates", "tasks", "taskruns"]
   verbs: ["get"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch"]
+# Permissions to create resources in associated TriggerTemplates
 - apiGroups: ["tekton.dev"]
   resources: ["pipelineruns", "pipelineresources", "taskruns"]
   verbs: ["create"]

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	"flag"
+	"github.com/tektoncd/pipeline/pkg/system"
+	"go.uber.org/zap"
+	"k8s.io/client-go/kubernetes"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/logging/logkey"
+	"log"
+)
+
+// Configure logging
+func ConfigureLogging(logKeyString, configName string, stopCh <-chan struct{}, kubeClient *kubernetes.Clientset) *zap.SugaredLogger {
+	flag.Parse()
+	cm, err := configmap.Load("/etc/config-logging")
+	if err != nil {
+		log.Fatalf("Error loading logging configuration: %v", err)
+	}
+	config, err := logging.NewConfigFromMap(cm)
+	if err != nil {
+		log.Fatalf("Error parsing logging configuration: %v", err)
+	}
+	logger, atomicLevel := logging.NewLoggerFromConfig(config, logKeyString)
+
+	logger = logger.With(zap.String(logkey.ControllerType, logKeyString))
+
+	logger.Infof("Starting the Configuration %v", logKeyString)
+
+	// Watch the logging config map and dynamically update logging levels.
+	configMapWatcher := configmap.NewInformedWatcher(kubeClient, system.GetNamespace())
+	configMapWatcher.Watch(configName, logging.UpdateLevelFromConfigMap(logger, atomicLevel, logKeyString))
+	if err = configMapWatcher.Start(stopCh); err != nil {
+		logger.Fatalf("failed to start configuration manager: %v", err)
+	}
+	return logger
+}

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
@@ -278,6 +278,34 @@ func Test_reconcileDeployment(t *testing.T) {
 								"-el-namespace", namespace,
 								"-port", strconv.Itoa(Port),
 							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "config-logging",
+									MountPath: "/etc/config-logging",
+								},
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name: "SYSTEM_NAMESPACE",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.namespace",
+										},
+									},
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "config-logging",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "config-logging-triggers",
+									},
+								},
+							},
 						},
 					},
 				},
@@ -491,6 +519,34 @@ func TestReconcile(t *testing.T) {
 								"-el-name", eventListenerName,
 								"-el-namespace", namespace,
 								"-port", strconv.Itoa(Port),
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "config-logging",
+									MountPath: "/etc/config-logging",
+								},
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name: "SYSTEM_NAMESPACE",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.namespace",
+										},
+									},
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "config-logging",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "config-logging-triggers",
+									},
+								},
 							},
 						},
 					},

--- a/pkg/sink/sink.go
+++ b/pkg/sink/sink.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"path"
@@ -34,6 +33,7 @@ import (
 	"github.com/tektoncd/triggers/pkg/template"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
+	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	discoveryclient "k8s.io/client-go/discovery"
@@ -50,26 +50,27 @@ type Resource struct {
 	HTTPClient             *http.Client
 	EventListenerName      string
 	EventListenerNamespace string
+	Logger                 *zap.SugaredLogger
 }
 
 // HandleEvent processes an incoming HTTP event for the event listener.
 func (r Resource) HandleEvent(response http.ResponseWriter, request *http.Request) {
 	el, err := r.TriggersClient.TektonV1alpha1().EventListeners(r.EventListenerNamespace).Get(r.EventListenerName, metav1.GetOptions{})
 	if err != nil {
-		log.Printf("Error getting EventListener %s in Namespace %s: %s", r.EventListenerName, r.EventListenerNamespace, err)
+		r.Logger.Fatalf("Error getting EventListener %s in Namespace %s: %s", r.EventListenerName, r.EventListenerNamespace, err)
 		response.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	event, err := ioutil.ReadAll(request.Body)
 	if err != nil {
-		log.Printf("Error reading event body: %s", err)
+		r.Logger.Errorf("Error reading event body: %s", err)
 		response.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	eventID := template.UID()
-	log.Printf("EventListener: %s in Namespace: %s handling event (EventID: %s) with payload: %s and header: %v",
+	r.Logger.Debugf("EventListener: %s in Namespace: %s handling event (EventID: %s) with payload: %s and header: %v",
 		r.EventListenerName, r.EventListenerNamespace, eventID, string(event), request.Header)
 
 	result := make(chan int, 10)
@@ -98,14 +99,14 @@ func (r Resource) executeTrigger(payload []byte, request *http.Request, trigger 
 	if trigger.Interceptor != nil {
 		interceptorURL, err := GetURI(trigger.Interceptor.ObjectRef, r.EventListenerNamespace) // TODO: Cache this result or do this on initialization
 		if err != nil {
-			log.Printf("Could not resolve Interceptor Service URI: %q", err)
+			r.Logger.Errorf("Could not resolve Interceptor Service URI: %q", err)
 			result <- http.StatusAccepted
 			return
 		}
 
 		modifiedPayload, err := r.processEvent(interceptorURL, request, payload, trigger.Interceptor.Header)
 		if err != nil {
-			log.Printf("Error Intercepting Event (EventID: %s): %q", eventID, err)
+			r.Logger.Errorf("Error Intercepting Event (EventID: %s): %q", eventID, err)
 			result <- http.StatusAccepted
 			return
 		}
@@ -116,20 +117,20 @@ func (r Resource) executeTrigger(payload []byte, request *http.Request, trigger 
 		r.TriggersClient.TektonV1alpha1().TriggerBindings(r.EventListenerNamespace).Get,
 		r.TriggersClient.TektonV1alpha1().TriggerTemplates(r.EventListenerNamespace).Get)
 	if err != nil {
-		log.Print(err)
+		r.Logger.Error(err)
 		result <- http.StatusAccepted
 		return
 	}
 	resources, err := template.NewResources(payload, request.Header, trigger.Params, binding)
 	if err != nil {
-		log.Print(err)
+		r.Logger.Error(err)
 		result <- http.StatusAccepted
 		return
 	}
-	err = createResources(resources, r.RESTClient, r.DiscoveryClient, r.EventListenerNamespace, r.EventListenerName, eventID)
+	err = createResources(resources, r.RESTClient, r.DiscoveryClient, r.EventListenerNamespace, r.EventListenerName, eventID, r.Logger)
 	if err != nil {
+		r.Logger.Error(err)
 		result <- http.StatusAccepted
-		log.Print(err)
 	}
 	result <- http.StatusCreated
 }
@@ -155,9 +156,9 @@ func addInterceptorHeaders(header http.Header, headerParams []pipelinev1.Param) 
 	}
 }
 
-func createResources(resources []json.RawMessage, restClient restclient.Interface, discoveryClient discoveryclient.DiscoveryInterface, eventListenerNamespace string, eventListenerName string, eventID string) error {
+func createResources(resources []json.RawMessage, restClient restclient.Interface, discoveryClient discoveryclient.DiscoveryInterface, eventListenerNamespace string, eventListenerName string, eventID string, logger *zap.SugaredLogger) error {
 	for _, resource := range resources {
-		if err := createResource(resource, restClient, discoveryClient, eventListenerNamespace, eventListenerName, eventID); err != nil {
+		if err := createResource(resource, restClient, discoveryClient, eventListenerNamespace, eventListenerName, eventID, logger); err != nil {
 			return err
 		}
 	}
@@ -166,7 +167,7 @@ func createResources(resources []json.RawMessage, restClient restclient.Interfac
 
 // createResource uses the kubeClient to create the resource defined in the
 // TriggerResourceTemplate and returns any errors with this process
-func createResource(rt json.RawMessage, restClient restclient.Interface, discoveryClient discoveryclient.DiscoveryInterface, eventListenerNamespace string, eventListenerName string, eventID string) error {
+func createResource(rt json.RawMessage, restClient restclient.Interface, discoveryClient discoveryclient.DiscoveryInterface, eventListenerNamespace string, eventListenerName string, eventID string, logger *zap.SugaredLogger) error {
 	// Assume the TriggerResourceTemplate is valid (it has an apiVersion and Kind)
 	apiVersion := gjson.GetBytes(rt, "apiVersion").String()
 	kind := gjson.GetBytes(rt, "kind").String()
@@ -182,18 +183,16 @@ func createResource(rt json.RawMessage, restClient restclient.Interface, discove
 
 	rt, err = sjson.SetBytes(rt, "metadata.labels."+triggersv1.LabelEscape+triggersv1.EventListenerLabelKey, eventListenerName)
 	if err != nil {
-		log.Print(err)
 		return err
 	}
 	rt, err = sjson.SetBytes(rt, "metadata.labels."+triggersv1.LabelEscape+triggersv1.EventIDLabelKey, eventID)
 	if err != nil {
-		log.Print(err)
 		return err
 	}
 
 	resourcename := gjson.GetBytes(rt, "metadata.name")
 	resourcekind := gjson.GetBytes(rt, "kind")
-	log.Printf("Generating resource: kind: %v, name: %v ", resourcekind, resourcename)
+	logger.Infof("Generating resource: kind: %s, name: %s ", resourcekind, resourcename)
 
 	uri := createRequestURI(apiVersion, apiResource.Name, namespace, apiResource.Namespaced)
 	result := restClient.Post().

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/logging"
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	faketriggersclientset "github.com/tektoncd/triggers/pkg/client/clientset/versioned/fake"
 	bldr "github.com/tektoncd/triggers/test/builder"
@@ -309,6 +310,7 @@ func Test_createResource(t *testing.T) {
 			wantURLPath:            "/api/v1/namespaces",
 		},
 	}
+	logger, _ := logging.NewLogger("", "")
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup fake client
@@ -337,7 +339,7 @@ func Test_createResource(t *testing.T) {
 			})
 
 			// Run test
-			err := createResource(tt.resource, restClient, kubeClient.Discovery(), tt.eventListenerNamespace, tt.eventListenerName, tt.eventID)
+			err := createResource(tt.resource, restClient, kubeClient.Discovery(), tt.eventListenerNamespace, tt.eventListenerName, tt.eventID, logger)
 			if err != nil {
 				t.Errorf("createResource() returned error: %s", err)
 			}
@@ -448,12 +450,14 @@ func Test_HandleEvent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating RESTClient: %s", err)
 	}
+	logger, _ := logging.NewLogger("", "")
 	r := Resource{
 		EventListenerName:      el.Name,
 		EventListenerNamespace: namespace,
 		RESTClient:             restClient,
 		DiscoveryClient:        kubeClient.Discovery(),
 		TriggersClient:         triggersClient,
+		Logger:                 logger,
 	}
 	ts := httptest.NewServer(http.HandlerFunc(r.HandleEvent))
 	defer ts.Close()
@@ -515,10 +519,12 @@ func Test_HandleEvent(t *testing.T) {
 }
 
 func TestResource_processEvent(t *testing.T) {
+	logger, _ := logging.NewLogger("", "")
 	r := Resource{
 		HTTPClient:             http.DefaultClient,
 		EventListenerName:      "foo-listener",
 		EventListenerNamespace: "foo",
+		Logger:                 logger,
 	}
 
 	payload, _ := json.Marshal(map[string]string{

--- a/test/eventlistener_test.go
+++ b/test/eventlistener_test.go
@@ -193,11 +193,19 @@ func TestEventListenerCreate(t *testing.T) {
 	_, err = c.KubeClient.RbacV1().Roles(namespace).Create(
 		&rbacv1.Role{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-role"},
-			Rules: []rbacv1.PolicyRule{{
-				APIGroups: []string{"tekton.dev"},
-				Resources: []string{"eventlisteners", "triggerbindings", "triggertemplates", "pipelineresources"},
-				Verbs:     []string{"create", "get"},
-			}}},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{"tekton.dev"},
+					Resources: []string{"eventlisteners", "triggerbindings", "triggertemplates", "pipelineresources"},
+					Verbs:     []string{"create", "get"},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"configmaps"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
+			},
+		},
 	)
 	if err != nil {
 		t.Fatalf("Error creating Role: %s", err)

--- a/vendor/github.com/tektoncd/pipeline/pkg/logging/config.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/logging/config.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	"go.uber.org/zap"
+
+	"knative.dev/pkg/logging"
+)
+
+const (
+	// ConfigName is the name of the ConfigMap that the logging config will be stored in
+	ConfigName = "config-logging"
+)
+
+// NewLogger creates a logger with the supplied configuration.
+// In addition to the logger, it returns AtomicLevel that can
+// be used to change the logging level at runtime.
+// If configuration is empty, a fallback configuration is used.
+// If configuration cannot be used to instantiate a logger,
+// the same fallback configuration is used.
+func NewLogger(configJSON string, levelOverride string) (*zap.SugaredLogger, zap.AtomicLevel) {
+	return logging.NewLogger(configJSON, levelOverride)
+}
+
+// NewLoggerFromConfig creates a logger using the provided Config
+func NewLoggerFromConfig(config *logging.Config, name string) (*zap.SugaredLogger, zap.AtomicLevel) {
+	return logging.NewLoggerFromConfig(config, name)
+}


### PR DESCRIPTION
# Changes

This PR for the issue #76

The logging config is in config-logging.yaml file. The log component string is eventlistener and the default setting is info. The Logger is set in the sink.Resource so that any member function of the struct can use the logger.

Note: The config-logging-triggers ConfigMap is created in the namespace where the eventlistener is created when it doesn't exist.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
