### PR TITLE
Add more linters 🤾

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,4 +3,12 @@ run:
   - e2e
   skip-dirs:
   - vendor
-  - pkg/client/clientset/versioned/fake
+  - pkg/client/clientset/(.*)/fake
+linters:
+  enable:
+  - errcheck
+  - gofmt
+  - goimports
+  - gosec
+  - gocritic
+  - golint

--- a/cmd/eventlistenersink/main.go
+++ b/cmd/eventlistenersink/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-		http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,9 +18,10 @@ package main
 
 import (
 	"fmt"
-	"go.uber.org/zap"
 	"log"
 	"net/http"
+
+	"go.uber.org/zap"
 
 	"github.com/tektoncd/triggers/pkg/logging"
 	"github.com/tektoncd/triggers/pkg/sink"

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
@@ -176,8 +176,7 @@ func Test_EventListenerValidate_error(t *testing.T) {
 	)
 
 	dynamicClient := fakedynamicclient.NewSimpleDynamicClient(scheme, tb, tt, svc)
-	ctx := context.TODO()
-	ctx = context.WithValue(ctx, "clientSet", dynamicClient)
+	ctx := v1alpha1.WithClientSet(context.TODO(), dynamicClient)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			err := test.el.Validate(ctx)

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -18,13 +18,14 @@ package logging
 
 import (
 	"flag"
+	"log"
+
 	"github.com/tektoncd/pipeline/pkg/system"
 	"go.uber.org/zap"
 	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/logging/logkey"
-	"log"
 )
 
 // Configure logging

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
@@ -87,8 +87,8 @@ var (
 )
 
 // getEventListenerTestAssets returns TestAssets that have been seeded with the
-// given TestResources r where r represents the state of the system
-func getEventListenerTestAssets(t *testing.T, r test.TestResources) (test.TestAssets, context.CancelFunc) {
+// given test.Resources r where r represents the state of the system
+func getEventListenerTestAssets(t *testing.T, r test.Resources) (test.Assets, context.CancelFunc) {
 	t.Helper()
 	ctx, _ := rtesting.SetupFakeContext(t)
 	ctx, cancel := context.WithCancel(ctx)
@@ -108,9 +108,9 @@ func getEventListenerTestAssets(t *testing.T, r test.TestResources) (test.TestAs
 			// Pass modified resource and react using the default catch all reactor
 			return kubeClient.ReactionChain[len(kubeClient.ReactionChain)-1].React(action)
 		})
-	clients := test.SeedTestResources(t, ctx, r)
+	clients := test.SeedResources(t, ctx, r)
 	cmw := configmap.NewInformedWatcher(clients.Kube, system.GetNamespace())
-	return test.TestAssets{
+	return test.Assets{
 		Controller: NewController(ctx, cmw),
 		Clients:    clients,
 	}, cancel
@@ -147,40 +147,40 @@ func Test_reconcileService(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		startResources test.TestResources
-		endResources   test.TestResources
+		startResources test.Resources
+		endResources   test.Resources
 	}{
 		{
 			name: "create-service",
-			startResources: test.TestResources{
+			startResources: test.Resources{
 				Namespaces:     []*corev1.Namespace{namespaceResource},
 				EventListeners: []*v1alpha1.EventListener{eventListener0},
 			},
-			endResources: test.TestResources{
+			endResources: test.Resources{
 				EventListeners: []*v1alpha1.EventListener{eventListener1},
 				Services:       []*corev1.Service{service1},
 			},
 		},
 		{
 			name: "eventlistener-label-update",
-			startResources: test.TestResources{
+			startResources: test.Resources{
 				Namespaces:     []*corev1.Namespace{namespaceResource},
 				EventListeners: []*v1alpha1.EventListener{eventListener2},
 				Services:       []*corev1.Service{service1},
 			},
-			endResources: test.TestResources{
+			endResources: test.Resources{
 				EventListeners: []*v1alpha1.EventListener{eventListener2},
 				Services:       []*corev1.Service{service2},
 			},
 		},
 		{
 			name: "service-label-update",
-			startResources: test.TestResources{
+			startResources: test.Resources{
 				Namespaces:     []*corev1.Namespace{namespaceResource},
 				EventListeners: []*v1alpha1.EventListener{eventListener1},
 				Services:       []*corev1.Service{service2},
 			},
-			endResources: test.TestResources{
+			endResources: test.Resources{
 				Namespaces:     []*corev1.Namespace{namespaceResource},
 				EventListeners: []*v1alpha1.EventListener{eventListener1},
 				Services:       []*corev1.Service{service1},
@@ -188,12 +188,12 @@ func Test_reconcileService(t *testing.T) {
 		},
 		{
 			name: "service-nodeport-update",
-			startResources: test.TestResources{
+			startResources: test.Resources{
 				Namespaces:     []*corev1.Namespace{namespaceResource},
 				EventListeners: []*v1alpha1.EventListener{eventListener1},
 				Services:       []*corev1.Service{service3},
 			},
-			endResources: test.TestResources{
+			endResources: test.Resources{
 				Namespaces:     []*corev1.Namespace{namespaceResource},
 				EventListeners: []*v1alpha1.EventListener{eventListener1},
 				Services:       []*corev1.Service{service3},
@@ -213,7 +213,7 @@ func Test_reconcileService(t *testing.T) {
 				return
 			}
 			// Grab test resource results
-			actualEndResources, err := test.GetTestResourcesFromClients(testAssets.Clients)
+			actualEndResources, err := test.GetResourcesFromClients(testAssets.Clients)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -335,16 +335,16 @@ func Test_reconcileDeployment(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		startResources test.TestResources
-		endResources   test.TestResources
+		startResources test.Resources
+		endResources   test.Resources
 	}{
 		{
 			name: "create-deployment",
-			startResources: test.TestResources{
+			startResources: test.Resources{
 				Namespaces:     []*corev1.Namespace{namespaceResource},
 				EventListeners: []*v1alpha1.EventListener{eventListener0},
 			},
-			endResources: test.TestResources{
+			endResources: test.Resources{
 				Namespaces:     []*corev1.Namespace{namespaceResource},
 				EventListeners: []*v1alpha1.EventListener{eventListener1},
 				Deployments:    []*appsv1.Deployment{deployment1},
@@ -352,12 +352,12 @@ func Test_reconcileDeployment(t *testing.T) {
 		},
 		{
 			name: "eventlistener-label-update",
-			startResources: test.TestResources{
+			startResources: test.Resources{
 				Namespaces:     []*corev1.Namespace{namespaceResource},
 				EventListeners: []*v1alpha1.EventListener{eventListener2},
 				Deployments:    []*appsv1.Deployment{deployment1},
 			},
-			endResources: test.TestResources{
+			endResources: test.Resources{
 				Namespaces:     []*corev1.Namespace{namespaceResource},
 				EventListeners: []*v1alpha1.EventListener{eventListener2},
 				Deployments:    []*appsv1.Deployment{deployment2},
@@ -365,12 +365,12 @@ func Test_reconcileDeployment(t *testing.T) {
 		},
 		{
 			name: "deployment-label-update",
-			startResources: test.TestResources{
+			startResources: test.Resources{
 				Namespaces:     []*corev1.Namespace{namespaceResource},
 				EventListeners: []*v1alpha1.EventListener{eventListener1},
 				Deployments:    []*appsv1.Deployment{deployment2},
 			},
-			endResources: test.TestResources{
+			endResources: test.Resources{
 				Namespaces:     []*corev1.Namespace{namespaceResource},
 				EventListeners: []*v1alpha1.EventListener{eventListener1},
 				Deployments:    []*appsv1.Deployment{deployment1},
@@ -378,12 +378,12 @@ func Test_reconcileDeployment(t *testing.T) {
 		},
 		{
 			name: "deployment-replica-update",
-			startResources: test.TestResources{
+			startResources: test.Resources{
 				Namespaces:     []*corev1.Namespace{namespaceResource},
 				EventListeners: []*v1alpha1.EventListener{eventListener1},
 				Deployments:    []*appsv1.Deployment{deployment3},
 			},
-			endResources: test.TestResources{
+			endResources: test.Resources{
 				Namespaces:     []*corev1.Namespace{namespaceResource},
 				EventListeners: []*v1alpha1.EventListener{eventListener1},
 				Deployments:    []*appsv1.Deployment{deployment3},
@@ -391,12 +391,12 @@ func Test_reconcileDeployment(t *testing.T) {
 		},
 		{
 			name: "eventlistener-replica-failure-status-update",
-			startResources: test.TestResources{
+			startResources: test.Resources{
 				Namespaces:     []*corev1.Namespace{namespaceResource},
 				EventListeners: []*v1alpha1.EventListener{eventListener3},
 				Deployments:    []*appsv1.Deployment{deployment1},
 			},
-			endResources: test.TestResources{
+			endResources: test.Resources{
 				Namespaces:     []*corev1.Namespace{namespaceResource},
 				EventListeners: []*v1alpha1.EventListener{eventListener1},
 				Deployments:    []*appsv1.Deployment{deployment1},
@@ -404,12 +404,12 @@ func Test_reconcileDeployment(t *testing.T) {
 		},
 		{
 			name: "eventlistener-serviceaccount-update",
-			startResources: test.TestResources{
+			startResources: test.Resources{
 				Namespaces:     []*corev1.Namespace{namespaceResource},
 				EventListeners: []*v1alpha1.EventListener{eventListener4},
 				Deployments:    []*appsv1.Deployment{deployment1},
 			},
-			endResources: test.TestResources{
+			endResources: test.Resources{
 				Namespaces:     []*corev1.Namespace{namespaceResource},
 				EventListeners: []*v1alpha1.EventListener{eventListener4},
 				Deployments:    []*appsv1.Deployment{deployment4},
@@ -429,7 +429,7 @@ func Test_reconcileDeployment(t *testing.T) {
 				return
 			}
 			// Grab test resource results
-			actualEndResources, err := test.GetTestResourcesFromClients(testAssets.Clients)
+			actualEndResources, err := test.GetResourcesFromClients(testAssets.Clients)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -582,16 +582,16 @@ func TestReconcile(t *testing.T) {
 	tests := []struct {
 		name           string
 		key            string
-		startResources test.TestResources
-		endResources   test.TestResources
+		startResources test.Resources
+		endResources   test.Resources
 	}{{
 		name: "create-eventlistener",
 		key:  reconcileKey,
-		startResources: test.TestResources{
+		startResources: test.Resources{
 			Namespaces:     []*corev1.Namespace{namespaceResource},
 			EventListeners: []*v1alpha1.EventListener{eventListener0},
 		},
-		endResources: test.TestResources{
+		endResources: test.Resources{
 			Namespaces:     []*corev1.Namespace{namespaceResource},
 			EventListeners: []*v1alpha1.EventListener{eventListener1},
 			Deployments:    []*appsv1.Deployment{deployment1},
@@ -600,13 +600,13 @@ func TestReconcile(t *testing.T) {
 	}, {
 		name: "update-eventlistener-labels",
 		key:  reconcileKey,
-		startResources: test.TestResources{
+		startResources: test.Resources{
 			Namespaces:     []*corev1.Namespace{namespaceResource},
 			EventListeners: []*v1alpha1.EventListener{eventListener2},
 			Deployments:    []*appsv1.Deployment{deployment1},
 			Services:       []*corev1.Service{service1},
 		},
-		endResources: test.TestResources{
+		endResources: test.Resources{
 			Namespaces:     []*corev1.Namespace{namespaceResource},
 			EventListeners: []*v1alpha1.EventListener{eventListener2},
 			Deployments:    []*appsv1.Deployment{deployment2},
@@ -615,13 +615,13 @@ func TestReconcile(t *testing.T) {
 	}, {
 		name: "update-eventlistener-serviceaccount",
 		key:  reconcileKey,
-		startResources: test.TestResources{
+		startResources: test.Resources{
 			Namespaces:     []*corev1.Namespace{namespaceResource},
 			EventListeners: []*v1alpha1.EventListener{eventListener3},
 			Deployments:    []*appsv1.Deployment{deployment2},
 			Services:       []*corev1.Service{service2},
 		},
-		endResources: test.TestResources{
+		endResources: test.Resources{
 			Namespaces:     []*corev1.Namespace{namespaceResource},
 			EventListeners: []*v1alpha1.EventListener{eventListener3},
 			Deployments:    []*appsv1.Deployment{deployment3},
@@ -630,13 +630,13 @@ func TestReconcile(t *testing.T) {
 	}, {
 		name: "update-eventlistener-servicetype",
 		key:  reconcileKey,
-		startResources: test.TestResources{
+		startResources: test.Resources{
 			Namespaces:     []*corev1.Namespace{namespaceResource},
 			EventListeners: []*v1alpha1.EventListener{eventListener4},
 			Deployments:    []*appsv1.Deployment{deployment3},
 			Services:       []*corev1.Service{service2},
 		},
-		endResources: test.TestResources{
+		endResources: test.Resources{
 			Namespaces:     []*corev1.Namespace{namespaceResource},
 			EventListeners: []*v1alpha1.EventListener{eventListener4},
 			Deployments:    []*appsv1.Deployment{deployment3},
@@ -645,8 +645,8 @@ func TestReconcile(t *testing.T) {
 	}, {
 		name:           "delete-eventlistener",
 		key:            reconcileKey,
-		startResources: test.TestResources{},
-		endResources:   test.TestResources{},
+		startResources: test.Resources{},
+		endResources:   test.Resources{},
 	},
 	}
 	for _, tt := range tests {
@@ -662,7 +662,7 @@ func TestReconcile(t *testing.T) {
 				return
 			}
 			// Grab test resource results
-			actualEndResources, err := test.GetTestResourcesFromClients(testAssets.Clients)
+			actualEndResources, err := test.GetResourcesFromClients(testAssets.Clients)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/test/builder/meta_test.go
+++ b/test/builder/meta_test.go
@@ -1,9 +1,10 @@
 package builder
 
 import (
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func TestObjectMeta(t *testing.T) {

--- a/test/builder/triggerbinding_test.go
+++ b/test/builder/triggerbinding_test.go
@@ -1,11 +1,12 @@
 package builder
 
 import (
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func TestTriggerBindingBuilder(t *testing.T) {

--- a/test/builder/triggertemplate_test.go
+++ b/test/builder/triggertemplate_test.go
@@ -2,11 +2,12 @@ package builder
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func TestTriggerTemplateBuilder(t *testing.T) {

--- a/test/controller.go
+++ b/test/controller.go
@@ -38,9 +38,9 @@ import (
 	"knative.dev/pkg/controller"
 )
 
-// TestResources represents the desired state of the system (i.e. existing resources)
+// Resources represents the desired state of the system (i.e. existing resources)
 // to seed controllers with.
-type TestResources struct {
+type Resources struct {
 	Namespaces     []*corev1.Namespace
 	EventListeners []*v1alpha1.EventListener
 	Deployments    []*appsv1.Deployment
@@ -54,14 +54,15 @@ type Clients struct {
 	Pipeline *fakepipelineclientset.Clientset
 }
 
-// TestAssets holds references to the controller and clients.
-type TestAssets struct {
+// Assets holds references to the controller and clients.
+type Assets struct {
 	Controller *controller.Impl
 	Clients    Clients
 }
 
-// SeedTestResources returns Clients populated with the given TestResources
-func SeedTestResources(t *testing.T, ctx context.Context, r TestResources) Clients {
+// SeedResources returns Clients populated with the given Resources
+// nolint: golint
+func SeedResources(t *testing.T, ctx context.Context, r Resources) Clients {
 	t.Helper()
 	c := Clients{
 		Kube:     fakekubeclient.Get(ctx),
@@ -79,7 +80,7 @@ func SeedTestResources(t *testing.T, ctx context.Context, r TestResources) Clien
 			t.Fatal(err)
 		}
 	}
-	// Create TestResources
+	// Create test Resources
 	for _, el := range r.EventListeners {
 		if err := elInformer.Informer().GetIndexer().Add(el); err != nil {
 			t.Fatal(err)
@@ -111,10 +112,11 @@ func SeedTestResources(t *testing.T, ctx context.Context, r TestResources) Clien
 	return c
 }
 
-// GetTestResourcesFromClients returns the TestResources in the Clients provided
-// Precondition: all Namespaces used in TestResources must be listed in TestResources.Namespaces
-func GetTestResourcesFromClients(c Clients) (*TestResources, error) {
-	testResources := &TestResources{}
+// GetResourcesFromClients returns the Resources in the Clients provided
+// Precondition: all Namespaces used in Resources must be listed in Resources.Namespaces
+// nolint: golint
+func GetResourcesFromClients(c Clients) (*Resources, error) {
+	testResources := &Resources{}
 	nsList, err := c.Kube.CoreV1().Namespaces().List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err

--- a/test/controller_test.go
+++ b/test/controller_test.go
@@ -27,7 +27,7 @@ import (
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
-func TestGetTestResourcesFromClients(t *testing.T) {
+func TestGetResourcesFromClients(t *testing.T) {
 	nsFoo := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "foo",
@@ -76,16 +76,16 @@ func TestGetTestResourcesFromClients(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
-		testResources TestResources
+		name      string
+		Resources Resources
 	}{
 		{
-			name:          "empty",
-			testResources: TestResources{},
+			name:      "empty",
+			Resources: Resources{},
 		},
 		{
 			name: "one resource each",
-			testResources: TestResources{
+			Resources: Resources{
 				Namespaces:     []*corev1.Namespace{nsFoo},
 				EventListeners: []*v1alpha1.EventListener{eventListener1},
 				Deployments:    []*appsv1.Deployment{deployment1},
@@ -94,7 +94,7 @@ func TestGetTestResourcesFromClients(t *testing.T) {
 		},
 		{
 			name: "two resources each",
-			testResources: TestResources{
+			Resources: Resources{
 				Namespaces:     []*corev1.Namespace{nsFoo, nsTektonPipelines},
 				EventListeners: []*v1alpha1.EventListener{eventListener1, eventListener2},
 				Deployments:    []*appsv1.Deployment{deployment1, deployment2},
@@ -103,27 +103,27 @@ func TestGetTestResourcesFromClients(t *testing.T) {
 		},
 		{
 			name: "only namespaces",
-			testResources: TestResources{
+			Resources: Resources{
 				Namespaces: []*corev1.Namespace{nsFoo, nsTektonPipelines},
 			},
 		},
 		{
 			name: "only eventlisteners (and namespaces)",
-			testResources: TestResources{
+			Resources: Resources{
 				Namespaces:     []*corev1.Namespace{nsFoo, nsTektonPipelines},
 				EventListeners: []*v1alpha1.EventListener{eventListener1, eventListener2},
 			},
 		},
 		{
 			name: "only Deployments (and namespaces)",
-			testResources: TestResources{
+			Resources: Resources{
 				Namespaces:  []*corev1.Namespace{nsFoo, nsTektonPipelines},
 				Deployments: []*appsv1.Deployment{deployment1, deployment2},
 			},
 		},
 		{
 			name: "only Services (and namespaces)",
-			testResources: TestResources{
+			Resources: Resources{
 				Namespaces: []*corev1.Namespace{nsFoo, nsTektonPipelines},
 				Services:   []*corev1.Service{service1},
 			},
@@ -132,13 +132,13 @@ func TestGetTestResourcesFromClients(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, _ := rtesting.SetupFakeContext(t)
-			clients := SeedTestResources(t, ctx, tt.testResources)
-			actualTestResources, err := GetTestResourcesFromClients(clients)
+			clients := SeedResources(t, ctx, tt.Resources)
+			actualResources, err := GetResourcesFromClients(clients)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(tt.testResources, *actualTestResources); diff != "" {
-				t.Errorf("Diff request body: -want +got: %s", cmp.Diff(tt.testResources, *actualTestResources))
+			if diff := cmp.Diff(tt.Resources, *actualResources); diff != "" {
+				t.Errorf("Diff request body: -want +got: %s", cmp.Diff(tt.Resources, *actualResources))
 			}
 		})
 	}

--- a/test/eventlistener_test.go
+++ b/test/eventlistener_test.go
@@ -259,7 +259,8 @@ func TestEventListenerCreate(t *testing.T) {
 
 	// Port forward sink pod for http request
 	portString := strconv.Itoa(eventReconciler.Port)
-	cmd := exec.Command("kubectl", "port-forward", sinkPods.Items[0].Name, "-n", namespace, fmt.Sprintf("%s:%s", portString, portString))
+	podName := sinkPods.Items[0].Name
+	cmd := exec.Command("kubectl", "port-forward", podName, "-n", namespace, fmt.Sprintf("%s:%s", portString, portString))
 	err = cmd.Start()
 	if err != nil {
 		t.Fatalf("Error starting port-forward command: %s", err)

--- a/test/logs.go
+++ b/test/logs.go
@@ -26,9 +26,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// CollectPodLogsWithLabel will get the logs of all the Pods given a LabelSelector
-func CollectPodLogsWithLabel(c kubernetes.Interface, namespace, LabelSelector string) (string, error) {
-	pods, err := c.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: LabelSelector})
+// CollectPodLogsWithLabel will get the logs of all the Pods given a labelSelector
+func CollectPodLogsWithLabel(c kubernetes.Interface, namespace, labelSelector string) (string, error) {
+	pods, err := c.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
 		return "", err
 	}

--- a/test/wait.go
+++ b/test/wait.go
@@ -35,13 +35,14 @@ package test
 import (
 	"time"
 
+	"testing"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/apis"
-	"testing"
 )
 
 const (


### PR DESCRIPTION
# Changes

Add more linters to triggers and fixing the current code according to them :angel:.

- lot's of `goimports`
- it's preferable to use `struct` instead of `string` for `context`
  keys
- Rename some function and struct in the `test` package to remove
  `Test` angel
- …

/cc @dibyom @bobcatfish 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

