### PR TITLE
Fix serviceAccountName in triggers.yaml

### DIFF
--- a/docs/getting-started/triggers.yaml
+++ b/docs/getting-started/triggers.yaml
@@ -51,7 +51,7 @@ spec:
         name: getting-started-pipeline-run-$(uid)
         namespace: $(params.namespace)
       spec:
-        serviceAccount: tekton-triggers-admin
+        serviceAccountName: tekton-triggers-admin
         pipelineRef:
           name: getting-started-pipeline
         resources:


### PR DESCRIPTION
See also #278 

When a trigger is received, the following error is shown in el-tekton-listener log:

Internal error occurred: admission webhook "triggers-webhook.tekton.dev" denied the request: mutation failed: cannot decode incoming new object: json: unknown field "serviceAccount"

Renaming serviceAccount to serviceAccountName fixed the issue.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
