### PR TITLE
Migrate EventListeners with binding to bindings

### DIFF
--- a/pkg/apis/triggers/v1alpha1/contexts.go
+++ b/pkg/apis/triggers/v1alpha1/contexts.go
@@ -1,0 +1,22 @@
+package v1alpha1
+
+import "context"
+
+// upgradeViaDefaultingKey is used as the key in a context.Context.
+// This variable doesn't really matter, so it can be a total random name.
+// Setting this key indicates that default values for a resource should be
+// updated to new values. This is used to ensure non breaking updates when
+// a default value of a resource changes or when a field is removed.
+type upgradeViaDefaultingKey struct{}
+
+// WithUpgradeViaDefaulting sets the upgradeViaDefaultingKey on the context
+// indicating that default values for a resource should be updated to new values.
+func WithUpgradeViaDefaulting(ctx context.Context) context.Context {
+	return context.WithValue(ctx, upgradeViaDefaultingKey{}, struct{}{})
+}
+
+// IsUpgradeViaDefaulting checks if the upgradeViaDefaultingKey is set on
+// the context.
+func IsUpgradeViaDefaulting(ctx context.Context) bool {
+	return ctx.Value(upgradeViaDefaultingKey{}) != nil
+}

--- a/pkg/apis/triggers/v1alpha1/event_listener_defaults.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_defaults.go
@@ -5,4 +5,22 @@ import (
 )
 
 // SetDefaults sets the defaults on the object.
-func (el *EventListener) SetDefaults(ctx context.Context) {}
+func (el *EventListener) SetDefaults(ctx context.Context) {
+	if IsUpgradeViaDefaulting(ctx) {
+		// Most likely the EventListener passed here is already running
+		for i := range el.Spec.Triggers {
+			t := &el.Spec.Triggers[i]
+			if t.DeprecatedBinding != nil {
+				if len(t.Bindings) > 0 {
+					// Do nothing since it will be a Validaiton Error.
+				} else {
+					// Set the binding to bindings
+					t.Bindings = append(t.Bindings, &EventListenerBinding{
+						Name: t.DeprecatedBinding.Name,
+					})
+					t.DeprecatedBinding = nil
+				}
+			}
+		}
+	}
+}

--- a/pkg/apis/triggers/v1alpha1/event_listener_defaults_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_defaults_test.go
@@ -1,0 +1,121 @@
+package v1alpha1_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+)
+
+func TestEventListenerSetDefaults(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *v1alpha1.EventListener
+		want *v1alpha1.EventListener
+		wc   func(context.Context) context.Context
+	}{{
+		name: "with upgrade context - binding present",
+		in: &v1alpha1.EventListener{
+			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					DeprecatedBinding: &v1alpha1.EventListenerBinding{
+						Name: "my-binding",
+					},
+				}},
+			},
+		},
+		want: &v1alpha1.EventListener{
+			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					Bindings: []*v1alpha1.EventListenerBinding{{
+						Name: "my-binding",
+					}},
+				}},
+			},
+		},
+		wc: v1alpha1.WithUpgradeViaDefaulting,
+	}, {
+		name: "with upgrade context - no binding present",
+		in: &v1alpha1.EventListener{
+			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					Bindings: []*v1alpha1.EventListenerBinding{{
+						Name: "my-binding",
+					}},
+				}},
+			},
+		},
+		want: &v1alpha1.EventListener{
+			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					Bindings: []*v1alpha1.EventListenerBinding{{
+						Name: "my-binding",
+					}},
+				}},
+			},
+		},
+		wc: v1alpha1.WithUpgradeViaDefaulting,
+	}, {
+		name: "with upgrade context - both binding and bindings present",
+		in: &v1alpha1.EventListener{
+			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					DeprecatedBinding: &v1alpha1.EventListenerBinding{
+						Name: "my-binding-1",
+					},
+					Bindings: []*v1alpha1.EventListenerBinding{{
+						Name: "my-binding",
+					}},
+				}},
+			},
+		},
+		want: &v1alpha1.EventListener{
+			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					DeprecatedBinding: &v1alpha1.EventListenerBinding{
+						Name: "my-binding-1",
+					},
+					Bindings: []*v1alpha1.EventListenerBinding{{
+						Name: "my-binding",
+					}},
+				}},
+			},
+		},
+		wc: v1alpha1.WithUpgradeViaDefaulting,
+	}, {
+		name: "no upgrade context",
+		in: &v1alpha1.EventListener{
+			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					DeprecatedBinding: &v1alpha1.EventListenerBinding{
+						Name: "my-binding",
+					},
+				}},
+			},
+		},
+		want: &v1alpha1.EventListener{
+			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					DeprecatedBinding: &v1alpha1.EventListenerBinding{
+						Name: "my-binding",
+					},
+				}},
+			},
+		},
+	}}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.in
+			ctx := context.Background()
+			if tc.wc != nil {
+				ctx = tc.wc(ctx)
+			}
+			got.SetDefaults(ctx)
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("SetDefaults (-want, +got) = %v", diff)
+			}
+		})
+	}
+}

--- a/pkg/apis/triggers/v1alpha1/event_listener_types.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_types.go
@@ -31,6 +31,7 @@ import (
 
 // Check that EventListener may be validated and defaulted.
 var _ apis.Validatable = (*EventListener)(nil)
+var _ apis.Defaultable = (*EventListener)(nil)
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -66,8 +67,11 @@ type EventListenerTrigger struct {
 	// +optional
 	Name string `json:"name,omitempty"`
 	// +optional
-	// TODO(dibyom): Allow multiple interceptors
+	// TODO(#249): Allow multiple interceptors
 	Interceptor *EventInterceptor `json:"interceptor,omitempty"`
+
+	// TODO(#248): Remove this before 0.3 release
+	DeprecatedBinding *EventListenerBinding `json:"binding,omitempty"`
 }
 
 // EventInterceptor provides a hook to intercept and pre-process events

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
@@ -12,7 +12,7 @@ import (
 	fakedynamicclient "k8s.io/client-go/dynamic/fake"
 )
 
-func Test_EventListenerValidate_error(t *testing.T) {
+func Test_EventListenerValidate(t *testing.T) {
 	tests := []struct {
 		name     string
 		el       *v1alpha1.EventListener
@@ -22,6 +22,22 @@ func Test_EventListenerValidate_error(t *testing.T) {
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tb", "dne", "v1alpha1"))),
+		raiseErr: true,
+	}, {
+		name: "Both Binding and Bindings Present",
+		el: &v1alpha1.EventListener{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					Bindings:          []*v1alpha1.EventListenerBinding{{Name: "tb"}},
+					DeprecatedBinding: &v1alpha1.EventListenerBinding{Name: "bar"},
+					Template:          v1alpha1.EventListenerTemplate{Name: "tt"},
+				}},
+			},
+		},
 		raiseErr: true,
 	}, {
 		name: "Interceptor Does Not Exist",

--- a/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
@@ -230,6 +230,11 @@ func (in *EventListenerTrigger) DeepCopyInto(out *EventListenerTrigger) {
 		*out = new(EventInterceptor)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.DeprecatedBinding != nil {
+		in, out := &in.DeprecatedBinding, &out.DeprecatedBinding
+		*out = new(EventListenerBinding)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
@@ -125,6 +125,10 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) (returnError err
 }
 
 func (c *Reconciler) reconcile(ctx context.Context, el *v1alpha1.EventListener) error {
+	// We may be reading a version of the object that was stored at an older version
+	// and may not have had all of the assumed default specified.
+	el.SetDefaults(v1alpha1.WithUpgradeViaDefaulting(ctx))
+
 	// TODO(dibyom): Once #70 is merged, we should validate triggerTemplate here
 	// and update the StatusCondition
 

--- a/pkg/template/resource.go
+++ b/pkg/template/resource.go
@@ -42,7 +42,7 @@ type ResolvedTrigger struct {
 type getTriggerBinding func(name string, options metav1.GetOptions) (*triggersv1.TriggerBinding, error)
 type getTriggerTemplate func(name string, options metav1.GetOptions) (*triggersv1.TriggerTemplate, error)
 
-// ResolveBindings takes in a trigger containing object refs to bindings and
+// ResolveTrigger takes in a trigger containing object refs to bindings and
 // templates and resolves them to their underlying values.
 func ResolveTrigger(trigger triggersv1.EventListenerTrigger, getTB getTriggerBinding, getTT getTriggerTemplate) (ResolvedTrigger, error) {
 	tb := make([]*triggersv1.TriggerBinding, 0, len(trigger.Bindings))

--- a/third_party/VENDOR-LICENSE
+++ b/third_party/VENDOR-LICENSE
@@ -7517,3 +7517,4 @@ Import: github.com/tektoncd/triggers/vendor/knative.dev/pkg
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+


### PR DESCRIPTION
# Changes

After the 0.1 release, we replaced the `binding` field
with `bindings`. This commit migrates those to use the
`bindings` field. Without this, users who perform a controller
upgrade from the 0.1 release will not be able to update any
existing `EventListeners` i.e. they would have to delete and
recreate.

/cc @vdemeester @afrittoli @wlynch 
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._
