### PR TITLE
Regression: Add back interceptor errors for non-OK status codes.

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -80,10 +80,12 @@ to a Kubernetes Service. If a Webhook interceptor is specified, the
 `EventListener` sink will forward incoming events to the service referenced by
 the interceptor over HTTP. The service is expected to process the event and
 return a response back. The status code of the response determines if the
-processing is successful and the returned body is used as the new event payload
-by the EventListener and passed on the `TriggerBinding`. An interceptor has an
-optional header field with key-value pairs that will be merged with event
-headers before being sent;
+processing is successful - a 200 response means the interceptor was successful
+and that processing should continue, any other status code will halt trigger
+processing. The returned body is used as the new event payload by the
+EventListener and passed on the `TriggerBinding`. An interceptor has an optional
+header field with key-value pairs that will be merged with event headers before
+being sent;
 [canonical](https://github.com/golang/go/blob/master/src/net/http/header.go#L214)
 names must be specified.
 


### PR DESCRIPTION
# Changes

Regression: Add back interceptor errors for non-OK status codes.

This was accidentally removed in d182697. This behavior is something I want to
take a closer look at to see how we can improve "OK, but don't trigger"
responses, but for now adding this back in for paritity with the old
behavior.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._
