### PR TITLE
Daisy-chain interceptor requests.

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -89,9 +89,12 @@ being sent;
 [canonical](https://github.com/golang/go/blob/master/src/net/http/header.go#L214)
 names must be specified.
 
-When multiple interceptors are specified, the request is sent to each
-interceptor sequentially for processing. The response body and headers of the
-last interceptor is used for resource binding/templating.
+When multiple interceptors are specified, requests are piped through each
+interceptor sequentially for processing - e.g. the headers/body of the first
+interceptor's response will be sent as the request to the second interceptor. It
+is the responsibility of interceptors to preserve header/body data if desired.
+The response body and headers of the last interceptor is used for resource
+binding/templating.
 
 #### Event Interceptor Services
 
@@ -151,6 +154,9 @@ To use this interceptor as a filter, add the event types you would like to
 accept to the `eventTypes` field. Valid values can be found in GitHub
 [docs](https://developer.github.com/webhooks/#events).
 
+The body/header of the incoming request will be preserved in this interceptor's
+response.
+
 <!-- FILE: examples/eventlisteners/github-eventlistener-interceptor.yaml -->
 ```YAML
 ---
@@ -195,6 +201,9 @@ to the `gitlab` interceptor.
 To use this interceptor as a filter, add the event types you would like to
 accept to the `eventTypes` field.
 
+The body/header of the incoming request will be preserved in this interceptor's
+response.
+
 <!-- FILE: examples/eventlisteners/gitlab-eventlistener-interceptor.yaml -->
 ```YAML
 ---
@@ -228,6 +237,9 @@ request headers, using the [CEL](https://github.com/google/cel-go) expression
 language.
 
 Supported features include case-insensitive matching on request headers.
+
+The body/header of the incoming request will be preserved in this interceptor's
+response.
 
 <!-- FILE: examples/eventlisteners/cel-eventlistener-interceptor.yaml -->
 ```YAML

--- a/pkg/interceptors/webhook/webhook_test.go
+++ b/pkg/interceptors/webhook/webhook_test.go
@@ -113,7 +113,6 @@ func TestWebHookInterceptor_NotOK(t *testing.T) {
 	// Create test server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
-		return
 	}))
 	defer ts.Close()
 	interceptorURL, _ := url.Parse(ts.URL)


### PR DESCRIPTION
# Changes

This changes the behavior of interceptors to feed the body/header of an
interceptor response in as the request for the next interceptor. This
allows interceptors to be layered to modify the behavior of future
interceptors.

Fixes #325

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Interceptors will now feed body/header responses as the request for the next interceptor.
```
