### PR TITLE
Stop validating binding/template in Triggers

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -25,7 +25,6 @@ import (
 	"github.com/tektoncd/triggers/pkg/logging"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"knative.dev/pkg/signals"
@@ -51,10 +50,6 @@ func main() {
 	kubeClient, err := kubernetes.NewForConfig(clusterConfig)
 	if err != nil {
 		log.Fatalf("Failed to get the client set: %v", err)
-	}
-	client, err := dynamic.NewForConfig(clusterConfig)
-	if err != nil {
-		log.Fatalf("Failed to get the dynamic client set: %v", err)
 	}
 
 	logger := logging.ConfigureLogging(WebhookLogKey, ConfigName, stopCh, kubeClient)
@@ -87,8 +82,7 @@ func main() {
 
 	// Decorate contexts with the current state of the config.
 	ctxFunc := func(ctx context.Context) context.Context {
-		return v1alpha1.WithClientSet(ctx, client)
-
+		return ctx
 	}
 
 	controller, err := webhook.New(kubeClient, options, admissionControllers, logger, ctxFunc)

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation.go
@@ -41,18 +41,18 @@ func (s *EventListenerSpec) validate(ctx context.Context, el *EventListener) *ap
 		}
 		// Validate optional TriggerBinding
 		for j, b := range t.Bindings {
-			if len(b.Name) == 0 {
+			if b.Name == "" {
 				return apis.ErrMissingField(fmt.Sprintf("spec.triggers[%d].bindings[%d].name", i, j))
 			}
 		}
 		// Validate required TriggerTemplate
 		// Optional explicit match
-		if len(t.Template.APIVersion) != 0 {
+		if t.Template.APIVersion != "" {
 			if t.Template.APIVersion != "v1alpha1" {
 				return apis.ErrInvalidValue(fmt.Errorf("invalid apiVersion"), fmt.Sprintf("spec.triggers[%d].template.apiVersion", i))
 			}
 		}
-		if len(t.Template.Name) == 0 {
+		if t.Template.Name == "" {
 			return apis.ErrMissingField(fmt.Sprintf("spec.triggers[%d].template.name", i))
 		}
 		if t.Interceptor != nil {
@@ -88,20 +88,17 @@ func (i *EventInterceptor) validate(ctx context.Context, namespace string) *apis
 	}
 
 	if i.Webhook != nil {
-		if i.Webhook.ObjectRef == nil || len(i.Webhook.ObjectRef.Name) == 0 {
-			return apis.ErrMissingField("interceptor.webhook")
+		if i.Webhook.ObjectRef == nil || i.Webhook.ObjectRef.Name == "" {
+			return apis.ErrMissingField("interceptor.webhook.objectRef")
 		}
 		w := i.Webhook
-		if len(w.ObjectRef.Kind) != 0 {
-			if w.ObjectRef.Kind != "Service" {
-				return apis.ErrInvalidValue(fmt.Errorf("invalid kind"), "interceptor.webhook.objectRef.kind")
-			}
+		if w.ObjectRef.Kind != "Service" {
+			return apis.ErrInvalidValue(fmt.Errorf("invalid kind"), "interceptor.webhook.objectRef.kind")
 		}
+
 		// Optional explicit match
-		if len(w.ObjectRef.APIVersion) != 0 {
-			if w.ObjectRef.APIVersion != "v1" {
-				return apis.ErrInvalidValue(fmt.Errorf("invalid apiVersion"), "interceptor.webhook.objectRef.apiVersion")
-			}
+		if w.ObjectRef.APIVersion != "v1" {
+			return apis.ErrInvalidValue(fmt.Errorf("invalid apiVersion"), "interceptor.webhook.objectRef.apiVersion")
 		}
 
 		for i, header := range w.Header {

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
@@ -4,26 +4,84 @@ import (
 	"context"
 	"testing"
 
-	v1alpha1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	bldr "github.com/tektoncd/triggers/test/builder"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	fakedynamicclient "k8s.io/client-go/dynamic/fake"
 )
 
 func Test_EventListenerValidate(t *testing.T) {
 	tests := []struct {
-		name     string
-		el       *v1alpha1.EventListener
-		raiseErr bool
+		name string
+		el   *v1alpha1.EventListener
 	}{{
 		name: "TriggerTemplate Does Not Exist",
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tb", "dne", "v1alpha1"))),
-		raiseErr: true,
 	}, {
+		name: "Valid EventListener No TriggerBinding",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("", "tt", "v1alpha1"))),
+	}, {
+		name: "Valid EventListener No Interceptor",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tb", "tt", "v1alpha1"))),
+	}, {
+		name: "Valid EventListener Interceptor Name only",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
+					bldr.EventListenerTriggerInterceptor("svc", "", "", "")))),
+	}, {
+		name: "Valid EventListener Interceptor",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
+					bldr.EventListenerTriggerInterceptor("svc", "v1", "Service", "namespace")))),
+	}, {
+		name: "Valid EventListener Interceptor With Header",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
+					bldr.EventListenerTriggerInterceptor("svc", "v1", "Service", "namespace",
+						bldr.EventInterceptorParam("Valid-Header-Key", "valid value"))))),
+	}, {
+		name: "Valid EventListener Interceptor With Headers",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
+					bldr.EventListenerTriggerInterceptor("svc", "v1", "Service", "namespace",
+						bldr.EventInterceptorParam("Valid-Header-Key1", "valid value1"),
+						bldr.EventInterceptorParam("Valid-Header-Key1", "valid value2"),
+						bldr.EventInterceptorParam("Valid-Header-Key2", "valid value"))))),
+	}, {
+		name: "Valid EventListener Two Triggers",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
+					bldr.EventListenerTriggerInterceptor("svc", "v1", "Service", "namespace"),
+				),
+				bldr.EventListenerTrigger("tb", "tt", "v1alpha1"))),
+	},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.el.Validate(context.TODO())
+			if err != nil {
+				t.Errorf("EventListener.Validate() expected no error, but got one, EventListener: %v, error: %v", test.el, err)
+			}
+		})
+	}
+}
+
+func TestEventListenerValidate_error(t *testing.T) {
+	tests := []struct {
+		name string
+		el   *v1alpha1.EventListener
+	}{{
 		name: "Both Binding and Bindings Present",
 		el: &v1alpha1.EventListener{
 			ObjectMeta: metav1.ObjectMeta{
@@ -38,14 +96,6 @@ func Test_EventListenerValidate(t *testing.T) {
 				}},
 			},
 		},
-		raiseErr: true,
-	}, {
-		name: "Interceptor Does Not Exist",
-		el: bldr.EventListener("name", "namespace",
-			bldr.EventListenerSpec(
-				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
-					bldr.EventListenerTriggerInterceptor("dne", "v1", "Service", "")))),
-		raiseErr: true,
 	}, {
 		name: "Interceptor Missing ObjectRef",
 		el: &v1alpha1.EventListener{
@@ -61,21 +111,18 @@ func Test_EventListenerValidate(t *testing.T) {
 				}},
 			},
 		},
-		raiseErr: true,
 	}, {
 		name: "Interceptor Wrong APIVersion",
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
 					bldr.EventListenerTriggerInterceptor("foo", "v3", "Service", "")))),
-		raiseErr: true,
 	}, {
 		name: "Interceptor Wrong Kind",
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
 					bldr.EventListenerTriggerInterceptor("foo", "v1", "Deployment", "")))),
-		raiseErr: true,
 	}, {
 		name: "Interceptor Non-Canonical Header",
 		el: bldr.EventListener("name", "namespace",
@@ -83,7 +130,6 @@ func Test_EventListenerValidate(t *testing.T) {
 				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
 					bldr.EventListenerTriggerInterceptor("foo", "v1", "Deployment", "",
 						bldr.EventInterceptorParam("non-canonical-header-key", "valid value"))))),
-		raiseErr: true,
 	}, {
 		name: "Interceptor Empty Header Name",
 		el: bldr.EventListener("name", "namespace",
@@ -91,7 +137,6 @@ func Test_EventListenerValidate(t *testing.T) {
 				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
 					bldr.EventListenerTriggerInterceptor("foo", "v1", "Deployment", "",
 						bldr.EventInterceptorParam("", "valid value"))))),
-		raiseErr: true,
 	}, {
 		name: "Interceptor Empty Header Value",
 		el: bldr.EventListener("name", "namespace",
@@ -99,107 +144,13 @@ func Test_EventListenerValidate(t *testing.T) {
 				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
 					bldr.EventListenerTriggerInterceptor("foo", "v1", "Deployment", "",
 						bldr.EventInterceptorParam("Valid-Header-Key", ""))))),
-		raiseErr: true,
-	}, {
-		name: "Valid EventListener No TriggerBinding",
-		el: bldr.EventListener("name", "namespace",
-			bldr.EventListenerSpec(
-				bldr.EventListenerTrigger("", "tt", "v1alpha1"))),
-		raiseErr: false,
-	}, {
-		name: "Valid EventListener No Interceptor",
-		el: bldr.EventListener("name", "namespace",
-			bldr.EventListenerSpec(
-				bldr.EventListenerTrigger("tb", "tt", "v1alpha1"))),
-		raiseErr: false,
-	}, {
-		name: "Valid EventListener Interceptor Name only",
-		el: bldr.EventListener("name", "namespace",
-			bldr.EventListenerSpec(
-				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
-					bldr.EventListenerTriggerInterceptor("svc", "", "", "")))),
-		raiseErr: false,
-	}, {
-		name: "Valid EventListener Interceptor",
-		el: bldr.EventListener("name", "namespace",
-			bldr.EventListenerSpec(
-				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
-					bldr.EventListenerTriggerInterceptor("svc", "v1", "Service", "namespace")))),
-		raiseErr: false,
-	}, {
-		name: "Valid EventListener Interceptor With Header",
-		el: bldr.EventListener("name", "namespace",
-			bldr.EventListenerSpec(
-				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
-					bldr.EventListenerTriggerInterceptor("svc", "v1", "Service", "namespace",
-						bldr.EventInterceptorParam("Valid-Header-Key", "valid value"))))),
-		raiseErr: false,
-	}, {
-		name: "Valid EventListener Interceptor With Headers",
-		el: bldr.EventListener("name", "namespace",
-			bldr.EventListenerSpec(
-				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
-					bldr.EventListenerTriggerInterceptor("svc", "v1", "Service", "namespace",
-						bldr.EventInterceptorParam("Valid-Header-Key1", "valid value1"),
-						bldr.EventInterceptorParam("Valid-Header-Key1", "valid value2"),
-						bldr.EventInterceptorParam("Valid-Header-Key2", "valid value"))))),
-		raiseErr: false,
-	}, {
-		name: "Valid EventListener Two Triggers",
-		el: bldr.EventListener("name", "namespace",
-			bldr.EventListenerSpec(
-				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
-					bldr.EventListenerTriggerInterceptor("svc", "v1", "Service", "namespace"),
-				),
-				bldr.EventListenerTrigger("tb", "tt", "v1alpha1"))),
-		raiseErr: false,
-	},
-	}
+	}}
 
-	tb := bldr.TriggerBinding("tb", "namespace",
-		bldr.TriggerBindingSpec(
-			bldr.TriggerBindingParam("oneparam", "$(event.one)"),
-			bldr.TriggerBindingParam("twoparamname", "$(event.two.name)"),
-		),
-	)
-
-	tt := bldr.TriggerTemplate("tt", "namespace",
-		bldr.TriggerTemplateSpec(
-			bldr.TriggerTemplateParam("foo", "desc", "val"),
-			bldr.TriggerResourceTemplate(simpleResourceTemplate)))
-
-	svc := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "svc",
-			Namespace: "namespace",
-		},
-	}
-
-	scheme := runtime.NewScheme()
-	triggerBinding := v1alpha1.SchemeGroupVersion.WithKind("TriggerBinding")
-	scheme.AddKnownTypeWithName(triggerBinding,
-		&v1alpha1.TriggerBinding{},
-	)
-
-	triggerTemplate := v1alpha1.SchemeGroupVersion.WithKind("TriggerTemplate")
-	scheme.AddKnownTypeWithName(triggerTemplate,
-		&v1alpha1.TriggerTemplate{},
-	)
-
-	service := corev1.SchemeGroupVersion.WithKind("Service")
-	scheme.AddKnownTypeWithName(service,
-		&corev1.Service{},
-	)
-
-	dynamicClient := fakedynamicclient.NewSimpleDynamicClient(scheme, tb, tt, svc)
-	ctx := v1alpha1.WithClientSet(context.TODO(), dynamicClient)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.el.Validate(ctx)
-			if test.raiseErr && err == nil {
+			err := test.el.Validate(context.TODO())
+			if err == nil {
 				t.Errorf("EventListener.Validate() expected error, but get none, EventListener: %v", test.el)
-			} else if !test.raiseErr && err != nil {
-				t.Errorf("EventListener.Validate() expected no error, but get one, EventListener: %v, error: %v", test.el, err)
 			}
 		})
 	}

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
@@ -253,33 +253,27 @@ func (c *Reconciler) reconcileDeployment(el *v1alpha1.EventListener) error {
 	container := corev1.Container{
 		Name:  "event-listener",
 		Image: *elImage,
-		Ports: []corev1.ContainerPort{
-			{
-				ContainerPort: int32(Port),
-				Protocol:      corev1.ProtocolTCP,
-			},
-		},
+		Ports: []corev1.ContainerPort{{
+			ContainerPort: int32(Port),
+			Protocol:      corev1.ProtocolTCP,
+		}},
 		Args: []string{
 			"-el-name", el.Name,
 			"-el-namespace", el.Namespace,
 			"-port", strconv.Itoa(Port),
 		},
-		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      "config-logging",
-				MountPath: "/etc/config-logging",
-			},
-		},
-		Env: []corev1.EnvVar{
-			{
-				Name: "SYSTEM_NAMESPACE",
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{
-						FieldPath: "metadata.namespace",
-					},
+		VolumeMounts: []corev1.VolumeMount{{
+			Name:      "config-logging",
+			MountPath: "/etc/config-logging",
+		}},
+		Env: []corev1.EnvVar{{
+			Name: "SYSTEM_NAMESPACE",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.namespace",
 				},
 			},
-		},
+		}},
 	}
 	deployment := &appsv1.Deployment{
 		ObjectMeta: generateObjectMeta(el),
@@ -296,18 +290,16 @@ func (c *Reconciler) reconcileDeployment(el *v1alpha1.EventListener) error {
 					ServiceAccountName: el.Spec.ServiceAccountName,
 					Containers:         []corev1.Container{container},
 
-					Volumes: []corev1.Volume{
-						{
-							Name: "config-logging",
-							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: eventListenerConfigMapName,
-									},
+					Volumes: []corev1.Volume{{
+						Name: "config-logging",
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: eventListenerConfigMapName,
 								},
 							},
 						},
-					},
+					}},
 				},
 			},
 		},


### PR DESCRIPTION
# Changes

Currently, while validating triggers in an EventListener, we fetch
all the bindings and templates, and validate that they exist. This
means that the bindings and the templates have to be created before
creating EventListeners leading to the fragile object creation order
issues listed in #187

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
We no longer validate the existence of `TriggerBindings` and `TriggerTemplates` when validating a EventListener.

```
