### PR TITLE
Fix e2e ingress test sleep wait behavior

### DIFF
--- a/test/e2e-tests-ingress.sh
+++ b/test/e2e-tests-ingress.sh
@@ -68,7 +68,13 @@ function wait_until_pod_started() {
 function get_eventlistener_service() {
   echo "Getting ServiceName for EventListener $1"
   for i in {1..150}; do  # timeout after 5 minutes
-    SERVICE_NAME=$(kubectl get eventlistener $1 -o=jsonpath='{.status.configuration.generatedName}') && return || sleep 2
+    SERVICE_NAME=$(kubectl get eventlistener $1 -o=jsonpath='{.status.configuration.generatedName}')
+    if [[ -z "$SERVICE_NAME" ]]
+    then
+      sleep 2
+    else
+      break
+    fi
   done
 }
 
@@ -76,7 +82,13 @@ function get_eventlistener_service() {
 function get_service_uid() {
   echo "Getting UID for Service $1"
   for i in {1..150}; do  # timeout after 5 minutes
-    SERVICE_UID=$(kubectl get svc $1 -o=jsonpath='{.metadata.uid}') && return || sleep 2
+    SERVICE_UID=$(kubectl get svc $1 -o=jsonpath='{.metadata.uid}')
+    if [ -z "${SERVICE_UID}" ];
+    then
+        sleep 2
+    else
+      break
+    fi
   done
 }
 
@@ -93,6 +105,7 @@ function matchOrFail() {
 
 set -o errexit
 set -o pipefail
+set -x
 
 # Apply ClusterRole/ClusterRoleBinding for default SA to run create Ingress Task
 kubectl apply -f ${REPO_ROOT_DIR}/test/ingress


### PR DESCRIPTION
# Changes

We weren't  properly for the SERVICE_NAME
and SERVICE_UID to be non-empty. So, in some cases
we tried creating the Taskrun with empty SERVICE_NAME
causing a validation error.

Also, added `set -x` to make it easy to debug via logs.

We should try to migrate these to go integration tests from bash at some point (or at least get rid of the taskruns embedded in the bash file

Should address #254 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
