### PR TITLE
Rename sink.Resource to sink.Sink

### DIFF
--- a/cmd/eventlistenersink/main.go
+++ b/cmd/eventlistenersink/main.go
@@ -70,8 +70,8 @@ func main() {
 		logger.Fatal(err)
 	}
 
-	// Create sink Resource
-	r := sink.Resource{
+	// Create EventListener Sink
+	r := sink.Sink{
 		DiscoveryClient:        sinkClients.DiscoveryClient,
 		RESTClient:             sinkClients.RESTClient,
 		TriggersClient:         sinkClients.TriggersClient,

--- a/pkg/apis/triggers/v1alpha1/event_listener_types_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_types_test.go
@@ -33,65 +33,51 @@ func TestSetGetCondition(t *testing.T) {
 		name               string
 		conditions         []*apis.Condition
 		expectedConditions int
-	}{
-		{
-			name:               "No conditions",
-			conditions:         []*apis.Condition{},
-			expectedConditions: 0,
-		},
-		{
-			name: "One condition",
-			conditions: []*apis.Condition{
-				{
-					Type:    "Some Type",
-					Status:  corev1.ConditionTrue,
-					Message: "Message",
-				},
-			},
-			expectedConditions: 1,
-		},
-		{
-			name: "Two conditions",
-			conditions: []*apis.Condition{
-				{
-					Type:    "Some Type1",
-					Status:  corev1.ConditionTrue,
-					Message: "Message1",
-				},
-				{
-					Type:    "Some Type2",
-					Status:  corev1.ConditionFalse,
-					Message: "Message2",
-				},
-			},
-			expectedConditions: 2,
-		},
-		{
-			name: "Two conditions repeated",
-			conditions: []*apis.Condition{
-				{
-					Type:    "Some Type1",
-					Status:  corev1.ConditionTrue,
-					Message: "Message1",
-				},
-				{
-					Type:    "Some Type1",
-					Status:  corev1.ConditionFalse,
-					Message: "Message2",
-				},
-				{
-					Type:    "Some Type2",
-					Status:  corev1.ConditionTrue,
-					Message: "Message1",
-				},
-				{
-					Type:    "Some Type2",
-					Status:  corev1.ConditionFalse,
-					Message: "Message2",
-				},
-			},
-			expectedConditions: 2,
-		},
+	}{{
+		name:               "No conditions",
+		conditions:         []*apis.Condition{},
+		expectedConditions: 0,
+	}, {
+		name: "One condition",
+		conditions: []*apis.Condition{{
+			Type:    "Some Type",
+			Status:  corev1.ConditionTrue,
+			Message: "Message",
+		}},
+		expectedConditions: 1,
+	}, {
+		name: "Two conditions",
+		conditions: []*apis.Condition{{
+			Type:    "Some Type1",
+			Status:  corev1.ConditionTrue,
+			Message: "Message1",
+		}, {
+			Type:    "Some Type2",
+			Status:  corev1.ConditionFalse,
+			Message: "Message2",
+		}},
+		expectedConditions: 2,
+	}, {
+		name: "Two conditions repeated",
+		conditions: []*apis.Condition{{
+			Type:    "Some Type1",
+			Status:  corev1.ConditionTrue,
+			Message: "Message1",
+		}, {
+			Type:    "Some Type1",
+			Status:  corev1.ConditionFalse,
+			Message: "Message2",
+		}, {
+			Type:    "Some Type2",
+			Status:  corev1.ConditionTrue,
+			Message: "Message1",
+		}, {
+			Type:    "Some Type2",
+			Status:  corev1.ConditionFalse,
+			Message: "Message2",
+		}},
+		expectedConditions: 2,
+	},
 	}
 	for i := range tests {
 		t.Run(tests[i].name, func(t *testing.T) {
@@ -134,27 +120,25 @@ func TestSetExistsCondition(t *testing.T) {
 		conditionType     apis.ConditionType
 		err               error
 		expectedCondition *apis.Condition
-	}{
-		{
-			name:          "Condition with error",
-			conditionType: condType,
-			err:           fmt.Errorf("Something bad"),
-			expectedCondition: &apis.Condition{
-				Type:    condType,
-				Status:  corev1.ConditionFalse,
-				Message: "Something bad",
-			},
+	}{{
+		name:          "Condition with error",
+		conditionType: condType,
+		err:           fmt.Errorf("Something bad"),
+		expectedCondition: &apis.Condition{
+			Type:    condType,
+			Status:  corev1.ConditionFalse,
+			Message: "Something bad",
 		},
-		{
-			name:          "Condition without error",
-			conditionType: condType,
-			err:           nil,
-			expectedCondition: &apis.Condition{
-				Type:    condType,
-				Status:  corev1.ConditionTrue,
-				Message: fmt.Sprintf("%s exists", condType),
-			},
+	}, {
+		name:          "Condition without error",
+		conditionType: condType,
+		err:           nil,
+		expectedCondition: &apis.Condition{
+			Type:    condType,
+			Status:  corev1.ConditionTrue,
+			Message: fmt.Sprintf("%s exists", condType),
 		},
+	},
 	}
 	for i := range tests {
 		t.Run(tests[i].name, func(t *testing.T) {
@@ -174,120 +158,108 @@ func TestSetDeploymentConditions(t *testing.T) {
 		deploymentConditions []appsv1.DeploymentCondition
 		initialStatus        *EventListenerStatus
 		expectedStatus       *EventListenerStatus
-	}{
-		{
-			name:                 "No Deployment Conditions",
-			deploymentConditions: []appsv1.DeploymentCondition{},
-			initialStatus:        &EventListenerStatus{},
-			expectedStatus:       &EventListenerStatus{},
-		},
-		{
-			name: "One Deployment Condition",
-			deploymentConditions: []appsv1.DeploymentCondition{
-				{
-					Type:    appsv1.DeploymentAvailable,
-					Status:  corev1.ConditionTrue,
-					Reason:  "Reason",
-					Message: "Message",
-				},
-			},
-			initialStatus: &EventListenerStatus{},
-			expectedStatus: &EventListenerStatus{
-				Status: duckv1beta1.Status{
-					Conditions: duckv1beta1.Conditions{
-						apis.Condition{
-							Type:    apis.ConditionType(appsv1.DeploymentAvailable),
-							Status:  corev1.ConditionTrue,
-							Reason:  "Reason",
-							Message: "Message",
-						},
+	}{{
+		name:                 "No Deployment Conditions",
+		deploymentConditions: []appsv1.DeploymentCondition{},
+		initialStatus:        &EventListenerStatus{},
+		expectedStatus:       &EventListenerStatus{},
+	}, {
+		name: "One Deployment Condition",
+		deploymentConditions: []appsv1.DeploymentCondition{{
+			Type:    appsv1.DeploymentAvailable,
+			Status:  corev1.ConditionTrue,
+			Reason:  "Reason",
+			Message: "Message",
+		}},
+		initialStatus: &EventListenerStatus{},
+		expectedStatus: &EventListenerStatus{
+			Status: duckv1beta1.Status{
+				Conditions: duckv1beta1.Conditions{
+					apis.Condition{
+						Type:    apis.ConditionType(appsv1.DeploymentAvailable),
+						Status:  corev1.ConditionTrue,
+						Reason:  "Reason",
+						Message: "Message",
 					},
 				},
 			},
 		},
-		{
-			name: "Two Deployment Conditions",
-			deploymentConditions: []appsv1.DeploymentCondition{
-				{
-					Type:    appsv1.DeploymentAvailable,
-					Status:  corev1.ConditionTrue,
-					Reason:  "Reason",
-					Message: "Message",
-				},
-				{
-					Type:    appsv1.DeploymentProgressing,
-					Status:  corev1.ConditionTrue,
-					Reason:  "Reason",
-					Message: "Message",
-				},
-			},
-			initialStatus: &EventListenerStatus{},
-			expectedStatus: &EventListenerStatus{
-				Status: duckv1beta1.Status{
-					Conditions: duckv1beta1.Conditions{
-						apis.Condition{
-							Type:    apis.ConditionType(appsv1.DeploymentAvailable),
-							Status:  corev1.ConditionTrue,
-							Reason:  "Reason",
-							Message: "Message",
-						},
-						apis.Condition{
-							Type:    apis.ConditionType(appsv1.DeploymentProgressing),
-							Status:  corev1.ConditionTrue,
-							Reason:  "Reason",
-							Message: "Message",
-						},
+	}, {
+		name: "Two Deployment Conditions",
+		deploymentConditions: []appsv1.DeploymentCondition{{
+			Type:    appsv1.DeploymentAvailable,
+			Status:  corev1.ConditionTrue,
+			Reason:  "Reason",
+			Message: "Message",
+		}, {
+			Type:    appsv1.DeploymentProgressing,
+			Status:  corev1.ConditionTrue,
+			Reason:  "Reason",
+			Message: "Message",
+		}},
+		initialStatus: &EventListenerStatus{},
+		expectedStatus: &EventListenerStatus{
+			Status: duckv1beta1.Status{
+				Conditions: duckv1beta1.Conditions{
+					apis.Condition{
+						Type:    apis.ConditionType(appsv1.DeploymentAvailable),
+						Status:  corev1.ConditionTrue,
+						Reason:  "Reason",
+						Message: "Message",
+					},
+					apis.Condition{
+						Type:    apis.ConditionType(appsv1.DeploymentProgressing),
+						Status:  corev1.ConditionTrue,
+						Reason:  "Reason",
+						Message: "Message",
 					},
 				},
 			},
 		},
-		{
-			name: "Update Replica Condition",
-			deploymentConditions: []appsv1.DeploymentCondition{
-				{
-					Type:    appsv1.DeploymentAvailable,
-					Status:  corev1.ConditionTrue,
-					Reason:  "Reason",
-					Message: "Message",
-				},
-				{
-					Type:    appsv1.DeploymentProgressing,
-					Status:  corev1.ConditionTrue,
-					Reason:  "Reason",
-					Message: "Message",
-				},
-			},
-			initialStatus: &EventListenerStatus{
-				Status: duckv1beta1.Status{
-					Conditions: duckv1beta1.Conditions{
-						apis.Condition{
-							Type:    apis.ConditionType(appsv1.DeploymentReplicaFailure),
-							Status:  corev1.ConditionTrue,
-							Reason:  "Reason",
-							Message: "Message",
-						},
-					},
-				},
-			},
-			expectedStatus: &EventListenerStatus{
-				Status: duckv1beta1.Status{
-					Conditions: duckv1beta1.Conditions{
-						apis.Condition{
-							Type:    apis.ConditionType(appsv1.DeploymentAvailable),
-							Status:  corev1.ConditionTrue,
-							Reason:  "Reason",
-							Message: "Message",
-						},
-						apis.Condition{
-							Type:    apis.ConditionType(appsv1.DeploymentProgressing),
-							Status:  corev1.ConditionTrue,
-							Reason:  "Reason",
-							Message: "Message",
-						},
+	}, {
+		name: "Update Replica Condition",
+		deploymentConditions: []appsv1.DeploymentCondition{{
+			Type:    appsv1.DeploymentAvailable,
+			Status:  corev1.ConditionTrue,
+			Reason:  "Reason",
+			Message: "Message",
+		}, {
+			Type:    appsv1.DeploymentProgressing,
+			Status:  corev1.ConditionTrue,
+			Reason:  "Reason",
+			Message: "Message",
+		}},
+		initialStatus: &EventListenerStatus{
+			Status: duckv1beta1.Status{
+				Conditions: duckv1beta1.Conditions{
+					apis.Condition{
+						Type:    apis.ConditionType(appsv1.DeploymentReplicaFailure),
+						Status:  corev1.ConditionTrue,
+						Reason:  "Reason",
+						Message: "Message",
 					},
 				},
 			},
 		},
+		expectedStatus: &EventListenerStatus{
+			Status: duckv1beta1.Status{
+				Conditions: duckv1beta1.Conditions{
+					apis.Condition{
+						Type:    apis.ConditionType(appsv1.DeploymentAvailable),
+						Status:  corev1.ConditionTrue,
+						Reason:  "Reason",
+						Message: "Message",
+					},
+					apis.Condition{
+						Type:    apis.ConditionType(appsv1.DeploymentProgressing),
+						Status:  corev1.ConditionTrue,
+						Reason:  "Reason",
+						Message: "Message",
+					},
+				},
+			},
+		},
+	},
 	}
 	for i := range tests {
 		t.Run(tests[i].name, func(t *testing.T) {

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
@@ -17,136 +17,127 @@ func Test_EventListenerValidate_error(t *testing.T) {
 		name     string
 		el       *v1alpha1.EventListener
 		raiseErr bool
-	}{
-		{
-			name: "TriggerTemplate Does Not Exist",
-			el: bldr.EventListener("name", "namespace",
-				bldr.EventListenerSpec(
-					bldr.EventListenerTrigger("tb", "dne", "v1alpha1"))),
-			raiseErr: true,
-		},
-		{
-			name: "Interceptor Does Not Exist",
-			el: bldr.EventListener("name", "namespace",
-				bldr.EventListenerSpec(
-					bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
-						bldr.EventListenerTriggerInterceptor("dne", "v1", "Service", "")))),
-			raiseErr: true,
-		},
-		{
-			name: "Interceptor Missing ObjectRef",
-			el: &v1alpha1.EventListener{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "name",
-					Namespace: "namespace",
-				},
-				Spec: v1alpha1.EventListenerSpec{
-					Triggers: []v1alpha1.EventListenerTrigger{{
-						Bindings:    []*v1alpha1.EventListenerBinding{{Name: "tb"}},
-						Template:    v1alpha1.EventListenerTemplate{Name: "tt"},
-						Interceptor: &v1alpha1.EventInterceptor{},
-					}},
-				},
+	}{{
+		name: "TriggerTemplate Does Not Exist",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tb", "dne", "v1alpha1"))),
+		raiseErr: true,
+	}, {
+		name: "Interceptor Does Not Exist",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
+					bldr.EventListenerTriggerInterceptor("dne", "v1", "Service", "")))),
+		raiseErr: true,
+	}, {
+		name: "Interceptor Missing ObjectRef",
+		el: &v1alpha1.EventListener{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
 			},
-			raiseErr: true,
+			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					Bindings:    []*v1alpha1.EventListenerBinding{{Name: "tb"}},
+					Template:    v1alpha1.EventListenerTemplate{Name: "tt"},
+					Interceptor: &v1alpha1.EventInterceptor{},
+				}},
+			},
 		},
-		{
-			name: "Interceptor Wrong APIVersion",
-			el: bldr.EventListener("name", "namespace",
-				bldr.EventListenerSpec(
-					bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
-						bldr.EventListenerTriggerInterceptor("foo", "v3", "Service", "")))),
-			raiseErr: true,
-		}, {
-			name: "Interceptor Wrong Kind",
-			el: bldr.EventListener("name", "namespace",
-				bldr.EventListenerSpec(
-					bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
-						bldr.EventListenerTriggerInterceptor("foo", "v1", "Deployment", "")))),
-			raiseErr: true,
-		}, {
-			name: "Interceptor Non-Canonical Header",
-			el: bldr.EventListener("name", "namespace",
-				bldr.EventListenerSpec(
-					bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
-						bldr.EventListenerTriggerInterceptor("foo", "v1", "Deployment", "",
-							bldr.EventInterceptorParam("non-canonical-header-key", "valid value"))))),
-			raiseErr: true,
-		}, {
-			name: "Interceptor Empty Header Name",
-			el: bldr.EventListener("name", "namespace",
-				bldr.EventListenerSpec(
-					bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
-						bldr.EventListenerTriggerInterceptor("foo", "v1", "Deployment", "",
-							bldr.EventInterceptorParam("", "valid value"))))),
-			raiseErr: true,
-		}, {
-			name: "Interceptor Empty Header Value",
-			el: bldr.EventListener("name", "namespace",
-				bldr.EventListenerSpec(
-					bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
-						bldr.EventListenerTriggerInterceptor("foo", "v1", "Deployment", "",
-							bldr.EventInterceptorParam("Valid-Header-Key", ""))))),
-			raiseErr: true,
-		}, {
-			name: "Valid EventListener No TriggerBinding",
-			el: bldr.EventListener("name", "namespace",
-				bldr.EventListenerSpec(
-					bldr.EventListenerTrigger("", "tt", "v1alpha1"))),
-			raiseErr: false,
-		}, {
-			name: "Valid EventListener No Interceptor",
-			el: bldr.EventListener("name", "namespace",
-				bldr.EventListenerSpec(
-					bldr.EventListenerTrigger("tb", "tt", "v1alpha1"))),
-			raiseErr: false,
-		},
-		{
-			name: "Valid EventListener Interceptor Name only",
-			el: bldr.EventListener("name", "namespace",
-				bldr.EventListenerSpec(
-					bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
-						bldr.EventListenerTriggerInterceptor("svc", "", "", "")))),
-			raiseErr: false,
-		},
-		{
-			name: "Valid EventListener Interceptor",
-			el: bldr.EventListener("name", "namespace",
-				bldr.EventListenerSpec(
-					bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
-						bldr.EventListenerTriggerInterceptor("svc", "v1", "Service", "namespace")))),
-			raiseErr: false,
-		},
-		{
-			name: "Valid EventListener Interceptor With Header",
-			el: bldr.EventListener("name", "namespace",
-				bldr.EventListenerSpec(
-					bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
-						bldr.EventListenerTriggerInterceptor("svc", "v1", "Service", "namespace",
-							bldr.EventInterceptorParam("Valid-Header-Key", "valid value"))))),
-			raiseErr: false,
-		},
-		{
-			name: "Valid EventListener Interceptor With Headers",
-			el: bldr.EventListener("name", "namespace",
-				bldr.EventListenerSpec(
-					bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
-						bldr.EventListenerTriggerInterceptor("svc", "v1", "Service", "namespace",
-							bldr.EventInterceptorParam("Valid-Header-Key1", "valid value1"),
-							bldr.EventInterceptorParam("Valid-Header-Key1", "valid value2"),
-							bldr.EventInterceptorParam("Valid-Header-Key2", "valid value"))))),
-			raiseErr: false,
-		},
-		{
-			name: "Valid EventListener Two Triggers",
-			el: bldr.EventListener("name", "namespace",
-				bldr.EventListenerSpec(
-					bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
-						bldr.EventListenerTriggerInterceptor("svc", "v1", "Service", "namespace"),
-					),
-					bldr.EventListenerTrigger("tb", "tt", "v1alpha1"))),
-			raiseErr: false,
-		},
+		raiseErr: true,
+	}, {
+		name: "Interceptor Wrong APIVersion",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
+					bldr.EventListenerTriggerInterceptor("foo", "v3", "Service", "")))),
+		raiseErr: true,
+	}, {
+		name: "Interceptor Wrong Kind",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
+					bldr.EventListenerTriggerInterceptor("foo", "v1", "Deployment", "")))),
+		raiseErr: true,
+	}, {
+		name: "Interceptor Non-Canonical Header",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
+					bldr.EventListenerTriggerInterceptor("foo", "v1", "Deployment", "",
+						bldr.EventInterceptorParam("non-canonical-header-key", "valid value"))))),
+		raiseErr: true,
+	}, {
+		name: "Interceptor Empty Header Name",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
+					bldr.EventListenerTriggerInterceptor("foo", "v1", "Deployment", "",
+						bldr.EventInterceptorParam("", "valid value"))))),
+		raiseErr: true,
+	}, {
+		name: "Interceptor Empty Header Value",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
+					bldr.EventListenerTriggerInterceptor("foo", "v1", "Deployment", "",
+						bldr.EventInterceptorParam("Valid-Header-Key", ""))))),
+		raiseErr: true,
+	}, {
+		name: "Valid EventListener No TriggerBinding",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("", "tt", "v1alpha1"))),
+		raiseErr: false,
+	}, {
+		name: "Valid EventListener No Interceptor",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tb", "tt", "v1alpha1"))),
+		raiseErr: false,
+	}, {
+		name: "Valid EventListener Interceptor Name only",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
+					bldr.EventListenerTriggerInterceptor("svc", "", "", "")))),
+		raiseErr: false,
+	}, {
+		name: "Valid EventListener Interceptor",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
+					bldr.EventListenerTriggerInterceptor("svc", "v1", "Service", "namespace")))),
+		raiseErr: false,
+	}, {
+		name: "Valid EventListener Interceptor With Header",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
+					bldr.EventListenerTriggerInterceptor("svc", "v1", "Service", "namespace",
+						bldr.EventInterceptorParam("Valid-Header-Key", "valid value"))))),
+		raiseErr: false,
+	}, {
+		name: "Valid EventListener Interceptor With Headers",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
+					bldr.EventListenerTriggerInterceptor("svc", "v1", "Service", "namespace",
+						bldr.EventInterceptorParam("Valid-Header-Key1", "valid value1"),
+						bldr.EventInterceptorParam("Valid-Header-Key1", "valid value2"),
+						bldr.EventInterceptorParam("Valid-Header-Key2", "valid value"))))),
+		raiseErr: false,
+	}, {
+		name: "Valid EventListener Two Triggers",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
+					bldr.EventListenerTriggerInterceptor("svc", "v1", "Service", "namespace"),
+				),
+				bldr.EventListenerTrigger("tb", "tt", "v1alpha1"))),
+		raiseErr: false,
+	},
 	}
 
 	tb := bldr.TriggerBinding("tb", "namespace",

--- a/pkg/apis/triggers/v1alpha1/trigger_binding_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_binding_validation_test.go
@@ -28,30 +28,26 @@ func Test_TriggerBindingValidate(t *testing.T) {
 	tests := []struct {
 		name string
 		tb   *v1alpha1.TriggerBinding
-	}{
-		{
-			name: "empty",
-			tb:   bldr.TriggerBinding("name", "namespace"),
-		},
-		{
-			name: "multiple params",
-			tb: bldr.TriggerBinding("name", "namespace",
-				bldr.TriggerBindingSpec(
-					bldr.TriggerBindingParam("param1", "$(body.input1)"),
-					bldr.TriggerBindingParam("param2", "$(body.input2)"),
-					bldr.TriggerBindingParam("param3", "$(body.input3)"),
-				)),
-		},
-		{
-			name: "multiple params case sensitive",
-			tb: bldr.TriggerBinding("name", "namespace",
-				bldr.TriggerBindingSpec(
-					bldr.TriggerBindingParam("param1", "$(body.input1)"),
-					bldr.TriggerBindingParam("PARAM1", "$(body.input2)"),
-					bldr.TriggerBindingParam("Param1", "$(body.input3)"),
-				)),
-		},
-	}
+	}{{
+		name: "empty",
+		tb:   bldr.TriggerBinding("name", "namespace"),
+	}, {
+		name: "multiple params",
+		tb: bldr.TriggerBinding("name", "namespace",
+			bldr.TriggerBindingSpec(
+				bldr.TriggerBindingParam("param1", "$(body.input1)"),
+				bldr.TriggerBindingParam("param2", "$(body.input2)"),
+				bldr.TriggerBindingParam("param3", "$(body.input3)"),
+			)),
+	}, {
+		name: "multiple params case sensitive",
+		tb: bldr.TriggerBinding("name", "namespace",
+			bldr.TriggerBindingSpec(
+				bldr.TriggerBindingParam("param1", "$(body.input1)"),
+				bldr.TriggerBindingParam("PARAM1", "$(body.input2)"),
+				bldr.TriggerBindingParam("Param1", "$(body.input3)"),
+			)),
+	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := tt.tb.Validate(context.Background()); err != nil {
@@ -65,17 +61,15 @@ func Test_TriggerBindingValidate_error(t *testing.T) {
 	tests := []struct {
 		name string
 		tb   *v1alpha1.TriggerBinding
-	}{
-		{
-			name: "duplicate params",
-			tb: bldr.TriggerBinding("name", "namespace",
-				bldr.TriggerBindingSpec(
-					bldr.TriggerBindingParam("param1", "$(body.param1)"),
-					bldr.TriggerBindingParam("param1", "$(body.param1)"),
-					bldr.TriggerBindingParam("param3", "$(body.param1)"),
-				)),
-		},
-	}
+	}{{
+		name: "duplicate params",
+		tb: bldr.TriggerBinding("name", "namespace",
+			bldr.TriggerBindingSpec(
+				bldr.TriggerBindingParam("param1", "$(body.param1)"),
+				bldr.TriggerBindingParam("param1", "$(body.param1)"),
+				bldr.TriggerBindingParam("param3", "$(body.param1)"),
+			)),
+	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := tt.tb.Validate(context.Background()); err == nil {

--- a/pkg/sink/initialization_test.go
+++ b/pkg/sink/initialization_test.go
@@ -52,26 +52,22 @@ func Test_GetArgs_error(t *testing.T) {
 		elName      string
 		elNamespace string
 		port        string
-	}{
-		{
-			name:        "no eventlistener name",
-			elName:      "",
-			elNamespace: "elnamespace",
-			port:        "port",
-		},
-		{
-			name:        "no eventlistener namespace",
-			elName:      "elname",
-			elNamespace: "",
-			port:        "port",
-		},
-		{
-			name:        "no eventlistener namespace",
-			elName:      "elname",
-			elNamespace: "elnamespace",
-			port:        "",
-		},
-	}
+	}{{
+		name:        "no eventlistener name",
+		elName:      "",
+		elNamespace: "elnamespace",
+		port:        "port",
+	}, {
+		name:        "no eventlistener namespace",
+		elName:      "elname",
+		elNamespace: "",
+		port:        "port",
+	}, {
+		name:        "no eventlistener namespace",
+		elName:      "elname",
+		elNamespace: "elnamespace",
+		port:        "",
+	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := flag.Set(name, tt.elName); err != nil {

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -47,36 +47,32 @@ import (
 const resourceLabel = triggersv1.GroupName + triggersv1.EventListenerLabelKey
 const eventIDLabel = triggersv1.GroupName + triggersv1.EventIDLabelKey
 
-func Test_createRequestURI(t *testing.T) {
+func TestCreateRequestURI(t *testing.T) {
 	tests := []struct {
 		apiVersion string
 		namePlural string
 		namespace  string
 		namespaced bool
 		want       string
-	}{
-		{
-			apiVersion: "tekton.dev/v1alpha1",
-			namePlural: "pipelineruns",
-			namespace:  "foo",
-			namespaced: true,
-			want:       "apis/tekton.dev/v1alpha1/namespaces/foo/pipelineruns",
-		},
-		{
-			apiVersion: "v1",
-			namePlural: "secrets",
-			namespace:  "foo",
-			namespaced: true,
-			want:       "api/v1/namespaces/foo/secrets",
-		},
-		{
-			apiVersion: "v1",
-			namePlural: "namespaces",
-			namespace:  "",
-			namespaced: false,
-			want:       "api/v1/namespaces",
-		},
-	}
+	}{{
+		apiVersion: "tekton.dev/v1alpha1",
+		namePlural: "pipelineruns",
+		namespace:  "foo",
+		namespaced: true,
+		want:       "apis/tekton.dev/v1alpha1/namespaces/foo/pipelineruns",
+	}, {
+		apiVersion: "v1",
+		namePlural: "secrets",
+		namespace:  "foo",
+		namespaced: true,
+		want:       "api/v1/namespaces/foo/secrets",
+	}, {
+		apiVersion: "v1",
+		namePlural: "namespaces",
+		namespace:  "",
+		namespaced: false,
+		want:       "api/v1/namespaces",
+	}}
 	for _, tt := range tests {
 		t.Run(tt.want, func(t *testing.T) {
 			got := createRequestURI(tt.apiVersion, tt.namePlural, tt.namespace, tt.namespaced)
@@ -87,82 +83,70 @@ func Test_createRequestURI(t *testing.T) {
 	}
 }
 
-func Test_findAPIResource(t *testing.T) {
+func TestFindAPIResource(t *testing.T) {
 	// Create fake kubeclient with list of resources
 	kubeClient := fakekubeclientset.NewSimpleClientset()
-	kubeClient.Resources = []*metav1.APIResourceList{
-		{
-			GroupVersion: "v1",
-			APIResources: []metav1.APIResource{
-				{
-					Name:       "pods",
-					Namespaced: true,
-					Kind:       "Pod",
-				},
-				{
-					Name:       "namespaces",
-					Namespaced: false,
-					Kind:       "Namespace",
-				},
-			},
-		},
-		{
-			GroupVersion: "tekton.dev/v1alpha1",
-			APIResources: []metav1.APIResource{
-				{
-					Name:       "triggertemplates",
-					Namespaced: true,
-					Kind:       "TriggerTemplate",
-				},
-				{
-					Name:       "pipelineruns",
-					Namespaced: true,
-					Kind:       "PipelineRun",
-				},
-			},
-		},
+	kubeClient.Resources = []*metav1.APIResourceList{{
+		GroupVersion: "v1",
+		APIResources: []metav1.APIResource{{
+			Name:       "pods",
+			Namespaced: true,
+			Kind:       "Pod",
+		}, {
+			Name:       "namespaces",
+			Namespaced: false,
+			Kind:       "Namespace",
+		}},
+	}, {
+		GroupVersion: "tekton.dev/v1alpha1",
+		APIResources: []metav1.APIResource{{
+			Name:       "triggertemplates",
+			Namespaced: true,
+			Kind:       "TriggerTemplate",
+		}, {
+			Name:       "pipelineruns",
+			Namespaced: true,
+			Kind:       "PipelineRun",
+		}},
+	},
 	}
 	tests := []struct {
 		apiVersion string
 		kind       string
 		want       *metav1.APIResource
-	}{
-		{
-			apiVersion: "v1",
-			kind:       "Pod",
-			want: &metav1.APIResource{
-				Name:       "pods",
-				Namespaced: true,
-				Kind:       "Pod",
-			},
+	}{{
+		apiVersion: "v1",
+		kind:       "Pod",
+		want: &metav1.APIResource{
+			Name:       "pods",
+			Namespaced: true,
+			Kind:       "Pod",
 		},
-		{
-			apiVersion: "v1",
-			kind:       "Namespace",
-			want: &metav1.APIResource{
-				Name:       "namespaces",
-				Namespaced: false,
-				Kind:       "Namespace",
-			},
+	}, {
+		apiVersion: "v1",
+		kind:       "Namespace",
+		want: &metav1.APIResource{
+			Name:       "namespaces",
+			Namespaced: false,
+			Kind:       "Namespace",
 		},
-		{
-			apiVersion: "tekton.dev/v1alpha1",
-			kind:       "TriggerTemplate",
-			want: &metav1.APIResource{
-				Name:       "triggertemplates",
-				Namespaced: true,
-				Kind:       "TriggerTemplate",
-			},
+	}, {
+		apiVersion: "tekton.dev/v1alpha1",
+		kind:       "TriggerTemplate",
+		want: &metav1.APIResource{
+			Name:       "triggertemplates",
+			Namespaced: true,
+			Kind:       "TriggerTemplate",
 		},
-		{
-			apiVersion: "tekton.dev/v1alpha1",
-			kind:       "PipelineRun",
-			want: &metav1.APIResource{
-				Name:       "pipelineruns",
-				Namespaced: true,
-				Kind:       "PipelineRun",
-			},
+	}, {
+		apiVersion: "tekton.dev/v1alpha1",
+		kind:       "PipelineRun",
+		want: &metav1.APIResource{
+			Name:       "pipelineruns",
+			Namespaced: true,
+			Kind:       "PipelineRun",
 		},
+	},
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%s_%s", tt.apiVersion, tt.kind), func(t *testing.T) {
@@ -176,7 +160,7 @@ func Test_findAPIResource(t *testing.T) {
 	}
 }
 
-func Test_findAPIResource_error(t *testing.T) {
+func TestFindAPIResource_error(t *testing.T) {
 	kubeClient := fakekubeclientset.NewSimpleClientset()
 	_, err := findAPIResource(kubeClient.Discovery(), "v1", "Pod")
 	if err == nil {
@@ -184,7 +168,7 @@ func Test_findAPIResource_error(t *testing.T) {
 	}
 }
 
-func Test_createResource(t *testing.T) {
+func TestCreateResource(t *testing.T) {
 	pr1 := pipelinev1.PipelineResource{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "tekton.dev/v1alpha1",
@@ -242,28 +226,23 @@ func Test_createResource(t *testing.T) {
 		t.Fatalf("Error marshalling Namespace: %s", err)
 	}
 	kubeClient := fakekubeclientset.NewSimpleClientset()
-	kubeClient.Resources = []*metav1.APIResourceList{
-		{
-			GroupVersion: "tekton.dev/v1alpha1",
-			APIResources: []metav1.APIResource{
-				{
-					Name:       "pipelineresources",
-					Kind:       "PipelineResource",
-					Namespaced: true,
-				},
+	kubeClient.Resources = []*metav1.APIResourceList{{
+		GroupVersion: "tekton.dev/v1alpha1",
+		APIResources: []metav1.APIResource{{
+			Name:       "pipelineresources",
+			Kind:       "PipelineResource",
+			Namespaced: true,
+		}},
+	}, {
+		GroupVersion: "v1",
+		APIResources: []metav1.APIResource{
+			{
+				Name:       "namespaces",
+				Kind:       "Namespace",
+				Namespaced: false,
 			},
 		},
-		{
-			GroupVersion: "v1",
-			APIResources: []metav1.APIResource{
-				{
-					Name:       "namespaces",
-					Kind:       "Namespace",
-					Namespaced: false,
-				},
-			},
-		},
-	}
+	}}
 	restClient, err := restclient.RESTClientFor(&restclient.Config{
 		APIPath: "/fooapipath",
 		ContentConfig: restclient.ContentConfig{
@@ -282,34 +261,31 @@ func Test_createResource(t *testing.T) {
 		eventListenerName      string
 		eventID                string
 		wantURLPath            string
-	}{
-		{
-			name:                   "PipelineResource without namespace",
-			resource:               json.RawMessage(pr1Bytes),
-			wantResource:           json.RawMessage(pr1WantBytes),
-			eventListenerNamespace: "bar",
-			eventListenerName:      "foo-el",
-			eventID:                "12345",
-			wantURLPath:            "/apis/tekton.dev/v1alpha1/namespaces/bar/pipelineresources",
-		},
-		{
-			name:                   "PipelineResource with namespace",
-			resource:               json.RawMessage(pr2Bytes),
-			wantResource:           json.RawMessage(pr2Bytes),
-			eventListenerNamespace: "bar",
-			eventListenerName:      "bar-el",
-			eventID:                "54321",
-			wantURLPath:            "/apis/tekton.dev/v1alpha1/namespaces/foo/pipelineresources",
-		},
-		{
-			name:                   "Namespace",
-			resource:               json.RawMessage(namespaceBytes),
-			wantResource:           json.RawMessage(namespaceBytes),
-			eventListenerNamespace: "",
-			eventListenerName:      "test-el",
-			eventID:                "12321",
-			wantURLPath:            "/api/v1/namespaces",
-		},
+	}{{
+		name:                   "PipelineResource without namespace",
+		resource:               json.RawMessage(pr1Bytes),
+		wantResource:           json.RawMessage(pr1WantBytes),
+		eventListenerNamespace: "bar",
+		eventListenerName:      "foo-el",
+		eventID:                "12345",
+		wantURLPath:            "/apis/tekton.dev/v1alpha1/namespaces/bar/pipelineresources",
+	}, {
+		name:                   "PipelineResource with namespace",
+		resource:               json.RawMessage(pr2Bytes),
+		wantResource:           json.RawMessage(pr2Bytes),
+		eventListenerNamespace: "bar",
+		eventListenerName:      "bar-el",
+		eventID:                "54321",
+		wantURLPath:            "/apis/tekton.dev/v1alpha1/namespaces/foo/pipelineresources",
+	}, {
+		name:                   "Namespace",
+		resource:               json.RawMessage(namespaceBytes),
+		wantResource:           json.RawMessage(namespaceBytes),
+		eventListenerNamespace: "",
+		eventListenerName:      "test-el",
+		eventID:                "12321",
+		wantURLPath:            "/api/v1/namespaces",
+	},
 	}
 	logger, _ := logging.NewLogger("", "")
 	for _, tt := range tests {
@@ -351,7 +327,7 @@ func Test_createResource(t *testing.T) {
 	}
 }
 
-func Test_HandleEvent(t *testing.T) {
+func TestHandleEvent(t *testing.T) {
 	namespace := "foo"
 	eventBody := json.RawMessage(`{"head_commit": {"id": "testrevision"}, "repository": {"url": "testurl"}}`)
 	pipelineResource := pipelinev1.PipelineResource{
@@ -419,17 +395,14 @@ func Test_HandleEvent(t *testing.T) {
 		))
 
 	kubeClient := fakekubeclientset.NewSimpleClientset()
-	kubeClient.Resources = []*metav1.APIResourceList{
-		{
-			GroupVersion: "tekton.dev/v1alpha1",
-			APIResources: []metav1.APIResource{
-				{
-					Name:       "pipelineresources",
-					Kind:       "PipelineResource",
-					Namespaced: true,
-				},
-			},
-		},
+	kubeClient.Resources = []*metav1.APIResourceList{{
+		GroupVersion: "tekton.dev/v1alpha1",
+		APIResources: []metav1.APIResource{{
+			Name:       "pipelineresources",
+			Kind:       "PipelineResource",
+			Namespaced: true,
+		}},
+	},
 	}
 	triggersClient := faketriggersclientset.NewSimpleClientset()
 	if _, err := triggersClient.TektonV1alpha1().TriggerTemplates(namespace).Create(tt); err != nil {
@@ -452,7 +425,7 @@ func Test_HandleEvent(t *testing.T) {
 		t.Fatalf("Error creating RESTClient: %s", err)
 	}
 	logger, _ := logging.NewLogger("", "")
-	r := Resource{
+	r := Sink{
 		EventListenerName:      el.Name,
 		EventListenerNamespace: namespace,
 		RESTClient:             restClient,
@@ -519,8 +492,8 @@ func Test_HandleEvent(t *testing.T) {
 	}
 }
 
-func TestResource_processEvent(t *testing.T) {
-	r := Resource{HTTPClient: http.DefaultClient}
+func TestResourceProcessEvent(t *testing.T) {
+	r := Sink{HTTPClient: http.DefaultClient}
 
 	payload, _ := json.Marshal(map[string]string{
 		"eventType": "push",
@@ -565,103 +538,8 @@ func TestResource_processEvent(t *testing.T) {
 	}
 }
 
-func Test_addInterceptorHeaders(t *testing.T) {
-	type args struct {
-		header       http.Header
-		headerParams []pipelinev1.Param
-	}
-	tests := []struct {
-		name string
-		args args
-		want http.Header
-	}{
-		{
-			name: "Empty params",
-			args: args{
-				header: map[string][]string{
-					"header1": {"val"},
-				},
-				headerParams: []pipelinev1.Param{},
-			},
-			want: map[string][]string{
-				"header1": {"val"},
-			},
-		},
-		{
-			name: "One string param",
-			args: args{
-				header: map[string][]string{
-					"header1": {"val"},
-				},
-				headerParams: []pipelinev1.Param{
-					{
-						Name: "header2",
-						Value: pipelinev1.ArrayOrString{
-							Type:      pipelinev1.ParamTypeString,
-							StringVal: "val",
-						},
-					},
-				},
-			},
-			want: map[string][]string{
-				"header1": {"val"},
-				"header2": {"val"},
-			},
-		},
-		{
-			name: "One array param",
-			args: args{
-				header: map[string][]string{
-					"header1": {"val"},
-				},
-				headerParams: []pipelinev1.Param{
-					{
-						Name: "header2",
-						Value: pipelinev1.ArrayOrString{
-							Type:     pipelinev1.ParamTypeArray,
-							ArrayVal: []string{"val1", "val2"},
-						},
-					},
-				},
-			},
-			want: map[string][]string{
-				"header1": {"val"},
-				"header2": {"val1", "val2"},
-			},
-		},
-		{
-			name: "Clobber param",
-			args: args{
-				header: map[string][]string{
-					"header1": {"val"},
-				},
-				headerParams: []pipelinev1.Param{
-					{
-						Name: "header1",
-						Value: pipelinev1.ArrayOrString{
-							Type:     pipelinev1.ParamTypeArray,
-							ArrayVal: []string{"new_val"},
-						},
-					},
-				},
-			},
-			want: map[string][]string{
-				"header1": {"new_val"},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			addInterceptorHeaders(tt.args.header, tt.args.headerParams)
-			if diff := cmp.Diff(tt.want, tt.args.header); diff != "" {
-				t.Errorf("addInterceptorHeaders() Diff: -want +got: %s", diff)
-			}
-		})
-	}
-}
-
 func TestResourceProcessEvent_TimeOut(t *testing.T) {
-	r := Resource{HTTPClient: http.DefaultClient}
+	r := Sink{HTTPClient: http.DefaultClient}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(50 * time.Millisecond)
 	}))


### PR DESCRIPTION
# Changes
This is a cleanup PR!

Resource is too generic and Sink seems like a more apt name.
Also, fixes the indenting in a bunch of tests to be more consistent
with they style from pipelines.

