### PR TITLE
Allow brackets inside Tekton expressions

### DIFF
--- a/docs/triggerbindings.md
+++ b/docs/triggerbindings.md
@@ -50,6 +50,14 @@ These are invalid expressions:
 $({body) # INVALID - Ending curly brace absent
 ```
 
+If the `$()` is embedded inside another `$()` we will use the contents of the innermost
+`$()` as the JSONPath expression
+
+```shell script
+$($(body.b)) -> $(body.b)
+$($($(body.b))) -> $(body.b)
+```
+
 ### Examples
 
 ```shell script

--- a/pkg/template/event.go
+++ b/pkg/template/event.go
@@ -88,7 +88,7 @@ func applyEventValuesToParams(params []pipelinev1.Param, body []byte, header htt
 	for idx, p := range params {
 		pValue := p.Value.StringVal
 		// Find all expressions wrapped in $() from the value
-		expressions := tektonVar.FindAllString(pValue, -1)
+		expressions := findTektonExpressions(pValue)
 		for _, expr := range expressions {
 			val, err := ParseJSONPath(event, expr)
 			if err != nil {

--- a/pkg/template/event_test.go
+++ b/pkg/template/event_test.go
@@ -150,6 +150,16 @@ func TestApplyEventValuesToParams(t *testing.T) {
 			bldr.Param("foo", `val1`),
 			bldr.Param("bar", `val2`),
 		},
+	}, {
+		name:   "Array filters",
+		body:   json.RawMessage(`{"child":[{"a": "b", "w": "1"}, {"a": "c", "w": "2"}, {"a": "d", "w": "3"}]}`),
+		params: []pipelinev1.Param{bldr.Param("a", "$(body.child[?(@.a == 'd')].w)")},
+		want:   []pipelinev1.Param{bldr.Param("a", "3")},
+	}, {
+		name:   "filters + multiple JSONPath expressions",
+		body:   json.RawMessage(`{"child":[{"a": "b", "w": "1"}, {"a": "c", "w": "2"}, {"a": "d", "w": "3"}]}`),
+		params: []pipelinev1.Param{bldr.Param("a", "$(body.child[?(@.a == 'd')].w) : $(body.child[0].a)")},
+		want:   []pipelinev1.Param{bldr.Param("a", "3 : b")},
 	}}
 
 	for _, tt := range tests {

--- a/pkg/template/jsonpath.go
+++ b/pkg/template/jsonpath.go
@@ -146,3 +146,37 @@ func relaxedJSONPathExpression(pathExpression string) (string, error) {
 func isTektonExpr(expr string) bool {
 	return tektonVar.MatchString(expr)
 }
+
+// findTektonExpressions searches for and returns a slice of
+// all substrings that are wrapped in $()
+func findTektonExpressions(in string) []string {
+	results := []string{}
+
+	// No expressions to return
+	if !strings.Contains(in, "$(") {
+		return results
+	}
+	// Splits string on $( to find potential Tekton expressions
+	maybeExpressions := strings.Split(in, "$(")
+	for _, e := range maybeExpressions[1:] { // Split always returns at least one element
+		// Iterate until we find the first unbalanced )
+		numOpenBrackets := 0
+		for i, ch := range e {
+			switch ch {
+			case '(':
+				numOpenBrackets++
+			case ')':
+				numOpenBrackets--
+				if numOpenBrackets < 0 {
+					results = append(results, fmt.Sprintf("$(%s)", e[:i]))
+				}
+			default:
+				continue
+			}
+			if numOpenBrackets < 0 {
+				break
+			}
+		}
+	}
+	return results
+}


### PR DESCRIPTION
We were previously using a regex to extract expressions within
TriggerBindings. The regex only extracted between the initial `$(`
and the first occurrence of the `)`. This meant that some valid
JSONPath expressions that contained brackets (e.g. filters) were
incorrectly extracted.

This commit fixes the issue by splitting the string on `$(` and then
extracting until the *first unbalanced* occurrence of `)`.

Fixes #365 

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
TriggerBinding values now correctly detect embedded brackets

```
