### PR TITLE
JSONPath Support for TriggerBindings

### DIFF
--- a/docs/triggerbindings.md
+++ b/docs/triggerbindings.md
@@ -33,46 +33,40 @@ Each parameter has a `name` and a `value`.
 
 ## Event Variable Interpolation
 
-In order to parse generic events as efficiently as possible,
-[GJSON](https://github.com/tidwall/gjson) is used internally. As a result, the
-binding [path syntax](https://github.com/tidwall/gjson#path-syntax) differs
-slightly from standard JSON. As of now, the following patterns are supported
-within `TriggerBinding` parameter value interpolation: -
-`\$\(body(\.[[:alnum:]/_\-\.\\]+|\.#\([[:alnum:]=<>%!"\*_-]+\)#??)*\)` -
-`\$\(header(\.[[:alnum:]_\-]+)?\)`
+TriggerBindings can access values from the HTTP JSON body and the headers using
+JSONPath expressions wrapped in `$()`.
 
-### Body
+These are all valid expressions:
+```shell script
+$(body.key1)
+$(.body.key)
+```
 
-HTTP Post request body data can be referenced using variable interpolation. Text
-in the form of `$(body.X.Y.Z)` is replaced by the body data at JSON path
-`X.Y.Z`.
+These are invalid expressions:
+```shell script
+.body.key1 # INVALID - Not wrapped in $()
+$({body) # INVALID - Ending curly brace absent
+```
+
+### Examples
+
+``` shell script
 
 `$(body)` is replaced by the entire body.
 
-The following are some example variable interpolation replacements:
-``` $(body)
--> "{\"key1\": \"value1\", \"key2\": {\"key3\": \"value3\"}, \"key4\":
-[\"value4\", \"value5\"]}"
+$(body) -> "{"key1": "value1", "key2": {"key3": "value3"}, "key4": ["value4", "value5"]}"
 
 $(body.key1) -> "value1"
 
-$(body.key2) -> "{\"key3\": \"value3\"}"
+$(body.key2) -> "{"key3": "value3"}"
 
 $(body.key2.key3) -> "value3"
 
-$(body.key4.0) -> "value4"
-```
+$(body.key4[0]) -> "value4"
 
-### Header
+# $(header) is replaced by all of the headers from the event.
 
-HTTP Post request header data can be referenced using variable interpolation.
-Text in the form of `$(header.X)` is replaced by the event's header named `X`.
-
-`$(header)` is replaced by all of the headers from the event.
-
-The following are some example variable interpolation replacements:
-```
-$(header) -> "{\"One\":[\"one\"], \"Two\":[\"one\",\"two\",\"three\"]}"
+$(header) -> "{"One":["one"], "Two":["one","two","three"]}"
 
 $(header.One) -> "one"
 

--- a/pkg/template/event_test.go
+++ b/pkg/template/event_test.go
@@ -18,7 +18,6 @@ package template
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -28,628 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 )
 
-func TestBodyPathVarRegex(t *testing.T) {
-	tests := []string{
-		"$(body)",
-		"$(body.a-b)",
-		"$(body.a1)",
-		"$(body.a.b)",
-		"$(body.a.b.c)",
-		"$(body.1.b.c\\.e/f)",
-		"$(body.#(a==b))",
-		"$(body.#(a>1)#)",
-		"$(body.#(a%\"D*\")#.c)",
-		"$(body.#(a!%\"D*\").c)",
-	}
-	for _, bodyPathVar := range tests {
-		t.Run(bodyPathVar, func(t *testing.T) {
-			if !bodyPathVarRegex.MatchString(bodyPathVar) {
-				t.Errorf("bodyPathVarRegex.MatchString(%s) = false, want = true", bodyPathVar)
-			}
-		})
-	}
-}
-
-func TestBodyPathVarRegex_invalid(t *testing.T) {
-	tests := []string{
-		"$body",
-		"$[body]",
-		"${body}",
-		"$(body.)",
-		"$(body.@)",
-		"$(body.$a)",
-		"$(body#a)",
-		"$(body@#)",
-		"body.a",
-		"body",
-		"${{body}",
-		"${body",
-	}
-	for _, bodyPathVar := range tests {
-		t.Run(bodyPathVar, func(t *testing.T) {
-			if bodyPathVarRegex.MatchString(bodyPathVar) {
-				t.Errorf("bodyPathVarRegex.MatchString(%s) = true, want = false", bodyPathVar)
-			}
-		})
-	}
-}
-
-func TestHeaderVarRegex(t *testing.T) {
-	tests := []string{
-		"$(header)",
-		"$(header.a-b)",
-		"$(header.a1)",
-	}
-	for _, headerVar := range tests {
-		t.Run(headerVar, func(t *testing.T) {
-			if !headerVarRegex.MatchString(headerVar) {
-				t.Errorf("headerVarRegex.MatchString(%s) = false, want = true", headerVar)
-			}
-		})
-	}
-}
-
-func TestHeaderVarRegex_invalid(t *testing.T) {
-	tests := []string{
-		"$(header.a.b)",
-		"$(header.a.b.c)",
-		"$header",
-		"$[header]",
-		"${header}",
-		"$(header.)",
-		"$(header..)",
-		"$(header.$a)",
-		"header.a",
-		"header",
-		"${{header}",
-		"${header",
-	}
-	for _, headerVar := range tests {
-		t.Run(headerVar, func(t *testing.T) {
-			if headerVarRegex.MatchString(headerVar) {
-				t.Errorf("headerVarRegex.MatchString(%s) = true, want = false", headerVar)
-			}
-		})
-	}
-}
-
-func TestGetBodyPathFromVar(t *testing.T) {
-	tests := []struct {
-		bodyPathVar string
-		want        string
-	}{
-		{bodyPathVar: "$(body)", want: ""},
-		{bodyPathVar: "$(body.a-b)", want: "a-b"},
-		{bodyPathVar: "$(body.a1)", want: "a1"},
-		{bodyPathVar: "$(body.a.b)", want: "a.b"},
-		{bodyPathVar: "$(body.a.b.c)", want: "a.b.c"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.bodyPathVar, func(t *testing.T) {
-			if bodyPath := getBodyPathFromVar(tt.bodyPathVar); bodyPath != tt.want {
-				t.Errorf("getBodyPathFromVar() = %s, want = %s", bodyPath, tt.want)
-			}
-		})
-	}
-}
-
-func TestGetHeaderFromVar(t *testing.T) {
-	tests := []struct {
-		headerVar string
-		want      string
-	}{
-		{headerVar: "$(header)", want: ""},
-		{headerVar: "$(header.a-b)", want: "a-b"},
-		{headerVar: "$(header.a1)", want: "a1"},
-		{headerVar: "$(header.a.b)", want: "a.b"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.headerVar, func(t *testing.T) {
-			if header := getHeaderFromVar(tt.headerVar); header != tt.want {
-				t.Errorf("getHeaderFromVar() = %s, want = %s", header, tt.want)
-			}
-		})
-	}
-}
-
-func Test_getBodyPathValue(t *testing.T) {
-	body := `{"empty": "", "null": null, "one": "one", "two": {"two": "twovalue"}, "three": {"three": {"three": {"three": {"three": "threevalue"}}}}}`
-	bodyJSON := json.RawMessage(body)
-	type args struct {
-		body     []byte
-		bodyPath string
-	}
-	tests := []struct {
-		args args
-		want string
-	}{{
-		args: args{
-			body:     bodyJSON,
-			bodyPath: "",
-		},
-		want: strings.Replace(body, `"`, `\"`, -1),
-	}, {
-		args: args{
-			body:     bodyJSON,
-			bodyPath: "one",
-		},
-		want: "one",
-	}, {
-		args: args{
-			body:     bodyJSON,
-			bodyPath: "two",
-		},
-		want: `{\"two\": \"twovalue\"}`,
-	}, {
-		args: args{
-			body:     bodyJSON,
-			bodyPath: "three.three.three.three.three",
-		},
-		want: "threevalue",
-	}, {
-		args: args{
-			body:     bodyJSON,
-			bodyPath: "empty",
-		},
-		want: "",
-	}, {
-		args: args{
-			body:     bodyJSON,
-			bodyPath: "null",
-		},
-		want: "null",
-	}}
-	for _, tt := range tests {
-		t.Run(tt.args.bodyPath, func(t *testing.T) {
-			got, err := getBodyPathValue(tt.args.body, tt.args.bodyPath)
-			if err != nil {
-				t.Errorf("getBodyPathValue() error: %s", err)
-			} else if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("getBodyPathValue(): -want +got: %s", diff)
-			}
-		})
-	}
-}
-
-func Test_getBodyPathValue_error(t *testing.T) {
-	bodyJSON := json.RawMessage(`{"one": "onevalue", "two": {"two": "twovalue"}, "three": {"three": {"three": {"three": {"three": "threevalue"}}}}}`)
-	tests := []struct {
-		body     []byte
-		bodyPath string
-	}{{
-		body:     bodyJSON,
-		bodyPath: "boguspath",
-	}, {
-		body:     bodyJSON,
-		bodyPath: "two.bogus",
-	}, {
-		body:     bodyJSON,
-		bodyPath: "three.three.bogus.three",
-	},
-	}
-	for _, tt := range tests {
-		t.Run(tt.bodyPath, func(t *testing.T) {
-			got, err := getBodyPathValue(tt.body, tt.bodyPath)
-			if err == nil {
-				t.Errorf("getBodyPathValue() did not return error when expected; got: %s", got)
-			}
-		})
-	}
-}
-
-func Test_getHeaderValue(t *testing.T) {
-	header := map[string][]string{"one": {"one"}, "two": {"one", "two"}, "three": {"one", "two", "three"}}
-	type args struct {
-		header     map[string][]string
-		headerName string
-	}
-	tests := []struct {
-		args args
-		want string
-	}{{
-		args: args{
-			header:     header,
-			headerName: "",
-		},
-		want: `{\"one\":[\"one\"],\"three\":[\"one\",\"two\",\"three\"],\"two\":[\"one\",\"two\"]}`,
-	}, {
-		args: args{
-			header:     header,
-			headerName: "one",
-		},
-		want: "one",
-	}, {
-		args: args{
-			header:     header,
-			headerName: "two",
-		},
-		want: "one two",
-	}, {
-		args: args{
-			header:     header,
-			headerName: "three",
-		},
-		want: "one two three",
-	}}
-	for _, tt := range tests {
-		t.Run(tt.args.headerName, func(t *testing.T) {
-			got, err := getHeaderValue(tt.args.header, tt.args.headerName)
-			if err != nil {
-				t.Errorf("getHeaderValue() error: %s", err)
-			} else if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("getHeaderValue(): -want +got: %s", diff)
-			}
-		})
-	}
-}
-
-func Test_getHeaderValue_error(t *testing.T) {
-	header := map[string][]string{"one": {"one"}}
-	tests := []struct {
-		header     map[string][]string
-		headerName string
-	}{{
-		header:     header,
-		headerName: "bogusheadername",
-	}}
-	for _, tt := range tests {
-		t.Run(tt.headerName, func(t *testing.T) {
-			got, err := getHeaderValue(tt.header, tt.headerName)
-			if err == nil {
-				t.Errorf("getHeaderValue() did not return error when expected; got: %s", got)
-			}
-		})
-	}
-}
-
-var (
-	testBodyJSON       = json.RawMessage(`{"one": "onevalue", "two": {"two": "twovalue"}, "three": {"three": {"three": {"three": {"three": "threevalue"}}}}}`)
-	paramNoBodyPathVar = pipelinev1.Param{
-		Name:  "paramNoBodyPathVar",
-		Value: pipelinev1.ArrayOrString{StringVal: "bar"},
-	}
-	wantParamNoBodyPathVar = pipelinev1.Param{
-		Name:  "paramNoBodyPathVar",
-		Value: pipelinev1.ArrayOrString{StringVal: "bar"},
-	}
-	paramOneBodyPathVar = pipelinev1.Param{
-		Name:  "paramOneBodyPathVar",
-		Value: pipelinev1.ArrayOrString{StringVal: "bar-$(body.one)-bar"},
-	}
-	wantParamOneBodyPathVar = pipelinev1.Param{
-		Name:  "paramOneBodyPathVar",
-		Value: pipelinev1.ArrayOrString{StringVal: "bar-onevalue-bar"},
-	}
-	paramMultipleIdenticalBodyPathVars = pipelinev1.Param{
-		Name:  "paramMultipleIdenticalBodyPathVars",
-		Value: pipelinev1.ArrayOrString{StringVal: "bar-$(body.one)-$(body.one)-$(body.one)-bar"},
-	}
-	wantParamMultipleIdenticalBodyPathVars = pipelinev1.Param{
-		Name:  "paramMultipleIdenticalBodyPathVars",
-		Value: pipelinev1.ArrayOrString{StringVal: "bar-onevalue-onevalue-onevalue-bar"},
-	}
-	paramMultipleUniqueBodyPathVars = pipelinev1.Param{
-		Name:  "paramMultipleUniqueBodyPathVars",
-		Value: pipelinev1.ArrayOrString{StringVal: "bar-$(body.one)-$(body.two.two)-$(body.three.three.three.three.three)-bar"},
-	}
-	wantParamMultipleUniqueBodyPathVars = pipelinev1.Param{
-		Name:  "paramMultipleUniqueBodyPathVars",
-		Value: pipelinev1.ArrayOrString{StringVal: "bar-onevalue-twovalue-threevalue-bar"},
-	}
-	paramSubobjectBodyPathVar = pipelinev1.Param{
-		Name:  "paramSubobjectBodyPathVar",
-		Value: pipelinev1.ArrayOrString{StringVal: "bar-$(body.three)-bar"},
-	}
-	wantParamSubobjectBodyPathVar = pipelinev1.Param{
-		Name:  "paramSubobjectBodyPathVar",
-		Value: pipelinev1.ArrayOrString{StringVal: `bar-{\"three\": {\"three\": {\"three\": {\"three\": \"threevalue\"}}}}-bar`},
-	}
-	paramEntireBodyPathVar = pipelinev1.Param{
-		Name:  "paramEntireBodyPathVar",
-		Value: pipelinev1.ArrayOrString{StringVal: "bar-$(body)-bar"},
-	}
-	wantParamEntireBodyPathVar = pipelinev1.Param{
-		Name:  "paramEntireBodyPathVar",
-		Value: pipelinev1.ArrayOrString{StringVal: `bar-{\"one\": \"onevalue\", \"two\": {\"two\": \"twovalue\"}, \"three\": {\"three\": {\"three\": {\"three\": {\"three\": \"threevalue\"}}}}}-bar`},
-	}
-	paramOneBogusBodyPathVar = pipelinev1.Param{
-		Name:  "paramOneBogusBodyPathVar",
-		Value: pipelinev1.ArrayOrString{StringVal: "bar-$(body.bogus.path)-bar"},
-	}
-	paramMultipleBogusBodyPathVars = pipelinev1.Param{
-		Name:  "paramMultipleBogusBodyPathVars",
-		Value: pipelinev1.ArrayOrString{StringVal: "bar-$(body.bogus.path)-$(body.two.bogus)-$(body.three.bogus)-bar"},
-	}
-)
-
-func Test_applyBodyToParam(t *testing.T) {
-	type args struct {
-		body  []byte
-		param pipelinev1.Param
-	}
-	tests := []struct {
-		args args
-		want pipelinev1.Param
-	}{{
-		args: args{body: []byte{}, param: paramNoBodyPathVar},
-		want: wantParamNoBodyPathVar,
-	}, {
-		args: args{body: testBodyJSON, param: paramOneBodyPathVar},
-		want: wantParamOneBodyPathVar,
-	}, {
-		args: args{body: testBodyJSON, param: paramMultipleIdenticalBodyPathVars},
-		want: wantParamMultipleIdenticalBodyPathVars,
-	}, {
-		args: args{body: testBodyJSON, param: paramMultipleUniqueBodyPathVars},
-		want: wantParamMultipleUniqueBodyPathVars,
-	}, {
-		args: args{body: testBodyJSON, param: paramEntireBodyPathVar},
-		want: wantParamEntireBodyPathVar,
-	}, {
-		args: args{body: testBodyJSON, param: paramSubobjectBodyPathVar},
-		want: wantParamSubobjectBodyPathVar,
-	}}
-	for _, tt := range tests {
-		t.Run(tt.args.param.Value.StringVal, func(t *testing.T) {
-			got, err := applyBodyToParam(tt.args.body, tt.args.param)
-			if err != nil {
-				t.Errorf("applyBodyToParam() error = %v", err)
-			} else if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("applyBodyToParam(): -want +got: %s", diff)
-			}
-		})
-	}
-}
-
-func Test_applyBodyToParam_error(t *testing.T) {
-	tests := []struct {
-		body  []byte
-		param pipelinev1.Param
-	}{{
-		body:  testBodyJSON,
-		param: paramOneBogusBodyPathVar,
-	}, {
-		body:  testBodyJSON,
-		param: paramMultipleBogusBodyPathVars,
-	}}
-	for _, tt := range tests {
-		t.Run(tt.param.Value.StringVal, func(t *testing.T) {
-			got, err := applyBodyToParam(tt.body, tt.param)
-			if err == nil {
-				t.Errorf("applyBodyToParam() did not return error when expected; got: %v", got)
-			}
-		})
-	}
-}
-
-func Test_ApplyBodyToParams(t *testing.T) {
-	type args struct {
-		body   []byte
-		params []pipelinev1.Param
-	}
-	tests := []struct {
-		name string
-		args args
-		want []pipelinev1.Param
-	}{{
-		name: "empty params",
-		args: args{
-			body:   testBodyJSON,
-			params: []pipelinev1.Param{},
-		},
-		want: []pipelinev1.Param{},
-	}, {
-		name: "one param",
-		args: args{
-			body:   testBodyJSON,
-			params: []pipelinev1.Param{paramOneBodyPathVar},
-		},
-		want: []pipelinev1.Param{wantParamOneBodyPathVar},
-	}, {
-		name: "multiple params",
-		args: args{
-			body: testBodyJSON,
-			params: []pipelinev1.Param{
-				paramOneBodyPathVar,
-				paramMultipleUniqueBodyPathVars,
-				paramSubobjectBodyPathVar,
-			},
-		},
-		want: []pipelinev1.Param{
-			wantParamOneBodyPathVar,
-			wantParamMultipleUniqueBodyPathVars,
-			wantParamSubobjectBodyPathVar,
-		},
-	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := ApplyBodyToParams(tt.args.body, tt.args.params)
-			if err != nil {
-				t.Errorf("ApplyBodyToParams() error = %v", err)
-				return
-			}
-			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("ApplyBodyToParams(): -want +got: %s", diff)
-			}
-		})
-	}
-}
-
-func Test_ApplyBodyToParams_error(t *testing.T) {
-	type args struct {
-		body   []byte
-		params []pipelinev1.Param
-	}
-	tests := []struct {
-		name string
-		args args
-	}{{
-		name: "error one bodypath not found",
-		args: args{
-			body: testBodyJSON,
-			params: []pipelinev1.Param{
-				paramOneBogusBodyPathVar,
-				paramMultipleUniqueBodyPathVars,
-				paramSubobjectBodyPathVar,
-			},
-		},
-	}, {
-		name: "error multiple bodypaths not found",
-		args: args{
-			body: testBodyJSON,
-			params: []pipelinev1.Param{
-				paramOneBogusBodyPathVar,
-				paramMultipleBogusBodyPathVars,
-			},
-		},
-	},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := ApplyBodyToParams(tt.args.body, tt.args.params)
-			if err == nil {
-				t.Errorf("ApplyBodyToParams() did not return error when expected; got: %v", got)
-			}
-		})
-	}
-}
-
-func Test_applyHeaderToParams(t *testing.T) {
-	header := map[string][]string{"one": {"one"}, "two": {"one", "two"}, "three": {"one", "two", "three"}}
-	type args struct {
-		header map[string][]string
-		param  pipelinev1.Param
-	}
-	tests := []struct {
-		name string
-		args args
-		want pipelinev1.Param
-	}{{
-		name: "empty",
-		args: args{
-			header: header,
-			param:  pipelinev1.Param{},
-		},
-		want: pipelinev1.Param{},
-	}, {
-		name: "no header vars",
-		args: args{
-			header: header,
-			param: pipelinev1.Param{
-				Name:  "noHeaderVars",
-				Value: pipelinev1.ArrayOrString{StringVal: "foo"},
-			},
-		},
-		want: pipelinev1.Param{
-			Name:  "noHeaderVars",
-			Value: pipelinev1.ArrayOrString{StringVal: "foo"},
-		},
-	}, {
-		name: "one header var",
-		args: args{
-			header: header,
-			param: pipelinev1.Param{
-				Name:  "oneHeaderVar",
-				Value: pipelinev1.ArrayOrString{StringVal: "$(header.one)"},
-			},
-		},
-		want: pipelinev1.Param{
-			Name:  "oneHeaderVar",
-			Value: pipelinev1.ArrayOrString{StringVal: "one"},
-		},
-	}, {
-		name: "multiple header vars",
-		args: args{
-			header: header,
-			param: pipelinev1.Param{
-				Name:  "multipleHeaderVars",
-				Value: pipelinev1.ArrayOrString{StringVal: "$(header.one)-$(header.two)-$(header.three)"},
-			},
-		},
-		want: pipelinev1.Param{
-			Name:  "multipleHeaderVars",
-			Value: pipelinev1.ArrayOrString{StringVal: `one-one two-one two three`},
-		},
-	}, {
-		name: "identical header vars",
-		args: args{
-			header: header,
-			param: pipelinev1.Param{
-				Name:  "identicalHeaderVars",
-				Value: pipelinev1.ArrayOrString{StringVal: "$(header.one)-$(header.one)-$(header.one)"},
-			},
-		},
-		want: pipelinev1.Param{
-			Name:  "identicalHeaderVars",
-			Value: pipelinev1.ArrayOrString{StringVal: `one-one-one`},
-		},
-	}, {
-		name: "entire header var",
-		args: args{
-			header: header,
-			param: pipelinev1.Param{
-				Name:  "entireHeaderVar",
-				Value: pipelinev1.ArrayOrString{StringVal: "$(header)"},
-			},
-		},
-		want: pipelinev1.Param{
-			Name:  "entireHeaderVar",
-			Value: pipelinev1.ArrayOrString{StringVal: `{\"one\":[\"one\"],\"three\":[\"one\",\"two\",\"three\"],\"two\":[\"one\",\"two\"]}`},
-		},
-	},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := applyHeaderToParam(tt.args.header, tt.args.param)
-			if err != nil {
-				t.Errorf("applyHeaderToParam() error = %v", err)
-				return
-			}
-			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("applyHeaderToParam(): -want +got: %s", diff)
-			}
-		})
-	}
-}
-
-func Test_applyHeaderToParams_error(t *testing.T) {
-	header := map[string][]string{"one": {"one"}}
-	type args struct {
-		header map[string][]string
-		param  pipelinev1.Param
-	}
-	tests := []struct {
-		name string
-		args args
-	}{{
-		name: "error header not found",
-		args: args{
-			header: header,
-			param: pipelinev1.Param{
-				Name:  "oneBogusHeader",
-				Value: pipelinev1.ArrayOrString{StringVal: "$(header.bogus)"},
-			},
-		},
-	}, {
-		name: "error multiple headers not found",
-		args: args{
-			header: header,
-			param: pipelinev1.Param{
-				Name:  "multipleBogusHeaders",
-				Value: pipelinev1.ArrayOrString{StringVal: "$(header.one)-$(header.bogus1)-$(header.bogus2)-$(header.bogus3)"},
-			},
-		},
-	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := applyHeaderToParam(tt.args.header, tt.args.param)
-			if err == nil {
-				t.Errorf("applyHeaderToParam() did not return error when expected; got: %v", got)
-			}
-		})
-	}
-}
-
+// TODO(#252): Split NewResourcesTests into separate tests for ResolveParams and ResolveResources
 func Test_NewResources(t *testing.T) {
 	type args struct {
 		body    []byte
@@ -799,7 +177,7 @@ func Test_NewResources(t *testing.T) {
 		},
 		want: []json.RawMessage{
 			json.RawMessage(`{"rt1": "bar-cbhtc", "cbhtc": "cbhtc"}`),
-			json.RawMessage(`{"rt2": "default2-cbhtc"}`),
+			json.RawMessage(`{"rt2": "default2-bsvjp"}`),
 			json.RawMessage(`{"rt3": "rt3"}`),
 		},
 	}, {
@@ -832,8 +210,94 @@ func Test_NewResources(t *testing.T) {
 		want: []json.RawMessage{
 			json.RawMessage(`{"rt1": "bar-1"}`),
 		},
-	},
-	}
+	}, {
+		name: "bindings with static values",
+		args: args{
+			body: json.RawMessage(`{"foo": "bar"}`),
+			binding: ResolvedTrigger{
+				TriggerTemplate: bldr.TriggerTemplate("tt", "ns", bldr.TriggerTemplateSpec(
+					bldr.TriggerTemplateParam("p1", "", ""),
+					bldr.TriggerTemplateParam("p2", "", ""),
+					bldr.TriggerResourceTemplate(json.RawMessage(`{"p1": "$(params.p1)", "p2": "$(params.p2)"}`)),
+				),
+				),
+				TriggerBindings: []*triggersv1.TriggerBinding{
+					bldr.TriggerBinding("tb", "ns", bldr.TriggerBindingSpec(
+						bldr.TriggerBindingParam("p1", "static_value"),
+						bldr.TriggerBindingParam("p2", "$(body.foo)"),
+					)),
+				},
+			},
+		},
+		want: []json.RawMessage{
+			json.RawMessage(`{"p1": "static_value", "p2": "bar"}`),
+		},
+	}, {
+		name: "bindings with combination of static values ",
+		args: args{
+			body: json.RawMessage(`{"foo": "fooValue", "bar": "barValue"}`),
+			binding: ResolvedTrigger{
+				TriggerTemplate: bldr.TriggerTemplate("tt", "ns", bldr.TriggerTemplateSpec(
+					bldr.TriggerTemplateParam("p1", "", ""),
+					bldr.TriggerResourceTemplate(json.RawMessage(`{"p1": "$(params.p1)"`)),
+				),
+				),
+				TriggerBindings: []*triggersv1.TriggerBinding{
+					bldr.TriggerBinding("tb", "ns", bldr.TriggerBindingSpec(
+						bldr.TriggerBindingParam("p1", "Event values are - foo: $(body.foo); bar: $(body.bar)"),
+					)),
+				},
+			},
+		},
+		want: []json.RawMessage{
+			json.RawMessage(`{"p1": "Event values are - foo: fooValue; bar: barValue"`),
+		},
+	}, {
+		name: "event value is JSON string",
+		args: args{
+			body: json.RawMessage(`{"a": "b"}`),
+			binding: ResolvedTrigger{
+				TriggerTemplate: bldr.TriggerTemplate("tt", "ns", bldr.TriggerTemplateSpec(
+					bldr.TriggerTemplateParam("p1", "", ""),
+					bldr.TriggerResourceTemplate(json.RawMessage(`{"p1": "$(params.p1)"}`)),
+				),
+				),
+				TriggerBindings: []*triggersv1.TriggerBinding{
+					bldr.TriggerBinding("tb", "ns", bldr.TriggerBindingSpec(
+						bldr.TriggerBindingParam("p1", "$(body)"),
+					)),
+				},
+			},
+		},
+		want: []json.RawMessage{
+			json.RawMessage(`{"p1": "{\"a\":\"b\"}"}`),
+		},
+	}, {
+		name: "header event values",
+		args: args{
+			header: map[string][]string{
+				"a": {"singlevalue"},
+				"b": {"multiple", "values"},
+			},
+			binding: ResolvedTrigger{
+				TriggerTemplate: bldr.TriggerTemplate("tt", "ns", bldr.TriggerTemplateSpec(
+					bldr.TriggerTemplateParam("p1", "", ""),
+					bldr.TriggerTemplateParam("p2", "", ""),
+					bldr.TriggerResourceTemplate(json.RawMessage(`{"p1": "$(params.p1)","p2": "$(params.p2)"}`)),
+				),
+				),
+				TriggerBindings: []*triggersv1.TriggerBinding{
+					bldr.TriggerBinding("tb", "ns", bldr.TriggerBindingSpec(
+						bldr.TriggerBindingParam("p1", "$(header.a)"),
+						bldr.TriggerBindingParam("p2", "$(header.b)"),
+					)),
+				},
+			},
+		},
+		want: []json.RawMessage{
+			json.RawMessage(`{"p1": "singlevalue","p2": "multiple,values"}`),
+		},
+	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// This seeds Uid() to return 'cbhtc'
@@ -866,89 +330,85 @@ func Test_NewResources_error(t *testing.T) {
 		header   map[string][]string
 		elParams []pipelinev1.Param
 		binding  ResolvedTrigger
-	}{
-		{
-			name: "bodypath not found in body",
-			body: json.RawMessage(`{"foo": "bar"}`),
-			binding: ResolvedTrigger{
-				TriggerTemplate: bldr.TriggerTemplate("tt", "namespace",
-					bldr.TriggerTemplateSpec(
-						bldr.TriggerTemplateParam("param1", "description", ""),
+	}{{
+		name: "bodypath not found in body",
+		body: json.RawMessage(`{"foo": "bar"}`),
+		binding: ResolvedTrigger{
+			TriggerTemplate: bldr.TriggerTemplate("tt", "namespace",
+				bldr.TriggerTemplateSpec(
+					bldr.TriggerTemplateParam("param1", "description", ""),
+				),
+			),
+			TriggerBindings: []*triggersv1.TriggerBinding{
+				bldr.TriggerBinding("tb", "namespace",
+					bldr.TriggerBindingSpec(
+						bldr.TriggerBindingParam("param1", "$(body.bogusvalue)"),
 					),
 				),
-				TriggerBindings: []*triggersv1.TriggerBinding{
-					bldr.TriggerBinding("tb", "namespace",
-						bldr.TriggerBindingSpec(
-							bldr.TriggerBindingParam("param1", "$(body.bogusvalue)"),
-						),
-					),
-				},
 			},
 		},
-		{
-			name:   "header not found in event",
-			body:   json.RawMessage(`{"foo": "bar"}`),
-			header: map[string][]string{"One": {"one"}},
-			binding: ResolvedTrigger{
-				TriggerTemplate: bldr.TriggerTemplate("tt", "namespace",
-					bldr.TriggerTemplateSpec(
-						bldr.TriggerTemplateParam("param1", "description", ""),
+	}, {
+		name:   "header not found in event",
+		body:   json.RawMessage(`{"foo": "bar"}`),
+		header: map[string][]string{"One": {"one"}},
+		binding: ResolvedTrigger{
+			TriggerTemplate: bldr.TriggerTemplate("tt", "namespace",
+				bldr.TriggerTemplateSpec(
+					bldr.TriggerTemplateParam("param1", "description", ""),
+				),
+			),
+			TriggerBindings: []*triggersv1.TriggerBinding{
+				bldr.TriggerBinding("tb", "namespace",
+					bldr.TriggerBindingSpec(
+						bldr.TriggerBindingParam("param1", "$(header.bogusvalue)"),
 					),
 				),
-				TriggerBindings: []*triggersv1.TriggerBinding{
-					bldr.TriggerBinding("tb", "namespace",
-						bldr.TriggerBindingSpec(
-							bldr.TriggerBindingParam("param1", "$(header.bogusvalue)"),
-						),
-					),
-				},
 			},
 		},
-		{
-			name: "merge params error",
-			elParams: []pipelinev1.Param{
-				{
-					Name:  "param1",
-					Value: pipelinev1.ArrayOrString{StringVal: "value1", Type: pipelinev1.ParamTypeString},
-				},
+	}, {
+		name: "merge params error",
+		elParams: []pipelinev1.Param{
+			{
+				Name:  "param1",
+				Value: pipelinev1.ArrayOrString{StringVal: "value1", Type: pipelinev1.ParamTypeString},
 			},
-			binding: ResolvedTrigger{
-				TriggerTemplate: bldr.TriggerTemplate("tt", "namespace",
-					bldr.TriggerTemplateSpec(
-						bldr.TriggerTemplateParam("param1", "description", ""),
+		},
+		binding: ResolvedTrigger{
+			TriggerTemplate: bldr.TriggerTemplate("tt", "namespace",
+				bldr.TriggerTemplateSpec(
+					bldr.TriggerTemplateParam("param1", "description", ""),
+				),
+			),
+			TriggerBindings: []*triggersv1.TriggerBinding{
+				bldr.TriggerBinding("tb", "namespace",
+					bldr.TriggerBindingSpec(
+						bldr.TriggerBindingParam("param1", "$(body.bogusvalue)"),
 					),
 				),
-				TriggerBindings: []*triggersv1.TriggerBinding{
-					bldr.TriggerBinding("tb", "namespace",
-						bldr.TriggerBindingSpec(
-							bldr.TriggerBindingParam("param1", "$(body.bogusvalue)"),
-						),
-					),
-				},
 			},
 		},
-		{
-			name: "conflicting bindings",
-			binding: ResolvedTrigger{
-				TriggerTemplate: bldr.TriggerTemplate("tt", "namespace",
-					bldr.TriggerTemplateSpec(
-						bldr.TriggerTemplateParam("param1", "description", ""),
+	}, {
+		name: "conflicting bindings",
+		binding: ResolvedTrigger{
+			TriggerTemplate: bldr.TriggerTemplate("tt", "namespace",
+				bldr.TriggerTemplateSpec(
+					bldr.TriggerTemplateParam("param1", "description", ""),
+				),
+			),
+			TriggerBindings: []*triggersv1.TriggerBinding{
+				bldr.TriggerBinding("tb", "namespace",
+					bldr.TriggerBindingSpec(
+						bldr.TriggerBindingParam("param1", "foo"),
 					),
 				),
-				TriggerBindings: []*triggersv1.TriggerBinding{
-					bldr.TriggerBinding("tb", "namespace",
-						bldr.TriggerBindingSpec(
-							bldr.TriggerBindingParam("param1", "foo"),
-						),
+				bldr.TriggerBinding("tb2", "namespace",
+					bldr.TriggerBindingSpec(
+						bldr.TriggerBindingParam("param1", "bar"),
 					),
-					bldr.TriggerBinding("tb2", "namespace",
-						bldr.TriggerBindingSpec(
-							bldr.TriggerBindingParam("param1", "bar"),
-						),
-					),
-				},
+				),
 			},
 		},
+	},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/template/jsonpath.go
+++ b/pkg/template/jsonpath.go
@@ -1,0 +1,156 @@
+package template
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"k8s.io/client-go/third_party/forked/golang/template"
+	"k8s.io/client-go/util/jsonpath"
+)
+
+var (
+	// tektonVar captures strings that are enclosed in $()
+	tektonVar = regexp.MustCompile(`\$\(?([^\)]+)\)`)
+
+	// jsonRegexp is a regular expression for JSONPath expressions
+	// with or without the enclosing {} and the leading . inside the curly
+	// braces e.g.  'a.b' or '.a.b' or '{a.b}' or '{.a.b}'
+	jsonRegexp = regexp.MustCompile(`^\{\.?([^{}]+)\}$|^\.?([^{}]+)$`)
+)
+
+// ParseJSONPath extracts a subset of the given JSON input
+// using the provided JSONPath expression.
+func ParseJSONPath(input interface{}, expr string) (string, error) {
+	j := jsonpath.New("").AllowMissingKeys(false)
+	buf := new(bytes.Buffer)
+
+	//First turn the expression into fully valid JSONPath
+	expr, err := TektonJSONPathExpression(expr)
+	if err != nil {
+		return "", err
+	}
+
+	if err := j.Parse(expr); err != nil {
+		return "", err
+	}
+
+	fullResults, err := j.FindResults(input)
+	if err != nil {
+		return "", err
+	}
+
+	for _, r := range fullResults {
+		if err := printResults(buf, r); err != nil {
+			return "", err
+		}
+	}
+
+	return buf.String(), nil
+}
+
+// PrintResults writes the results into writer
+// This is a slightly modified copy of the original
+// j.PrintResults from k8s.io/client-go/util/jsonpath/jsonpath.go
+// in that it uses calls `textValue()` for instead of `evalToText`
+// This is a workaround for kubernetes/kubernetes#16707
+func printResults(wr io.Writer, results []reflect.Value) error {
+	for i, r := range results {
+		text, err := textValue(r)
+		if err != nil {
+			return err
+		}
+		if i != len(results)-1 {
+			text = append(text, ' ')
+		}
+		if _, err := wr.Write(text); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// textValue translates reflect value to corresponding text
+// If the value if an array or map, it returns a JSON representation
+// of the value (as opposed to the internal go representation of the value)
+// Otherwise, the text value is from the `evalToText` function, originally from
+// k8s.io/client-go/util/jsonpath/jsonpath.go
+func textValue(v reflect.Value) ([]byte, error) {
+	t := reflect.TypeOf(v.Interface())
+	// special case for null values in JSON; evalToText() returns <nil> here
+	if t == nil {
+		return []byte("null"), nil
+	}
+
+	switch t.Kind() {
+	// evalToText() returns <map> ....; return JSON string instead.
+	case reflect.Map, reflect.Slice:
+		return json.Marshal(v.Interface())
+	default:
+		return evalToText(v)
+	}
+}
+
+// evalToText translates reflect value to corresponding text
+// This is a unmodified copy of j.evalToText from k8s.io/client-go/util/jsonpath/jsonpath.go
+func evalToText(v reflect.Value) ([]byte, error) {
+	iface, ok := template.PrintableValue(v)
+	if !ok {
+		// only happens if v is a Chan or a Func
+		return nil, fmt.Errorf("can't print type %s", v.Type())
+	}
+	var buffer bytes.Buffer
+	fmt.Fprint(&buffer, iface)
+	return buffer.Bytes(), nil
+}
+
+// TektonJSONPathExpression returns a valid JSONPath expression. It accepts
+// a "RelaxedJSONPath" expression that is wrapped in the Tekton variable
+// interpolation syntax i.e. $(). RelaxedJSONPath expressions can optionally
+// omit the leading curly braces '{}' and '.'
+func TektonJSONPathExpression(expr string) (string, error) {
+	if !isTektonExpr(expr) {
+		return "", errors.New("expression not wrapped in $()")
+	}
+	unwrapped := strings.TrimSuffix(strings.TrimPrefix(expr, "$("), ")")
+	return relaxedJSONPathExpression(unwrapped)
+}
+
+// RelaxedJSONPathExpression attempts to be flexible with JSONPath expressions, it accepts:
+//   * metadata.name (no leading '.' or curly braces '{...}'
+//   * {metadata.name} (no leading '.')
+//   * .metadata.name (no curly braces '{...}')
+//   * {.metadata.name} (complete expression)
+// And transforms them all into a valid jsonpath expression:
+//   {.metadata.name}
+// This function has been copied as-is from
+// https://github.com/kubernetes/kubectl/blob/c273777957bd657233cf867892fb061a6498dab8/pkg/cmd/get/customcolumn.go#L47
+func relaxedJSONPathExpression(pathExpression string) (string, error) {
+	if len(pathExpression) == 0 {
+		return pathExpression, nil
+	}
+	submatches := jsonRegexp.FindStringSubmatch(pathExpression)
+	if submatches == nil {
+		return "", fmt.Errorf("unexpected path string, expected a 'name1.name2' or '.name1.name2' or '{name1.name2}' or '{.name1.name2}'")
+	}
+	if len(submatches) != 3 {
+		return "", fmt.Errorf("unexpected submatch list: %v", submatches)
+	}
+	var fieldSpec string
+	if len(submatches[1]) != 0 {
+		fieldSpec = submatches[1]
+	} else {
+		fieldSpec = submatches[2]
+	}
+	return fmt.Sprintf("{.%s}", fieldSpec), nil
+}
+
+// IsTektonExpr returns true if the expr is wrapped in $()
+func isTektonExpr(expr string) bool {
+	return tektonVar.MatchString(expr)
+}

--- a/pkg/template/jsonpath_test.go
+++ b/pkg/template/jsonpath_test.go
@@ -77,8 +77,7 @@ func TestParseJSONPath(t *testing.T) {
 			}
 			got, err := ParseJSONPath(data, tt.expr)
 			if err != nil {
-				t.Errorf("ParseJSONPath() error = %v", err)
-				return
+				t.Fatalf("ParseJSONPath() error = %v", err)
 			}
 			if diff := cmp.Diff(strings.Replace(tt.want, " ", "", -1), got); diff != "" {
 				t.Errorf("ParseJSONPath() -want,+got: %s", diff)
@@ -103,7 +102,6 @@ func TestParseJSONPath_Error(t *testing.T) {
 	err := json.Unmarshal([]byte(testJSON), &data)
 	if err != nil {
 		t.Fatalf("Could not unmarshall body : %q", err)
-		return
 	}
 
 	for _, expr := range invalidExprs {

--- a/pkg/template/jsonpath_test.go
+++ b/pkg/template/jsonpath_test.go
@@ -1,0 +1,201 @@
+package template
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var objects = `{"a":"v","c":{"d":"e"},"empty": "","null": null, "number": 42}`
+var arrays = `[{"a": "b"}, {"c": "d"}, {"e": "f"}]`
+
+// Checks that we print JSON strings when the JSONPath selects
+// an array or map value and regular values otherwise
+func TestParseJSONPath(t *testing.T) {
+	var objectBody = fmt.Sprintf(`{"body":%s}`, objects)
+	tests := []struct {
+		name string
+		expr string
+		in   string
+		want string
+	}{{
+		name: "objects",
+		in:   objectBody,
+		expr: "$(body)",
+		// TODO: Do we need to escape backslashes for backwards compat?
+		want: objects,
+	}, {
+		name: "array of objects",
+		in:   fmt.Sprintf(`{"body":%s}`, arrays),
+		expr: "$(body)",
+		want: arrays,
+	}, {
+		name: "array of values",
+		in:   `{"body": ["a", "b", "c"]}`,
+		expr: "$(body)",
+		want: `["a", "b", "c"]`,
+	}, {
+		name: "string values",
+		in:   objectBody,
+		expr: "$(body.a)",
+		want: "v",
+	}, {
+		name: "string values",
+		in:   objectBody,
+		expr: "$(body.a)",
+		want: "v",
+	}, {
+		name: "empty string",
+		in:   objectBody,
+		expr: "$(body.empty)",
+		want: "",
+	}, {
+		name: "numbers",
+		in:   objectBody,
+		expr: "$(body.number)",
+		want: "42",
+	}, {
+		name: "booleans",
+		in:   `{"body": {"bool": true}}`,
+		expr: "$(body.bool)",
+		want: "true",
+	}, {
+		name: "null values",
+		in:   objectBody,
+		expr: "$(body.null)",
+		want: "null",
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var data interface{}
+			err := json.Unmarshal([]byte(tt.in), &data)
+			if err != nil {
+				t.Fatalf("Could not unmarshall body : %q", err)
+			}
+			got, err := ParseJSONPath(data, tt.expr)
+			if err != nil {
+				t.Errorf("ParseJSONPath() error = %v", err)
+				return
+			}
+			if diff := cmp.Diff(strings.Replace(tt.want, " ", "", -1), got); diff != "" {
+				t.Errorf("ParseJSONPath() -want,+got: %s", diff)
+			}
+		})
+	}
+}
+
+func TestParseJSONPath_Error(t *testing.T) {
+	testJSON := `{"body": {"key": "val"}}`
+	invalidExprs := []string{
+		"$({.hello)",
+		"$(+12.3.0)",
+		"$([1)",
+		"$(body",
+		"body)",
+		"body",
+		"$(body.missing)",
+		"$(body.key[0])",
+	}
+	var data interface{}
+	err := json.Unmarshal([]byte(testJSON), &data)
+	if err != nil {
+		t.Fatalf("Could not unmarshall body : %q", err)
+		return
+	}
+
+	for _, expr := range invalidExprs {
+		t.Run(expr, func(t *testing.T) {
+			got, err := ParseJSONPath(data, expr)
+			if err == nil {
+				t.Errorf("ParseJSONPath() did not return expected error; got = %v", got)
+			}
+		})
+	}
+}
+
+func TestTektonJSONPathExpression(t *testing.T) {
+	tests := []struct {
+		expr string
+		want string
+	}{
+		{"$(metadata.name)", "{.metadata.name}"},
+		{"$(.metadata.name)", "{.metadata.name}"},
+		{"$({.metadata.name})", "{.metadata.name}"},
+		{"$()", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expr, func(t *testing.T) {
+			got, err := TektonJSONPathExpression(tt.expr)
+			if err != nil {
+				t.Errorf("TektonJSONPathExpression() unexpected error = %v,  got = %v", err, got)
+			}
+			if got != tt.want {
+				t.Errorf("TektonJSONPathExpression() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTektonJSONPathExpression_Error(t *testing.T) {
+	tests := []string{
+		"{.metadata.name}", // not wrapped in $()
+		"",
+		"$({asd)",
+		"$({)",
+		"$({foo.bar)",
+		"$(foo.bar})",
+		"$({foo.bar}})",
+		"$({{foo.bar)",
+	}
+	for _, expr := range tests {
+		t.Run(expr, func(t *testing.T) {
+			_, err := TektonJSONPathExpression(expr)
+			if err == nil {
+				t.Errorf("TektonJSONPathExpression() did not get expected error for expression = %s", expr)
+			}
+		})
+	}
+}
+
+func TestRelaxedJSONPathExpression(t *testing.T) {
+	tests := []struct {
+		expr string
+		want string
+	}{
+		{"metadata.name", "{.metadata.name}"},
+		{".metadata.name", "{.metadata.name}"},
+		{"{.metadata.name}", "{.metadata.name}"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expr, func(t *testing.T) {
+			got, err := relaxedJSONPathExpression(tt.expr)
+			if err != nil {
+				t.Errorf("TektonJSONPathExpression() unexpected error = %v,  got = %v", err, got)
+			}
+			if got != tt.want {
+				t.Errorf("TektonJSONPathExpression() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRelaxedJSONPathExpression_Error(t *testing.T) {
+	tests := []string{
+		"{foo.bar",
+		"foo.bar}",
+		"{foo.bar}}",
+		"{{foo.bar}",
+	}
+	for _, expr := range tests {
+		t.Run(expr, func(t *testing.T) {
+			got, err := relaxedJSONPathExpression(expr)
+			if err == nil {
+				t.Errorf("TektonJSONPathExpression() did not get expected error = %v,  got = %v", err, got)
+			}
+		})
+	}
+}

--- a/pkg/template/resource.go
+++ b/pkg/template/resource.go
@@ -20,10 +20,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
-	"golang.org/x/xerrors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -49,7 +49,7 @@ func ResolveTrigger(trigger triggersv1.EventListenerTrigger, getTB getTriggerBin
 	for _, b := range trigger.Bindings {
 		tb2, err := getTB(b.Name, metav1.GetOptions{})
 		if err != nil {
-			return ResolvedTrigger{}, xerrors.Errorf("error getting TriggerBinding %s: %s", b.Name, err)
+			return ResolvedTrigger{}, fmt.Errorf("error getting TriggerBinding %s: %w", b.Name, err)
 		}
 		tb = append(tb, tb2)
 	}
@@ -57,7 +57,7 @@ func ResolveTrigger(trigger triggersv1.EventListenerTrigger, getTB getTriggerBin
 	ttName := trigger.Template.Name
 	tt, err := getTT(ttName, metav1.GetOptions{})
 	if err != nil {
-		return ResolvedTrigger{}, xerrors.Errorf("Error getting TriggerTemplate %s: %s", ttName, err)
+		return ResolvedTrigger{}, fmt.Errorf("error getting TriggerTemplate %s: %w", ttName, err)
 	}
 	return ResolvedTrigger{TriggerBindings: tb, TriggerTemplate: tt}, nil
 }
@@ -92,7 +92,10 @@ func ApplyParamsToResourceTemplate(params []pipelinev1.Param, rt json.RawMessage
 func applyParamToResourceTemplate(param pipelinev1.Param, rt json.RawMessage) json.RawMessage {
 	// Assume the param is valid
 	paramVariable := fmt.Sprintf("$(params.%s)", param.Name)
-	return bytes.Replace(rt, []byte(paramVariable), []byte(param.Value.StringVal), -1)
+	// Escape quotes so that that JSON strings can be appended to regular strings.
+	// See #257 for discussion on this behavior.
+	paramValue := strings.Replace(param.Value.StringVal, `"`, `\"`, -1)
+	return bytes.Replace(rt, []byte(paramVariable), []byte(paramValue), -1)
 }
 
 // UID generates a random string like the Kubernetes apiserver generateName metafield postfix.

--- a/pkg/template/resource_test.go
+++ b/pkg/template/resource_test.go
@@ -176,6 +176,18 @@ func Test_applyParamToResourceTemplate(t *testing.T) {
 				rt:    rtMultipleParamVars,
 			},
 			want: wantRtMultipleParamVars,
+		}, {
+			name: "espcae quotes in param val",
+			args: args{
+				param: pipelinev1.Param{
+					Name: "p1",
+					Value: pipelinev1.ArrayOrString{
+						StringVal: `{"a":"b"}`,
+					},
+				},
+				rt: json.RawMessage(`{"foo": "$(params.p1)"}`),
+			},
+			want: json.RawMessage(`{"foo": "{\"a\":\"b\"}"}`),
 		},
 	}
 	for _, tt := range tests {

--- a/test/eventlistener_test.go
+++ b/test/eventlistener_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net/http"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -244,8 +245,8 @@ func TestEventListenerCreate(t *testing.T) {
 		Spec: v1alpha1.PipelineResourceSpec{
 			Type: "git",
 			Params: []v1alpha1.ResourceParam{
-				{Name: "body", Value: `{"one": "zonevalue", "two": {"name": "zfoo", "value": "bar"}}`},
-				{Name: "header", Value: `{"Accept-Encoding":["gzip"],"Content-Length":["61"],"Content-Type":["application/json"],"User-Agent":["Go-http-client/1.1"]}`},
+				{Name: "body", Value: strings.Replace(`{"one": "zonevalue", "two": {"name": "zfoo", "value": "bar"}}`, " ", "", -1)},
+				{Name: "header", Value: `{"Accept-Encoding":"gzip","Content-Length":"61","Content-Type":"application/json","User-Agent":"Go-http-client/1.1"}`},
 			},
 		},
 	}


### PR DESCRIPTION
# Changes
There are two commits in this PR. The first commit adds functions for JSONPath and the second one uses those functions to extract values for EventBinding.

Commits:
This commit adds functions to support JSONPath
in `TriggerBindings` using the `k8s.io/client-go/util/jsonpath`
library.

There are a few deviations from the default behavior of the library:

1. The JSONPath expressions have to be wrapped in the Tekton variable
interpolation syntax i.e `$()` : `$(body)`.

2.  We  support the `RelaxedJSONPathExpresion` syntax used in
`kubectl get -o custom-columns`. This means that the curly braces `{}`
and the leading dot `.` can be omitted i.e we support both `$(body.key)`
as well as `$({.body.key})

3. We return valid JSON values when the value is a JSON array or
map. By default, the library returns a string containing an internal
go representation. So, if the JSONPath expression selects `{"a": "b"}`,
the library will return `map[a: b]` while we return the valid JSON
string i.e `{"a":"b"}`

This commit switches TriggerBinding params to use
JSONPath instead of GJSON.

Part of #178 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
TriggerBindings now support JSONPath expressions instead of GJSON. Check docs/triggerbindings.md for the syntax and examples

```
