### PR TITLE
Drop unused KubeClientSet from the CEL interceptor.

### DIFF
--- a/pkg/interceptors/cel/cel.go
+++ b/pkg/interceptors/cel/cel.go
@@ -31,7 +31,6 @@ import (
 	"github.com/tektoncd/triggers/pkg/interceptors"
 	"go.uber.org/zap"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
-	"k8s.io/client-go/kubernetes"
 
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 )
@@ -40,19 +39,15 @@ import (
 // against the incoming body and headers to match, if the expression returns
 // a true value, then the interception is "successful".
 type Interceptor struct {
-	KubeClientSet          kubernetes.Interface
-	Logger                 *zap.SugaredLogger
-	CEL                    *triggersv1.CELInterceptor
-	EventListenerNamespace string
+	Logger *zap.SugaredLogger
+	CEL    *triggersv1.CELInterceptor
 }
 
 // NewInterceptor creates a prepopulated Interceptor.
-func NewInterceptor(cel *triggersv1.CELInterceptor, k kubernetes.Interface, ns string, l *zap.SugaredLogger) interceptors.Interceptor {
+func NewInterceptor(cel *triggersv1.CELInterceptor, l *zap.SugaredLogger) interceptors.Interceptor {
 	return &Interceptor{
-		Logger:                 l,
-		CEL:                    cel,
-		KubeClientSet:          k,
-		EventListenerNamespace: ns,
+		Logger: l,
+		CEL:    cel,
 	}
 }
 

--- a/pkg/interceptors/cel/cel_test.go
+++ b/pkg/interceptors/cel/cel_test.go
@@ -12,11 +12,7 @@ import (
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/tektoncd/pipeline/pkg/logging"
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
-	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
-	rtesting "knative.dev/pkg/reconciler/testing"
 )
-
-// Allow configuration via a config map
 
 func TestInterceptor_ExecuteTrigger(t *testing.T) {
 	type args struct {
@@ -126,13 +122,10 @@ func TestInterceptor_ExecuteTrigger(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx, _ := rtesting.SetupFakeContext(t)
 			logger, _ := logging.NewLogger("", "")
-			kubeClient := fakekubeclient.Get(ctx)
 			w := &Interceptor{
-				KubeClientSet: kubeClient,
-				CEL:           tt.CEL,
-				Logger:        logger,
+				CEL:    tt.CEL,
+				Logger: logger,
 			}
 			request := &http.Request{
 				Body: ioutil.NopCloser(bytes.NewReader(tt.args.payload)),

--- a/pkg/interceptors/gitlab/gitlab.go
+++ b/pkg/interceptors/gitlab/gitlab.go
@@ -46,7 +46,6 @@ func NewInterceptor(gl *triggersv1.GitLabInterceptor, k kubernetes.Interface, ns
 	}
 }
 
-//func (w *Interceptor) ExecuteTrigger(payload []byte, request *http.Request, _ *triggersv1.EventListenerTrigger, _ string) ([]byte, error) {
 func (w *Interceptor) ExecuteTrigger(request *http.Request) (*http.Response, error) {
 	// Validate the secret first, if set.
 	if w.GitLab.SecretRef != nil {

--- a/pkg/sink/sink.go
+++ b/pkg/sink/sink.go
@@ -169,7 +169,7 @@ func (r Sink) executeInterceptors(t *triggersv1.EventListenerTrigger, request *h
 		case i.GitLab != nil:
 			interceptor = gitlab.NewInterceptor(i.GitLab, r.KubeClientSet, r.EventListenerNamespace, log)
 		case i.CEL != nil:
-			interceptor = cel.NewInterceptor(i.CEL, r.KubeClientSet, r.EventListenerNamespace, log)
+			interceptor = cel.NewInterceptor(i.CEL, log)
 		default:
 			return nil, nil, fmt.Errorf("unknown interceptor type: %v", i)
 		}


### PR DESCRIPTION
This drops the kubeclient from the CEL interceptor, this was removed earlier, but I suspect crept back in during a rebase.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._