### PR TITLE
Refactor template resolution into separate binding and template funcs.

### DIFF
--- a/pkg/template/resource.go
+++ b/pkg/template/resource.go
@@ -32,9 +32,9 @@ import (
 // uidMatch determines the uid variable within the resource template
 var uidMatch = []byte(`$(uid)`)
 
-// ResolvedBinding contains the dereferenced TriggerBindings and
+// ResolvedTrigger contains the dereferenced TriggerBindings and
 // TriggerTemplate after resolving the k8s ObjectRef.
-type ResolvedBinding struct {
+type ResolvedTrigger struct {
 	TriggerBindings []*triggersv1.TriggerBinding
 	TriggerTemplate *triggersv1.TriggerTemplate
 }
@@ -44,12 +44,12 @@ type getTriggerTemplate func(name string, options metav1.GetOptions) (*triggersv
 
 // ResolveBindings takes in a trigger containing object refs to bindings and
 // templates and resolves them to their underlying values.
-func ResolveBinding(trigger triggersv1.EventListenerTrigger, getTB getTriggerBinding, getTT getTriggerTemplate) (ResolvedBinding, error) {
+func ResolveTrigger(trigger triggersv1.EventListenerTrigger, getTB getTriggerBinding, getTT getTriggerTemplate) (ResolvedTrigger, error) {
 	tb := make([]*triggersv1.TriggerBinding, 0, len(trigger.Bindings))
 	for _, b := range trigger.Bindings {
 		tb2, err := getTB(b.Name, metav1.GetOptions{})
 		if err != nil {
-			return ResolvedBinding{}, xerrors.Errorf("error getting TriggerBinding %s: %s", b.Name, err)
+			return ResolvedTrigger{}, xerrors.Errorf("error getting TriggerBinding %s: %s", b.Name, err)
 		}
 		tb = append(tb, tb2)
 	}
@@ -57,9 +57,9 @@ func ResolveBinding(trigger triggersv1.EventListenerTrigger, getTB getTriggerBin
 	ttName := trigger.Template.Name
 	tt, err := getTT(ttName, metav1.GetOptions{})
 	if err != nil {
-		return ResolvedBinding{}, xerrors.Errorf("Error getting TriggerTemplate %s: %s", ttName, err)
+		return ResolvedTrigger{}, xerrors.Errorf("Error getting TriggerTemplate %s: %s", ttName, err)
 	}
-	return ResolvedBinding{TriggerBindings: tb, TriggerTemplate: tt}, nil
+	return ResolvedTrigger{TriggerBindings: tb, TriggerTemplate: tt}, nil
 }
 
 // MergeInDefaultParams returns the params with the addition of all

--- a/pkg/template/resource_test.go
+++ b/pkg/template/resource_test.go
@@ -276,16 +276,16 @@ var (
 	}
 )
 
-func Test_ResolveBinding(t *testing.T) {
+func Test_ResolveTrigger(t *testing.T) {
 	tests := []struct {
 		name    string
 		trigger triggersv1.EventListenerTrigger
-		want    ResolvedBinding
+		want    ResolvedTrigger
 	}{
 		{
 			name:    "1 binding",
 			trigger: bldr.Trigger("my-triggerbinding", "my-triggertemplate", "v1alpha1"),
-			want: ResolvedBinding{
+			want: ResolvedTrigger{
 				TriggerBindings: []*triggersv1.TriggerBinding{tb},
 				TriggerTemplate: &tt,
 			},
@@ -298,7 +298,7 @@ func Test_ResolveBinding(t *testing.T) {
 					APIVersion: "v1alpha1",
 				},
 			},
-			want: ResolvedBinding{TriggerBindings: []*triggersv1.TriggerBinding{}, TriggerTemplate: &tt},
+			want: ResolvedTrigger{TriggerBindings: []*triggersv1.TriggerBinding{}, TriggerTemplate: &tt},
 		},
 		{
 			name: "multiple bindings",
@@ -318,7 +318,7 @@ func Test_ResolveBinding(t *testing.T) {
 					APIVersion: "v1alpha1",
 				},
 			},
-			want: ResolvedBinding{
+			want: ResolvedTrigger{
 				TriggerBindings: []*triggersv1.TriggerBinding{
 					tb,
 					triggerBindings["tb-params"],
@@ -330,17 +330,17 @@ func Test_ResolveBinding(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := ResolveBinding(tc.trigger, getTB, getTT)
+			got, err := ResolveTrigger(tc.trigger, getTB, getTT)
 			if err != nil {
-				t.Errorf("ResolveBinding() returned unexpected error: %s", err)
+				t.Errorf("ResolveTrigger() returned unexpected error: %s", err)
 			} else if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("ResolveBinding(): -want +got: %s", diff)
+				t.Errorf("ResolveTrigger(): -want +got: %s", diff)
 			}
 		})
 	}
 }
 
-func Test_ResolveBinding_error(t *testing.T) {
+func Test_ResolveTrigger_error(t *testing.T) {
 	tests := []struct {
 		name    string
 		trigger triggersv1.EventListenerTrigger
@@ -368,9 +368,9 @@ func Test_ResolveBinding_error(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := ResolveBinding(tt.trigger, tt.getTB, tt.getTT)
+			_, err := ResolveTrigger(tt.trigger, tt.getTB, tt.getTT)
 			if err == nil {
-				t.Error("ResolveBinding() did not return error when expected")
+				t.Error("ResolveTrigger() did not return error when expected")
 			}
 		})
 	}


### PR DESCRIPTION
# Changes

* Renames Resolve[d]Binding -> ResolvedTrigger to better reflect its
  purpose.
* Splits NewResources -> ResolveBinding, ResolveTemplate.
* Adds logging of resolved event parameters to sink to resolve #195.
* Adds annotated logging to sink to record event and trigger identifiers
  in sink logs.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

n/a