### PR TITLE
Avoid using gjson to parse a json.RawMessage

### DIFF
--- a/pkg/apis/triggers/v1alpha1/trigger_template_types.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_template_types.go
@@ -17,11 +17,11 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"bytes"
 	"encoding/json"
 	"strings"
 
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
-	"github.com/tidwall/gjson"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
@@ -83,9 +83,11 @@ type TriggerTemplateList struct {
 // getAPIVersionAndKind returns the apiVersion and Kind for the resourceTemplate
 // Missing fields are represented by empty strings
 func (trt *TriggerResourceTemplate) getAPIVersionAndKind() (string, string) {
-	apiVersion := gjson.GetBytes(trt.RawMessage, "apiVersion").String()
-	kind := gjson.GetBytes(trt.RawMessage, "kind").String()
-	return apiVersion, kind
+	var tm metav1.TypeMeta
+	if err := json.NewDecoder(bytes.NewReader(trt.RawMessage)).Decode(&tm); err != nil {
+		return "", ""
+	}
+	return tm.APIVersion, tm.Kind
 }
 
 // IsAllowedType returns true if the resourceTemplate has an apiVersion


### PR DESCRIPTION
`encoding/json` already has support for unmarshalling built-in, and this
avoids an unnecessary dependency in types code.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._
