### PR TITLE
Set a timeout for requests to interceptor services

### DIFF
--- a/cmd/eventlistenersink/main.go
+++ b/cmd/eventlistenersink/main.go
@@ -76,7 +76,7 @@ func main() {
 		RESTClient:             sinkClients.RESTClient,
 		TriggersClient:         sinkClients.TriggersClient,
 		PipelineClient:         sinkClients.PipelineClient,
-		HTTPClient:             http.DefaultClient, // TODO: Use a different client since the default client has weird timeout values
+		HTTPClient:             http.DefaultClient,
 		EventListenerName:      sinkArgs.ElName,
 		EventListenerNamespace: sinkArgs.ElNamespace,
 		Logger:                 logger,

--- a/pkg/sink/interceptors.go
+++ b/pkg/sink/interceptors.go
@@ -42,27 +42,10 @@ func GetURI(objRef *corev1.ObjectReference, ns string) (*url.URL, error) {
 	return nil, xerrors.New("Invalid objRef")
 }
 
-// TODO: Use request.Clone once we move to go 1.13
 func createOutgoingRequest(ctx context.Context, original *http.Request, url *url.URL, payload []byte) *http.Request {
-	r := original.WithContext(ctx)
-	// RequestURI cannot be set in outgoing requests
-	r.RequestURI = ""
+	r := original.Clone(ctx)
+	r.RequestURI = "" // RequestURI cannot be set in outgoing requests
 	r.URL = url
-
-	headers := make(map[string][]string, len(original.Header))
-	for k, v := range original.Header {
-		v2 := make([]string, len(v))
-		copy(v2, v)
-		headers[k] = v2
-	}
-	r.Header = headers
-
-	if s := original.TransferEncoding; s != nil {
-		s2 := make([]string, len(s))
-		copy(s2, s)
-		r.TransferEncoding = s
-	}
-
 	r.Body = ioutil.NopCloser(bytes.NewBuffer(payload))
 	return r
 }

--- a/pkg/sink/interceptors_test.go
+++ b/pkg/sink/interceptors_test.go
@@ -88,7 +88,7 @@ func TestCreateOutgoingRequest(t *testing.T) {
 		"foo":       "bar",
 	})
 
-	req, _ := http.NewRequest(http.MethodPost, "http://event.listener.url", ioutil.NopCloser(bytes.NewBuffer(reqBody)))
+	req := httptest.NewRequest(http.MethodPost, "http://event.listener.url", ioutil.NopCloser(bytes.NewBuffer(reqBody)))
 	req.Header.Add("Content-type", "application/json")
 	req.Header.Add("X-Event-Id", "blah")
 	eventProcessorURL, _ := url.Parse("http://some.other.url")


### PR DESCRIPTION
# Changes

Currently, we do not set any timeouts for the outgoing
requests to interceptor services which means a slow interceptor
can slow down event processing. This commit adds a timeout of 5
seconds for each interceptor request to respond within. In the future
we could consider making this value user configurable.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Add a timeout of 5 seconds for each interceptor request to respond within
```
