### PR TITLE
Add event type filtering to the gitlab interceptor.

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -159,12 +159,17 @@ spec:
 
 ### GitLab Interceptors
 
-GitLab interceptors contain logic to validate that a webhook actually came from Gitlab,
-using the logic outlined in GitLab [documentation](https://docs.gitlab.com/ee/user/project/integrations/webhooks.html/).
+GitLab interceptors contain logic to validate and filter requests that come from Gitlab.
+Supported features include validating that a webhook actually came from Gitlab, using the logic outlined
+in GitLab [documentation](https://docs.gitlab.com/ee/user/project/integrations/webhooks.html/),
+and to filter incoming events based on the event types.
+Event types can be found in Gitlab [documentation](https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#events).
 
-To use this interceptor, create a secret string using the method of your choice, and configure the Gitlab
-webhook to use that secret value.
-Create a Kubernetes secret containing this value, and pass that as a reference to the `gitlab` interceptor:
+To use this interceptor as a validator, create a secret string using the method of your choice, and configure
+the Gitlab webhook to use that secret value.
+Create a Kubernetes secret containing this value, and pass that as a reference to the `gitlab` interceptor.
+
+To use this interceptor as a filter, add the event types you would like to accept to the `eventTypes` field.
 
 <!-- FILE: examples/eventlisteners/gitlab-eventlistener-interceptor.yaml -->
 ```YAML
@@ -182,6 +187,8 @@ spec:
             secretName: foo
             secretKey: bar
             namespace: baz
+          eventTypes:
+          - Push Hook
       bindings:
       - name: pipeline-binding
       template:

--- a/examples/eventlisteners/gitlab-eventlistener-interceptor.yaml
+++ b/examples/eventlisteners/gitlab-eventlistener-interceptor.yaml
@@ -12,6 +12,8 @@ spec:
             secretName: foo
             secretKey: bar
             namespace: baz
+          eventTypes:
+          - Push Hook
       bindings:
       - name: pipeline-binding
       template:

--- a/pkg/apis/triggers/v1alpha1/event_listener_types.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_types.go
@@ -97,7 +97,8 @@ type GithubInterceptor struct {
 
 // GitlabInterceptor provides a webhook to intercept and pre-process events
 type GitlabInterceptor struct {
-	SecretRef *SecretRef `json:"secretRef,omitempty"`
+	SecretRef  *SecretRef `json:"secretRef,omitempty"`
+	EventTypes []string   `json:"eventTypes,omitempty"`
 }
 
 // SecretRef contains the information required to reference a single secret string

--- a/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
@@ -277,6 +277,11 @@ func (in *GitlabInterceptor) DeepCopyInto(out *GitlabInterceptor) {
 		*out = new(SecretRef)
 		**out = **in
 	}
+	if in.EventTypes != nil {
+		in, out := &in.EventTypes, &out.EventTypes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/interceptors/gitlab/gitlab.go
+++ b/pkg/interceptors/gitlab/gitlab.go
@@ -19,6 +19,7 @@ package gitlab
 import (
 	"crypto/subtle"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/tektoncd/triggers/pkg/interceptors"
@@ -46,23 +47,35 @@ func NewInterceptor(gl *triggersv1.GitlabInterceptor, k kubernetes.Interface, ns
 }
 
 func (w *Interceptor) ExecuteTrigger(payload []byte, request *http.Request, _ *triggersv1.EventListenerTrigger, _ string) ([]byte, error) {
-	// No secret set, just continue
-	if w.Gitlab.SecretRef == nil {
-		return payload, nil
-	}
-	header := request.Header.Get("X-Gitlab-Token")
-	if header == "" {
-		return nil, errors.New("no X-Gitlab-Token header set")
-	}
+	// Validate the secret first, if set.
+	if w.Gitlab.SecretRef != nil {
+		header := request.Header.Get("X-Gitlab-Token")
+		if header == "" {
+			return nil, errors.New("no X-Gitlab-Token header set")
+		}
 
-	secretToken, err := interceptors.GetSecretToken(w.KubeClientSet, w.Gitlab.SecretRef, w.EventListenerNamespace)
-	if err != nil {
-		return nil, err
-	}
+		secretToken, err := interceptors.GetSecretToken(w.KubeClientSet, w.Gitlab.SecretRef, w.EventListenerNamespace)
+		if err != nil {
+			return nil, err
+		}
 
-	// Make sure to use a constant time comparison here.
-	if subtle.ConstantTimeCompare([]byte(header), secretToken) == 0 {
-		return nil, errors.New("Invalid X-Gitlab-Token")
+		// Make sure to use a constant time comparison here.
+		if subtle.ConstantTimeCompare([]byte(header), secretToken) == 0 {
+			return nil, errors.New("Invalid X-Gitlab-Token")
+		}
+	}
+	if w.Gitlab.EventTypes != nil {
+		actualEvent := request.Header.Get("X-Gitlab-Event")
+		isAllowed := false
+		for _, allowedEvent := range w.Gitlab.EventTypes {
+			if actualEvent == allowedEvent {
+				isAllowed = true
+				break
+			}
+		}
+		if !isAllowed {
+			return nil, fmt.Errorf("event type %s is not allowed", actualEvent)
+		}
 	}
 
 	return payload, nil

--- a/third_party/VENDOR-LICENSE
+++ b/third_party/VENDOR-LICENSE
@@ -7517,4 +7517,3 @@ Import: github.com/tektoncd/triggers/vendor/knative.dev/pkg
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-


### PR DESCRIPTION
# Changes

This mirrors the event type fltering that exists for Github.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
The GitLab interceptor now supports filtering based on incoming event types.
```
