### PR TITLE
Update documentation to embed PipeineResources

### DIFF
--- a/docs/getting-started/triggers.yaml
+++ b/docs/getting-started/triggers.yaml
@@ -14,38 +14,6 @@ spec:
       description: The namespace to create the resources
   resourcetemplates:
     - apiVersion: tekton.dev/v1alpha1
-      kind: PipelineResource
-      metadata:
-        name: source-repo-$(uid)
-        namespace: $(params.namespace)
-      spec:
-        type: git
-        params:
-        - name: revision
-          value: $(params.gitrevision)
-        - name: url
-          value: $(params.gitrepositoryurl)
-    - apiVersion: tekton.dev/v1alpha1
-      kind: PipelineResource
-      metadata:
-        name: image-source-$(uid)
-        namespace: $(params.namespace)
-      spec:
-        type: image
-        params:
-          - name: url
-            value: DOCKERREPO-REPLACEME # docker-repo-location.com/repo:getting-started
-    - apiVersion: tekton.dev/v1alpha1
-      kind: PipelineResource
-      metadata:
-        name: event-to-sink-$(uid)
-        namespace: $(params.namespace)
-      spec:
-        type: cloudEvent
-        params:
-          - name: targetURI
-            value: http://event-display.getting-started.svc.cluster.local
-    - apiVersion: tekton.dev/v1alpha1
       kind: PipelineRun
       metadata:
         name: getting-started-pipeline-run-$(uid)
@@ -56,14 +24,25 @@ spec:
           name: getting-started-pipeline
         resources:
           - name: source-repo
-            resourceRef:
-              name: source-repo-$(uid)
+            resourceSpec:
+              type: git
+              params:
+              - name: revision
+                value: $(params.gitrevision)
+              - name: url
+                value: $(params.gitrepositoryurl)
           - name: image-source
-            resourceRef:
-              name: image-source-$(uid)
+            resourceSpec:
+              type: image
+              params:
+                - name: url
+                  value: DOCKERREPO-REPLACEME # docker-repo-location.com/repo:getting-started
           - name: event-to-sink
-            resourceRef:
-              name: event-to-sink-$(uid)
+            resourceSpec:
+              type: cloudEvent
+              params:
+                - name: targetURI
+                  value: http://event-display.getting-started.svc.cluster.local
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: TriggerBinding

--- a/docs/triggerbindings.md
+++ b/docs/triggerbindings.md
@@ -80,7 +80,7 @@ $(header.Two.1) -> "two"
 In an [`EventListener`](eventlisteners.md), you may specify multiple bindings as
 part of your trigger. This allows you to create reusable bindings that can be
 mixed and matched with various triggers. For example, a trigger with one binding
-that extracts event information, and another bind that provides deploy
+that extracts event information, and another binding that provides deploy
 environment information:
 
 ```yaml

--- a/docs/triggertemplates.md
+++ b/docs/triggertemplates.md
@@ -23,20 +23,9 @@ spec:
     description: The Content-Type of the event
   resourcetemplates:
   - apiVersion: tekton.dev/v1alpha1
-    kind: PipelineResource
-    metadata:
-      name: git-source-$(uid)
-    spec:
-      type: git
-      params:
-      - name: revision
-        value: $(params.gitrevision)
-      - name: url
-        value: $(params.gitrepositoryurl)
-  - apiVersion: tekton.dev/v1alpha1
     kind: PipelineRun
     metadata:
-      generateName: simple-pipeline-run
+      generateName: simple-pipeline-run-
     spec:
       pipelineRef:
         name: simple-pipeline
@@ -47,8 +36,13 @@ spec:
         value: $(params.contenttype)
       resources:
       - name: git-source
-        resourceRef:
-          name: git-source-$(uid)
+        resourceSpec:
+          type: git
+          params:
+          - name: revision
+            value: $(params.gitrevision)
+          - name: url
+            value: $(params.gitrepositoryurl)
 ```
 
 Similar to [Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md),`TriggerTemplate`s do not do any actual work, but instead act as the blueprint for what resources should be created.
@@ -80,3 +74,8 @@ $(params.<name>)
 `params` can be referenced in the `resourceTemplates` section of a
 `TriggerTemplate`. The purpose of `params` is to make `TriggerTemplates`
 reusable.
+
+## Best Practices
+As of Tekton Pipelines version [v0.8.0](https://github.com/tektoncd/pipeline/releases/tag/v0.8.0), users can embed
+resource specs. It is a best practice to embed each resource specs in the PipelineRun or TaskRun that uses the resource
+spec. Embedding the resource spec avoids a race condition between creating and using resources.

--- a/examples/eventlisteners/eventlistener.yaml
+++ b/examples/eventlisteners/eventlistener.yaml
@@ -8,5 +8,6 @@ spec:
     - name: foo-trig
       bindings:
       - name: pipeline-binding
+      - name: message-binding
       template:
         name: pipeline-template

--- a/examples/triggerbindings/triggerbinding-message.yaml
+++ b/examples/triggerbindings/triggerbinding-message.yaml
@@ -1,0 +1,8 @@
+apiVersion: tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: message-binding
+spec:
+  params:
+  - name: message
+    value: Hello from the Triggers EventListener!

--- a/examples/triggertemplates/triggertemplate.yaml
+++ b/examples/triggertemplates/triggertemplate.yaml
@@ -16,20 +16,9 @@ spec:
     description: The Content-Type of the event
   resourcetemplates:
   - apiVersion: tekton.dev/v1alpha1
-    kind: PipelineResource
-    metadata:
-      name: git-source-$(uid)
-    spec:
-      type: git
-      params:
-      - name: revision
-        value: $(params.gitrevision)
-      - name: url
-        value: $(params.gitrepositoryurl)
-  - apiVersion: tekton.dev/v1alpha1
     kind: PipelineRun
     metadata:
-      generateName: simple-pipeline-run
+      generateName: simple-pipeline-run-
     spec:
       pipelineRef:
         name: simple-pipeline
@@ -40,5 +29,10 @@ spec:
         value: $(params.contenttype)
       resources:
       - name: git-source
-        resourceRef:
-          name: git-source-$(uid)
+        resourceSpec:
+          type: git
+          params:
+          - name: revision
+            value: $(params.gitrevision)
+          - name: url
+            value: $(params.gitrepositoryurl)


### PR DESCRIPTION
# Changes
Fixes #283

Update the documentation including examples to embed all
PipelineResources as resourceSpecs. This avoids the race condition
where a PipelineRun is created before its PipelineResource(s).

FYI @anneqm, and thanks for creating the issue for this! 🙂 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._
