### PR TITLE
Add app.kubernetes.io labels to controller and webhook 🏷

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -17,6 +17,9 @@ kind: Deployment
 metadata:
   name: tekton-triggers-controller
   namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/name: tekton-triggers
+    app.kubernetes.io/component: controller
 spec:
   replicas: 1
   selector:

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -17,6 +17,9 @@ kind: Deployment
 metadata:
   name: tekton-triggers-webhook
   namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/name: tekton-triggers
+    app.kubernetes.io/component: webhook-controller
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
# Changes

Doing the same as `tektoncd/pipeline`, this allows consumer of the API
to do things with those (e.g. openshift groups the resources per app, …)

See [here](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) :label: 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @dibyom @bobcatfish 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Add app.kubernetes.io labels to triggers
```
