### PR TITLE
Delete config maps

### DIFF
--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/cache"
 
@@ -45,11 +46,15 @@ const (
 	eventListenerAgentName = "eventlistener-controller"
 	// eventListenerControllerName defines name for EventListener Controller
 	eventListenerControllerName = "EventListener"
+	// eventListenerConfigMapName is for the automatically created ConfigMap
+	eventListenerConfigMapName = "config-logging-triggers"
 	// Port defines the port for the EventListener to listen on
 	Port = 8080
 	// GeneratedResourcePrefix is the name prefix for resources generated in the
 	// EventListener reconciler
 	GeneratedResourcePrefix = "el"
+
+	defaultConfig = `{"level": "info","development": false,"sampling": {"initial": 100,"thereafter": 100},"outputPaths": ["stdout"],"errorOutputPaths": ["stderr"],"encoding": "json","encoderConfig": {"timeKey": "","levelKey": "level","nameKey": "logger","callerKey": "caller","messageKey": "msg","stacktraceKey": "stacktrace","lineEnding": "","levelEncoder": "","timeEncoder": "","durationEncoder": "","callerEncoder": ""}}`
 )
 
 var (
@@ -97,7 +102,18 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) (returnError err
 	if errors.IsNotFound(err) {
 		// The resource no longer exists, in which case we stop processing.
 		c.Logger.Infof("EventListener %q in work queue no longer exists", key)
-		return nil
+		cfgs, err := c.eventListenerLister.EventListeners(namespace).List(labels.Everything())
+		if err != nil {
+			return err
+		}
+		if len(cfgs) > 0 {
+			return nil
+		}
+		err = c.KubeClientSet.CoreV1().ConfigMaps(namespace).Delete(eventListenerConfigMapName, &metav1.DeleteOptions{})
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
 	} else if err != nil {
 		c.Logger.Errorf("Error retrieving EventListener %q: %s", name, err)
 		return err
@@ -209,47 +225,16 @@ func (c *Reconciler) reconcileService(el *v1alpha1.EventListener) error {
 }
 
 func (c *Reconciler) reconcileLoggingConfig(el *v1alpha1.EventListener) error {
-	_, err := c.KubeClientSet.CoreV1().ConfigMaps(el.Namespace).Get("config-logging-triggers", metav1.GetOptions{})
+	_, err := c.KubeClientSet.CoreV1().ConfigMaps(el.Namespace).Get(eventListenerConfigMapName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		// create default config-logging ConfigMap
-		_, err = c.KubeClientSet.CoreV1().ConfigMaps(el.Namespace).Create(
-			&corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Name: "config-logging-triggers"},
-				Data: map[string]string{
-					"loglevel.eventlistener": "info",
-					"zap-logger-config": "{" +
-						"\"level\": \"info\"," +
-						"\"developmen\": false," +
-						"\"sampling\": {" +
-						"\"initial\": 100," +
-						"\"thereafter\": 100" +
-						"}," +
-						"\"outputPaths\": [\"stdout\"]," +
-						"\"errorOutputPaths\": [\"stderr\"]," +
-						"\"encoding\": \"json\"," +
-						"\"encoderConfig\": {" +
-						"\"timeKey\": \"\"," +
-						"\"levelKey\": \"level\"," +
-						"\"nameKey\": \"logger\"," +
-						"\"callerKey\": \"caller\"," +
-						"\"messageKey\": \"msg\"," +
-						"\"stacktraceKey\": \"stacktrace\"," +
-						"\"lineEnding\": \"\"," +
-						"\"levelEncoder\": \"\"," +
-						"\"timeEncoder\": \"\"," +
-						"\"durationEncoder\": \"\"," +
-						"\"callerEncoder\": \"\"" +
-						"}" +
-						"}",
-				},
-			},
-		)
+		_, err = c.KubeClientSet.CoreV1().ConfigMaps(el.Namespace).Create(defaultLoggingConfigMap())
 		if err != nil {
 			c.Logger.Errorf("Failed to create logging config: %s.  EventListener won't start.", err)
 			return err
 		}
 	} else if err != nil {
-		c.Logger.Errorf("Error retrieving ConfigMap %q: %s", "config-logging-triggers", err)
+		c.Logger.Errorf("Error retrieving ConfigMap %q: %s", eventListenerConfigMapName, err)
 		return err
 	}
 	return nil
@@ -317,7 +302,7 @@ func (c *Reconciler) reconcileDeployment(el *v1alpha1.EventListener) error {
 							VolumeSource: corev1.VolumeSource{
 								ConfigMap: &corev1.ConfigMapVolumeSource{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "config-logging-triggers",
+										Name: eventListenerConfigMapName,
 									},
 								},
 							},
@@ -448,4 +433,14 @@ func wrapError(err1, err2 error) error {
 // listenerHostname returns the intended hostname for the EventListener service.
 func listenerHostname(name, namespace string, port int) string {
 	return fmt.Sprintf("%s.%s.svc.cluster.local:%d", name, namespace, port)
+}
+
+func defaultLoggingConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: eventListenerConfigMapName},
+		Data: map[string]string{
+			"loglevel.eventlistener": "info",
+			"zap-logger-config":      defaultConfig,
+		},
+	}
 }

--- a/test/controller_test.go
+++ b/test/controller_test.go
@@ -74,6 +74,12 @@ func TestGetResourcesFromClients(t *testing.T) {
 			Name:      "my-service2",
 		},
 	}
+	configMap1 := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+			Name:      "my-config-map-1",
+		},
+	}
 
 	tests := []struct {
 		name      string
@@ -126,6 +132,13 @@ func TestGetResourcesFromClients(t *testing.T) {
 			Resources: Resources{
 				Namespaces: []*corev1.Namespace{nsFoo, nsTektonPipelines},
 				Services:   []*corev1.Service{service1},
+			},
+		},
+		{
+			name: "only ConfigMaps (and namespaces)",
+			Resources: Resources{
+				Namespaces: []*corev1.Namespace{nsFoo, nsTektonPipelines},
+				ConfigMaps: []*corev1.ConfigMap{configMap1},
 			},
 		},
 	}


### PR DESCRIPTION
# Changes

This triggers a deletion of the automatically created logging config map when there are no more event-listeners in the namespace.

Fixes #209

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
- The automatically created logging config-map is now deleted when there are no more event-listeners in a namespace.
```