### PR TITLE
Remove Params from EventListener

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -40,12 +40,6 @@ When the `EventListener` is created in the different namespace from the trigger 
 is created for the logging configuration in the namespace when it doesn't exist.  The ConfigMap with the default configuration can be created
 by applying [config-logging.yaml](../config/config-logging.yaml)
 
-## Parameters
-
-`EventListener`s can provide `params` which are merged with the `TriggerBinding`
-`params` and passed to the `TriggerTemplate`. Each parameter has a `name` and a
-`value`.
-
 `EventListener` `spec.serviceType` can be set to `ClusterIP (default)` | `NodePort` | `LoadBalancer`
 to configure the underlying `Service` resource to make it reachable externally.
 
@@ -100,7 +94,5 @@ spec:
       - name: pipeline-binding
       template:
         name: pipeline-template
-      params:
-      - name: message
-        value: Hello from the Triggers EventListener!
 ```
+

--- a/examples/cron/eventlistener.yaml
+++ b/examples/cron/eventlistener.yaml
@@ -10,6 +10,3 @@ spec:
       - name: cron-binding
       template:
         name: pipeline-template
-      params:
-      - name: message
-        value: Hello from the Triggers EventListener!

--- a/examples/eventlisteners/eventlistener-interceptor.yaml
+++ b/examples/eventlisteners/eventlistener-interceptor.yaml
@@ -23,6 +23,3 @@ spec:
       - name: pipeline-binding
       template:
         name: pipeline-template
-      params:
-      - name: message
-        value: Hello from the Triggers EventListener!

--- a/examples/eventlisteners/eventlistener.yaml
+++ b/examples/eventlisteners/eventlistener.yaml
@@ -10,6 +10,3 @@ spec:
       - name: pipeline-binding
       template:
         name: pipeline-template
-      params:
-      - name: message
-        value: Hello from the Triggers EventListener!

--- a/pkg/apis/triggers/v1alpha1/event_listener_types.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_types.go
@@ -63,7 +63,6 @@ type EventListenerSpec struct {
 type EventListenerTrigger struct {
 	Bindings []*EventListenerBinding `json:"bindings"`
 	Template EventListenerTemplate   `json:"template"`
-	Params   []pipelinev1.Param      `json:"params,omitempty"`
 	// +optional
 	Name string `json:"name,omitempty"`
 	// +optional

--- a/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
@@ -222,13 +222,6 @@ func (in *EventListenerTrigger) DeepCopyInto(out *EventListenerTrigger) {
 		}
 	}
 	out.Template = in.Template
-	if in.Params != nil {
-		in, out := &in.Params, &out.Params
-		*out = make([]pipelinev1alpha1.Param, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
-	}
 	if in.Interceptor != nil {
 		in, out := &in.Interceptor, &out.Interceptor
 		*out = new(EventInterceptor)

--- a/pkg/sink/sink.go
+++ b/pkg/sink/sink.go
@@ -125,7 +125,7 @@ func (r Resource) executeTrigger(payload []byte, request *http.Request, trigger 
 		result <- http.StatusAccepted
 		return
 	}
-	resources, err := template.NewResources(payload, request.Header, trigger.Params, binding)
+	resources, err := template.NewResources(payload, request.Header, binding)
 	if err != nil {
 		r.Logger.Error(err)
 		result <- http.StatusAccepted

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -402,7 +402,7 @@ func Test_HandleEvent(t *testing.T) {
 		bldr.TriggerTemplateSpec(
 			bldr.TriggerTemplateParam("url", "", ""),
 			bldr.TriggerTemplateParam("revision", "", ""),
-			bldr.TriggerTemplateParam("appLabel", "", ""),
+			bldr.TriggerTemplateParam("appLabel", "", "foo"),
 			bldr.TriggerTemplateParam("contenttype", "", ""),
 			bldr.TriggerResourceTemplate(json.RawMessage(pipelineResourceBytes)),
 		))
@@ -413,10 +413,7 @@ func Test_HandleEvent(t *testing.T) {
 			bldr.TriggerBindingParam("contenttype", "$(header.Content-Type)"),
 		))
 	el := bldr.EventListener("my-eventlistener", namespace,
-		bldr.EventListenerSpec(
-			bldr.EventListenerTrigger("my-triggerbinding", "my-triggertemplate", "v1alpha1",
-				bldr.EventListenerTriggerParam("appLabel", "foo")),
-		))
+		bldr.EventListenerSpec(bldr.EventListenerTrigger("my-triggerbinding", "my-triggertemplate", "v1alpha1")))
 
 	kubeClient := fakekubeclientset.NewSimpleClientset()
 	kubeClient.Resources = []*metav1.APIResourceList{

--- a/pkg/template/event.go
+++ b/pkg/template/event.go
@@ -163,7 +163,7 @@ func getHeaderValue(header map[string][]string, headerName string) (string, erro
 
 // NewResources returns all resources defined when applying the event and
 // elParams to the TriggerTemplate and TriggerBinding in the ResolvedBinding.
-func NewResources(body []byte, header map[string][]string, elParams []pipelinev1.Param, binding ResolvedBinding) ([]json.RawMessage, error) {
+func NewResources(body []byte, header map[string][]string, binding ResolvedBinding) ([]json.RawMessage, error) {
 
 	params, err := mergeBindingParams(binding.TriggerBindings)
 	if err != nil {
@@ -178,10 +178,7 @@ func NewResources(body []byte, header map[string][]string, elParams []pipelinev1
 	if err != nil {
 		return []json.RawMessage{}, xerrors.Errorf("Error applying header to TriggerBinding params: %s", err)
 	}
-	params, err = MergeParams(params, elParams)
-	if err != nil {
-		return []json.RawMessage{}, xerrors.Errorf("Error merging params from EventListener with TriggerBinding params: %s", err)
-	}
+
 	params = MergeInDefaultParams(params, binding.TriggerTemplate.Spec.Params)
 
 	resources := make([]json.RawMessage, len(binding.TriggerTemplate.Spec.ResourceTemplates))

--- a/pkg/template/event_test.go
+++ b/pkg/template/event_test.go
@@ -701,10 +701,9 @@ func Test_applyHeaderToParams_error(t *testing.T) {
 
 func Test_NewResources(t *testing.T) {
 	type args struct {
-		body     []byte
-		header   map[string][]string
-		elParams []pipelinev1.Param
-		binding  ResolvedBinding
+		body    []byte
+		header  map[string][]string
+		binding ResolvedBinding
 	}
 	tests := []struct {
 		name string
@@ -860,82 +859,6 @@ func Test_NewResources(t *testing.T) {
 			},
 		},
 		{
-			name: "one BodyListener param",
-			args: args{
-				body: json.RawMessage(`{"foo": "bar"}`),
-				elParams: []pipelinev1.Param{
-					{
-						Name:  "param1",
-						Value: pipelinev1.ArrayOrString{StringVal: "value1", Type: pipelinev1.ParamTypeString},
-					},
-				},
-				binding: ResolvedBinding{
-					TriggerBindings: []*triggersv1.TriggerBinding{
-						bldr.TriggerBinding("tb", "namespace",
-							bldr.TriggerBindingSpec(
-								bldr.TriggerBindingParam("param2", "$(body.foo)"),
-							),
-						),
-					},
-					TriggerTemplate: bldr.TriggerTemplate("tt", "namespace",
-						bldr.TriggerTemplateSpec(
-							bldr.TriggerTemplateParam("param1", "description1", ""),
-							bldr.TriggerTemplateParam("param2", "description2", ""),
-							bldr.TriggerResourceTemplate(
-								json.RawMessage(`{"rt1": {"p1": "$(params.param1)", "p2": "$(params.param2)"}}`),
-							),
-						),
-					),
-				},
-			},
-			want: []json.RawMessage{
-				json.RawMessage(`{"rt1": {"p1": "value1", "p2": "bar"}}`),
-			},
-		},
-		{
-			name: "multiple BodyListener params",
-			args: args{
-				body: json.RawMessage(`{"foo": "bar"}`),
-				elParams: []pipelinev1.Param{
-					{
-						Name:  "param1",
-						Value: pipelinev1.ArrayOrString{StringVal: "value1", Type: pipelinev1.ParamTypeString},
-					},
-					{
-						Name:  "param3",
-						Value: pipelinev1.ArrayOrString{StringVal: "value3", Type: pipelinev1.ParamTypeString},
-					},
-				},
-				binding: ResolvedBinding{
-					TriggerBindings: []*triggersv1.TriggerBinding{
-						bldr.TriggerBinding("tb", "namespace",
-							bldr.TriggerBindingSpec(
-								bldr.TriggerBindingParam("param2", "$(body.foo)"),
-							),
-						),
-					},
-					TriggerTemplate: bldr.TriggerTemplate("tt", "namespace",
-						bldr.TriggerTemplateSpec(
-							bldr.TriggerTemplateParam("param1", "description1", ""),
-							bldr.TriggerTemplateParam("param2", "description2", ""),
-							bldr.TriggerTemplateParam("param3", "description3", ""),
-							bldr.TriggerTemplateParam("param4", "description4", "default4"),
-							bldr.TriggerResourceTemplate(
-								json.RawMessage(`{"rt1": {"p1": "$(params.param1)", "p3": "$(params.param3)"}}`),
-							),
-							bldr.TriggerResourceTemplate(json.RawMessage(`{"rt2": "$(params.param2)-$(uid)"}`)),
-							bldr.TriggerResourceTemplate(json.RawMessage(`{"rt3": "$(params.param4)"}`)),
-						),
-					),
-				},
-			},
-			want: []json.RawMessage{
-				json.RawMessage(`{"rt1": {"p1": "value1", "p3": "value3"}}`),
-				json.RawMessage(`{"rt2": "bar-cbhtc"}`),
-				json.RawMessage(`{"rt3": "default4"}`),
-			},
-		},
-		{
 			name: "one resource template multiple bindings",
 			args: args{
 				body:   json.RawMessage(`{"foo": "bar"}`),
@@ -971,7 +894,7 @@ func Test_NewResources(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// This seeds Uid() to return 'cbhtc'
 			rand.Seed(0)
-			got, err := NewResources(tt.args.body, tt.args.header, tt.args.elParams, tt.args.binding)
+			got, err := NewResources(tt.args.body, tt.args.header, tt.args.binding)
 			if err != nil {
 				t.Errorf("NewResources() returned unexpected error: %s", err)
 			} else if diff := cmp.Diff(tt.want, got); diff != "" {
@@ -1083,7 +1006,7 @@ func Test_NewResources_error(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewResources(tt.body, tt.header, tt.elParams, tt.binding)
+			got, err := NewResources(tt.body, tt.header, tt.binding)
 			if err == nil {
 				t.Errorf("NewResources() did not return error when expected; got: %s", got)
 			}

--- a/test/builder/eventlistener.go
+++ b/test/builder/eventlistener.go
@@ -81,20 +81,6 @@ func EventListenerTrigger(tbName, ttName, apiVersion string, ops ...EventListene
 	}
 }
 
-// EventListenerTriggerParam adds a param to the EventListenerTrigger
-func EventListenerTriggerParam(name, value string) EventListenerTriggerOp {
-	return func(trigger *v1alpha1.EventListenerTrigger) {
-		trigger.Params = append(trigger.Params,
-			pipelinev1.Param{
-				Name: name,
-				Value: pipelinev1.ArrayOrString{
-					StringVal: value,
-					Type:      pipelinev1.ParamTypeString,
-				},
-			})
-	}
-}
-
 // EventListenerStatus sets the specified status of the EventListener.
 // Any number of EventListenerStatusOp modifiers can be passed to create/modify it.
 func EventListenerStatus(ops ...EventListenerStatusOp) EventListenerOp {

--- a/test/builder/eventlistener_test.go
+++ b/test/builder/eventlistener_test.go
@@ -159,91 +159,6 @@ func TestEventListenerBuilder(t *testing.T) {
 			),
 		),
 	}, {
-		name: "One Trigger with One Param",
-		normal: &v1alpha1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
-			Spec: v1alpha1.EventListenerSpec{
-				ServiceAccountName: "serviceAccount",
-				Triggers: []v1alpha1.EventListenerTrigger{{
-					Bindings: []*v1alpha1.EventListenerBinding{{
-						Name:       "tb1",
-						APIVersion: "v1alpha1",
-					}},
-					Template: v1alpha1.EventListenerTemplate{
-						Name:       "tt1",
-						APIVersion: "v1alpha1",
-					},
-					Params: []pipelinev1.Param{
-						{
-							Name: "param1",
-							Value: pipelinev1.ArrayOrString{
-								StringVal: "value1",
-								Type:      pipelinev1.ParamTypeString,
-							},
-						},
-					},
-				}},
-			},
-		},
-		builder: EventListener("name", "namespace",
-			EventListenerSpec(
-				EventListenerServiceAccount("serviceAccount"),
-				EventListenerTrigger("tb1", "tt1", "v1alpha1",
-					EventListenerTriggerParam("param1", "value1"),
-				),
-			),
-		),
-	}, {
-		name: "One Trigger with Two Params",
-		normal: &v1alpha1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
-			Spec: v1alpha1.EventListenerSpec{
-				ServiceAccountName: "serviceAccount",
-				Triggers: []v1alpha1.EventListenerTrigger{{
-					Bindings: []*v1alpha1.EventListenerBinding{{
-						Name:       "tb1",
-						APIVersion: "v1alpha1",
-					}},
-					Template: v1alpha1.EventListenerTemplate{
-						Name:       "tt1",
-						APIVersion: "v1alpha1",
-					},
-					Params: []pipelinev1.Param{
-						{
-							Name: "param1",
-							Value: pipelinev1.ArrayOrString{
-								StringVal: "value1",
-								Type:      pipelinev1.ParamTypeString,
-							},
-						},
-						{
-							Name: "param2",
-							Value: pipelinev1.ArrayOrString{
-								StringVal: "value2",
-								Type:      pipelinev1.ParamTypeString,
-							},
-						},
-					},
-				},
-				},
-			},
-		},
-		builder: EventListener("name", "namespace",
-			EventListenerSpec(
-				EventListenerServiceAccount("serviceAccount"),
-				EventListenerTrigger("tb1", "tt1", "v1alpha1",
-					EventListenerTriggerParam("param1", "value1"),
-					EventListenerTriggerParam("param2", "value2"),
-				),
-			),
-		),
-	}, {
 		name: "Two Trigger with extra Meta",
 		normal: &v1alpha1.EventListener{
 			ObjectMeta: metav1.ObjectMeta{
@@ -319,15 +234,7 @@ func TestEventListenerBuilder(t *testing.T) {
 						Name:       "tt1",
 						APIVersion: "v1alpha1",
 					},
-					Params: []pipelinev1.Param{{
-						Name: "param1",
-						Value: pipelinev1.ArrayOrString{
-							StringVal: "value1",
-							Type:      pipelinev1.ParamTypeString,
-						}},
-					},
-				},
-				},
+				}},
 			},
 		},
 		builder: EventListener("name", "namespace",
@@ -335,7 +242,6 @@ func TestEventListenerBuilder(t *testing.T) {
 				EventListenerServiceAccount("serviceAccount"),
 				EventListenerTrigger("tb1", "tt1", "v1alpha1",
 					EventListenerTriggerName("foo-trig"),
-					EventListenerTriggerParam("param1", "value1"),
 					EventListenerTriggerInterceptor("foo", "v1", "Service", "namespace"),
 				),
 			),
@@ -376,22 +282,13 @@ func TestEventListenerBuilder(t *testing.T) {
 						Name:       "tt1",
 						APIVersion: "v1alpha1",
 					},
-					Params: []pipelinev1.Param{{
-						Name: "param1",
-						Value: pipelinev1.ArrayOrString{
-							StringVal: "value1",
-							Type:      pipelinev1.ParamTypeString,
-						}},
-					},
-				},
-				},
+				}},
 			}},
 		builder: EventListener("name", "namespace",
 			EventListenerSpec(
 				EventListenerServiceAccount("serviceAccount"),
 				EventListenerTrigger("tb1", "tt1", "v1alpha1",
 					EventListenerTriggerName("foo-trig"),
-					EventListenerTriggerParam("param1", "value1"),
 					EventListenerTriggerInterceptor("foo", "v1", "Service", "namespace",
 						EventInterceptorParam("header1", "value1"),
 					),

--- a/test/e2e-tests-ingress.sh
+++ b/test/e2e-tests-ingress.sh
@@ -116,9 +116,6 @@ spec:
     - name: pipeline-binding
     template:
       name: pipeline-template
-    params:
-    - name: param1
-      value: value1
 DONE
 
 INGRESS_TASKRUN_NAME="create-ingress-taskrun"

--- a/test/eventlistener_test.go
+++ b/test/eventlistener_test.go
@@ -86,7 +86,6 @@ func TestEventListenerCreate(t *testing.T) {
 			Name: "pr2",
 			Labels: map[string]string{
 				"$(params.twoparamname)": "$(params.twoparamvalue)",
-				"threeparam":             "$(params.threeparam)",
 			},
 		},
 		Spec: v1alpha1.PipelineResourceSpec{
@@ -110,7 +109,6 @@ func TestEventListenerCreate(t *testing.T) {
 				bldr.TriggerTemplateParam("oneparam", "", ""),
 				bldr.TriggerTemplateParam("twoparamname", "", ""),
 				bldr.TriggerTemplateParam("twoparamvalue", "", "defaultvalue"),
-				bldr.TriggerTemplateParam("threeparam", "", ""),
 				bldr.TriggerTemplateParam("body", "", ""),
 				bldr.TriggerTemplateParam("header", "", ""),
 				bldr.TriggerResourceTemplate(pr1Bytes),
@@ -168,7 +166,6 @@ func TestEventListenerCreate(t *testing.T) {
 			Labels: map[string]string{
 				resourceLabel: "my-eventlistener",
 				"zfoo":        "defaultvalue",
-				"threeparam":  "threevalue",
 			},
 		},
 		Spec: v1alpha1.PipelineResourceSpec{
@@ -237,11 +234,9 @@ func TestEventListenerCreate(t *testing.T) {
 			),
 			bldr.EventListenerSpec(
 				bldr.EventListenerServiceAccount(sa.Name),
-				bldr.EventListenerTrigger(tb.Name, tt.Name, "",
-					bldr.EventListenerTriggerParam("threeparam", "threevalue")),
+				bldr.EventListenerTrigger(tb.Name, tt.Name, ""),
 			),
-		),
-	)
+		))
 	if err != nil {
 		t.Fatalf("Failed to create EventListener: %s", err)
 	}


### PR DESCRIPTION
# Changes

Now that we support multiple `TriggerBindings`, we
do not have a need for a separate `Params` field within
`EventListener`

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
BREAKING CHANGE 
Removes the Params field from EventListeners. Use static values from TriggerBinding instead.

```
