### PR TITLE
Return valid arrays for multiple JSONPath results

### DIFF
--- a/docs/triggerbindings.md
+++ b/docs/triggerbindings.md
@@ -54,7 +54,7 @@ $({body) # INVALID - Ending curly brace absent
 
 `$(body)` is replaced by the entire body.
 
-$(body) -> "{"key1": "value1", "key2": {"key3": "value3"}, "key4": ["value4", "value5"]}"
+$(body) -> "{"key1": "value1", "key2": {"key3": "value3"}, "key4": ["value4", "value5", "value6"]}"
 
 $(body.key1) -> "value1"
 
@@ -63,6 +63,8 @@ $(body.key2) -> "{"key3": "value3"}"
 $(body.key2.key3) -> "value3"
 
 $(body.key4[0]) -> "value4"
+
+$(body.key4[0:2]) -> "{"value4", "value5"}"
 
 # $(header) is replaced by all of the headers from the event.
 

--- a/pkg/template/jsonpath_test.go
+++ b/pkg/template/jsonpath_test.go
@@ -16,6 +16,7 @@ var arrays = `[{"a": "b"}, {"c": "d"}, {"e": "f"}]`
 // an array or map value and regular values otherwise
 func TestParseJSONPath(t *testing.T) {
 	var objectBody = fmt.Sprintf(`{"body":%s}`, objects)
+	var arrayBody = fmt.Sprintf(`{"body":%s}`, arrays)
 	tests := []struct {
 		name string
 		expr string
@@ -29,7 +30,7 @@ func TestParseJSONPath(t *testing.T) {
 		want: objects,
 	}, {
 		name: "array of objects",
-		in:   fmt.Sprintf(`{"body":%s}`, arrays),
+		in:   arrayBody,
 		expr: "$(body)",
 		want: arrays,
 	}, {
@@ -62,6 +63,26 @@ func TestParseJSONPath(t *testing.T) {
 		in:   objectBody,
 		expr: "$(body.null)",
 		want: "null",
+	}, {
+		name: "multiple results",
+		in:   arrayBody,
+		expr: "$(body[:2])",
+		want: `[{"a": "b"}, {"c": "d"}]`,
+	}, {
+		name: "multiple results with empty string",
+		in:   `{"body":["", "some", "thing"]}`,
+		expr: "$(body[:2])",
+		want: `["", "some"]`,
+	}, {
+		name: "multiple results newlines/special chars",
+		in:   `{"body":["", "v\r\n烈", "thing"]}`,
+		expr: "$(body[:2])",
+		want: `["", "v\r\n烈"]`,
+	}, {
+		name: "multiple results with null",
+		in:   `{"body":["", null, "thing"]}`,
+		expr: "$(body[:2])",
+		want: `["", null]`,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Changes

Previously, if a JSONPath expressions resulted in multiple results, we'd return
each result separated by a space. Now we return a valid JSON array containing
all the results instead.

For example, given the body `{ body: [ {"a":"b"}, {"c","d"}, {"e":"f"} ] }` and the
expression `$(body[0:2])`, the previous output would be `{"a": "b"} {"c": "d"}`
while the new output is `[ {"a": "b"}, {"c": "d"} ]`.

Fixes #338

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
JSONPath expressions that select multiple results now return a valid JSON array.
```
