### PR TITLE
Fix codeblock types in examples/README.md.

### DIFF
--- a/docs/exposing-eventlisteners.md
+++ b/docs/exposing-eventlisteners.md
@@ -20,12 +20,12 @@ The following instructions have been tested on GKE cluster running version `1.13
 Instructions for installing nginx Ingress on other Kubernetes services can be found [here](https://kubernetes.github.io/ingress-nginx/deploy/).
 
 1. First, install Nginx ingress controller:
-    ```yaml
+    ```sh
       kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/mandatory.yaml
       kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/cloud-generic.yaml
     ```
 1. Find the service name expose by the GitHub service:
-    ```yaml
+    ```sh
      kubectl get el -o=jsonpath='{.status.configuration.generatedName} <EVENTLISTENR_NAME> '
     ```
 1. Create the Ingress resource. A sample Ingress is below. Check the docs [here](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/)

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@ In this example you will use Triggers to create a PipelineRun and PipelineResour
 
 1. Create the resources for the example
 
-```yaml
+```sh
 kubectl apply -f role-resources
 kubectl apply -f triggertemplates/triggertemplate.yaml
 kubectl apply -f triggerbindings/triggerbinding.yaml
@@ -163,7 +163,7 @@ simple-pipeline-runn4qps   True        Succeeded   5m          4m
 
 # Cleaning up
 
-```yaml
+```sh
 kubectl delete all -l generatedBy=triggers-example
 ```
 


### PR DESCRIPTION
# Changes

Codeblocks were marked as yaml, even though that are shell commands.
This caused issues when autoformatting documentation (i.e. #302).

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._
