### PR TITLE
Fix different uid generated in one triggerTemplate

### DIFF
--- a/pkg/template/event.go
+++ b/pkg/template/event.go
@@ -47,9 +47,10 @@ func ResolveParams(bindings []*triggersv1.TriggerBinding, body []byte, header ht
 // ResolveResources resolves a templated resource by replacing params with their values.
 func ResolveResources(template *triggersv1.TriggerTemplate, params []pipelinev1.Param) []json.RawMessage {
 	resources := make([]json.RawMessage, len(template.Spec.ResourceTemplates))
+	uid := UID()
 	for i := range template.Spec.ResourceTemplates {
 		resources[i] = ApplyParamsToResourceTemplate(params, template.Spec.ResourceTemplates[i].RawMessage)
-		resources[i] = ApplyUIDToResourceTemplate(resources[i], UID())
+		resources[i] = ApplyUIDToResourceTemplate(resources[i], uid)
 	}
 	return resources
 }

--- a/pkg/template/event_test.go
+++ b/pkg/template/event_test.go
@@ -179,7 +179,7 @@ func Test_NewResources(t *testing.T) {
 		},
 		want: []json.RawMessage{
 			json.RawMessage(`{"rt1": "bar-cbhtc", "cbhtc": "cbhtc"}`),
-			json.RawMessage(`{"rt2": "default2-bsvjp"}`),
+			json.RawMessage(`{"rt2": "default2-cbhtc"}`),
 			json.RawMessage(`{"rt3": "rt3"}`),
 		},
 	}, {


### PR DESCRIPTION
When different uid generated in one triggerTemplate, internal references will fail.

For example, code examples in [doc](https://github.com/tektoncd/triggers/blob/master/docs/triggertemplates.md#triggertemplates) also fail to run.

```
apiVersion: tekton.dev/v1alpha1
kind: TriggerTemplate
metadata:
  name: pipeline-template
spec:
  params:
  - name: gitrevision
    description: The git revision
    default: master
  - name: gitrepositoryurl
    description: The git repository url
  - name: message
    description: The message to print
    default: This is the default message
  - name: contenttype
    description: The Content-Type of the event
  resourcetemplates:
  - apiVersion: tekton.dev/v1alpha1
    kind: PipelineResource
    metadata:
      name: git-source-$(uid)
    spec:
      type: git
      params:
      - name: revision
        value: $(params.gitrevision)
      - name: url
        value: $(params.gitrepositoryurl)
  - apiVersion: tekton.dev/v1alpha1
    kind: PipelineRun
    metadata:
      generateName: simple-pipeline-run
    spec:
      pipelineRef:
        name: simple-pipeline
      params:
      - name: message
        value: $(params.message)
      - name: contenttype
        value: $(params.contenttype)
      resources:
      - name: git-source
        resourceRef:
          name: git-source-$(uid)
```
I found `git-source-5ls8v` in generated and error info shows
```
PipelineRun tekton-pipelines/simple-pipeline-runwfxxq can't be Run; it tries to bind Resources that don't exist: Error following resource reference for code-repo: pipelineresource.tekton.dev "git-source-vddbg" not found.  
```


# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
