### PR TITLE
Split Test_NewResources into smaller tests

### DIFF
--- a/pkg/template/resource_test.go
+++ b/pkg/template/resource_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/tektoncd/triggers/test"
 	bldr "github.com/tektoncd/triggers/test/builder"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 func Test_MergeInDefaultParams(t *testing.T) {
@@ -398,18 +397,18 @@ func Test_ApplyUIDToResourceTemplate(t *testing.T) {
 		{
 			name:       "One uid",
 			rt:         json.RawMessage(`{"rt": "uid is $(uid)"}`),
-			expectedRt: json.RawMessage(`{"rt": "uid is cbhtc"}`),
+			expectedRt: json.RawMessage(`{"rt": "uid is abcde"}`),
 		},
 		{
 			name:       "Three uid",
 			rt:         json.RawMessage(`{"rt1": "uid is $(uid)", "rt2": "nothing", "rt3": "$(uid)-center-$(uid)"}`),
-			expectedRt: json.RawMessage(`{"rt1": "uid is cbhtc", "rt2": "nothing", "rt3": "cbhtc-center-cbhtc"}`),
+			expectedRt: json.RawMessage(`{"rt1": "uid is abcde", "rt2": "nothing", "rt3": "abcde-center-abcde"}`),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// This seeds UID() to return 'cbhtc'
-			rand.Seed(0)
+			// This seeds UID() to return 'abcde'
+			UID = func() string { return "abcde" }
 			actualRt := ApplyUIDToResourceTemplate(tt.rt, UID())
 			if diff := cmp.Diff(string(tt.expectedRt), string(actualRt)); diff != "" {
 				t.Errorf("ApplyUIDToResourceTemplate(): -want +got: %s", diff)

--- a/test/builder/param.go
+++ b/test/builder/param.go
@@ -1,0 +1,13 @@
+package builder
+
+import "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+
+func Param(name, value string) v1alpha1.Param {
+	return v1alpha1.Param{
+		Name: name,
+		Value: v1alpha1.ArrayOrString{
+			Type:      v1alpha1.ParamTypeString,
+			StringVal: value,
+		},
+	}
+}

--- a/test/builder/param_test.go
+++ b/test/builder/param_test.go
@@ -1,0 +1,24 @@
+package builder
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+)
+
+func TestParam(t *testing.T) {
+	got := Param("foo", "bar")
+
+	want := v1alpha1.Param{
+		Name: "foo",
+		Value: v1alpha1.ArrayOrString{
+			Type:      v1alpha1.ParamTypeString,
+			StringVal: "bar",
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("-want/+got: %s", diff)
+	}
+}


### PR DESCRIPTION
# Changes

We used to have a function called NewResources that we later split into
smaller functions -- ResolveParams and ResolveResources. However, in our
unit tests, we kept the Test_NewResources function leading to tests that
were more verbose/needed more setup than necessary. This commit splits
the tests into smaller more targeted tests.

Fixes #252

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._


