### PR TITLE
Use `tekton` instead of all as categories 🎿

### DIFF
--- a/config/300-eventlistener.yaml
+++ b/config/300-eventlistener.yaml
@@ -26,7 +26,7 @@ spec:
     shortNames:
     - el
     categories:
-    - all
+    - tekton
     - tekton-triggers
   # Opt into the status subresource so metadata.generation
   # starts to increment

--- a/config/300-triggerbinding.yaml
+++ b/config/300-triggerbinding.yaml
@@ -26,7 +26,7 @@ spec:
     shortNames:
     - tb
     categories:
-    - all
+    - tekton
     - tekton-triggers
   # Opt into the status subresource so metadata.generation
   # starts to increment

--- a/config/300-triggertemplate.yaml
+++ b/config/300-triggertemplate.yaml
@@ -26,7 +26,7 @@ spec:
     shortNames:
     - tt
     categories:
-    - all
+    - tekton
     - tekton-triggers
   # Opt into the status subresource so metadata.generation
   # starts to increment


### PR DESCRIPTION

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

This means Tekton struct won't show in `kubectl get all` but in
`kubectl get tekton` 😉.

This is the same change as tektoncd/pipeline#1884 for triggers :angel: 

/cc @dibyom @wlynch 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Remove the category `all` for our CRD and have a `tekton` categorie that is shared with other tektoncd projects
```
