### PR TITLE
Add configmap permissions to getting started RBAC

### DIFF
--- a/docs/getting-started/rbac/admin-role.yaml
+++ b/docs/getting-started/rbac/admin-role.yaml
@@ -21,6 +21,14 @@ rules:
   - pipelineresources
   verbs:
   - create
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
# Changes

It looks like these are required after https://github.com/tektoncd/triggers/pull/204 It looks like that PR _did_ update some example config, so I wonder if:
1) there is some duplication in the examples that can be removed
2) if the getting started stuff could be tested

(bonus if you get this wrong before you start the event listener, it puts the event listener in a bad and confusing state even after you fix it!  yaaaay)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [:(] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [:(] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [?] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

