### PR TITLE
Update service ports name following istio-naming convention - https:/…

### DIFF
--- a/config/controller-service.yaml
+++ b/config/controller-service.yaml
@@ -21,7 +21,7 @@ metadata:
   namespace: tekton-pipelines
 spec:
   ports:
-  - name: metrics
+  - name: http-metrics
     port: 9090
     protocol: TCP
     targetPort: 9090

--- a/config/webhook-service.yaml
+++ b/config/webhook-service.yaml
@@ -7,7 +7,8 @@ metadata:
   namespace: tekton-pipelines
 spec:
   ports:
-    - port: 443
+    - name: https-webhook
+      port: 443
       targetPort: 8443
   selector:
     app: tekton-triggers-webhook

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
@@ -48,6 +48,8 @@ const (
 	eventListenerControllerName = "EventListener"
 	// eventListenerConfigMapName is for the automatically created ConfigMap
 	eventListenerConfigMapName = "config-logging-triggers"
+	// eventListenerServicePortName defines service port name for EventListener Service
+	eventListenerServicePortName = "http-listener"
 	// GeneratedResourcePrefix is the name prefix for resources generated in the
 	// EventListener reconciler
 	GeneratedResourcePrefix = "el"
@@ -171,6 +173,7 @@ func (c *Reconciler) reconcileService(el *v1alpha1.EventListener) error {
 			Type:     el.Spec.ServiceType,
 			Ports: []corev1.ServicePort{
 				{
+					Name:     eventListenerServicePortName,
 					Protocol: corev1.ProtocolTCP,
 					Port:     int32(*ElPort),
 					TargetPort: intstr.IntOrString{

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
@@ -136,6 +136,7 @@ func Test_reconcileService(t *testing.T) {
 			Type:     eventListener1.Spec.ServiceType,
 			Ports: []corev1.ServicePort{
 				{
+					Name:     eventListenerServicePortName,
 					Protocol: corev1.ProtocolTCP,
 					Port:     int32(*ElPort),
 					TargetPort: intstr.IntOrString{
@@ -575,6 +576,7 @@ func TestReconcile(t *testing.T) {
 			Type:     eventListener1.Spec.ServiceType,
 			Ports: []corev1.ServicePort{
 				{
+					Name:     eventListenerServicePortName,
 					Protocol: corev1.ProtocolTCP,
 					Port:     int32(*ElPort),
 					TargetPort: intstr.IntOrString{


### PR DESCRIPTION
…/istio.io/docs/ops/deployment/requirements/

# Changes

To be on the safer side when deployed to a cluster with Istio deployed, we should follow service port naming convention as stated here ->https://istio.io/docs/setup/kubernetes/additional-setup/requirements/

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
- Service port naming cleanup, follow standard istio naming convention based on this link:
https://istio.io/docs/setup/kubernetes/additional-setup/requirements/

```
