### PR TITLE
fix sink crashloop when upgrading from 0.1 to 0.2

### DIFF
--- a/pkg/apis/triggers/v1alpha1/event_listener_defaults.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_defaults.go
@@ -12,6 +12,7 @@ func (el *EventListener) SetDefaults(ctx context.Context) {
 			t := &el.Spec.Triggers[i]
 			upgradeBinding(t)
 			upgradeInterceptor(t)
+			removeParams(t)
 		}
 	}
 }
@@ -39,5 +40,11 @@ func upgradeInterceptor(t *EventListenerTrigger) {
 
 		t.Interceptors = []*EventInterceptor{t.DeprecatedInterceptor}
 		t.DeprecatedInterceptor = nil
+	}
+}
+
+func removeParams(t *EventListenerTrigger) {
+	if t.DeprecatedParams != nil {
+		t.DeprecatedParams = nil
 	}
 }

--- a/pkg/apis/triggers/v1alpha1/event_listener_defaults_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_defaults_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 )
 
@@ -141,8 +142,28 @@ func TestEventListenerSetDefaults(t *testing.T) {
 				},
 			},
 			wc: v1alpha1.WithUpgradeViaDefaulting,
-		},
-	}
+		}, {
+			name: "with upgrade context - deprecated params",
+			in: &v1alpha1.EventListener{
+				Spec: v1alpha1.EventListenerSpec{
+					Triggers: []v1alpha1.EventListenerTrigger{{
+						DeprecatedParams: []pipelinev1.Param{{
+							Name: "param-name",
+							Value: pipelinev1.ArrayOrString{
+								Type:      "string",
+								StringVal: "static",
+							},
+						},
+						}},
+					}},
+			},
+			want: &v1alpha1.EventListener{
+				Spec: v1alpha1.EventListenerSpec{
+					Triggers: []v1alpha1.EventListenerTrigger{{}},
+				},
+			},
+			wc: v1alpha1.WithUpgradeViaDefaulting,
+		}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := tc.in

--- a/pkg/apis/triggers/v1alpha1/event_listener_types.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_types.go
@@ -74,6 +74,10 @@ type EventListenerTrigger struct {
 
 	// TODO(#248): Remove this before 0.3 release.
 	DeprecatedBinding *EventListenerBinding `json:"binding,omitempty"`
+
+	// TODO(#): Remove this before 0.3 release
+	// DEPRECATED: Use TriggerBindings with static values instead
+	DeprecatedParams []pipelinev1.Param `json:"params,omitempty"`
 }
 
 // EventInterceptor provides a hook to intercept and pre-process events

--- a/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
@@ -267,6 +267,13 @@ func (in *EventListenerTrigger) DeepCopyInto(out *EventListenerTrigger) {
 		*out = new(EventListenerBinding)
 		**out = **in
 	}
+	if in.DeprecatedParams != nil {
+		in, out := &in.DeprecatedParams, &out.DeprecatedParams
+		*out = make([]pipelinev1alpha1.Param, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
@@ -354,6 +354,14 @@ func (c *Reconciler) reconcileDeployment(el *v1alpha1.EventListener) error {
 				existingDeployment.Spec.Template.Spec.Containers[0].Command = nil
 				updated = true
 			}
+			if len(existingDeployment.Spec.Template.Spec.Containers[0].VolumeMounts) == 0 {
+				existingDeployment.Spec.Template.Spec.Containers[0].VolumeMounts = container.VolumeMounts
+				updated = true
+			}
+			if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec.Volumes, deployment.Spec.Template.Spec.Volumes) {
+				existingDeployment.Spec.Template.Spec.Volumes = deployment.Spec.Template.Spec.Volumes
+				updated = true
+			}
 		}
 		if updated {
 			if _, err := c.KubeClientSet.AppsV1().Deployments(el.Namespace).Update(existingDeployment); err != nil {


### PR DESCRIPTION
The crashloop is due to 2 reasons:
1. We deprecated and removed the `params` field from the EventListener. So, when the reconciler tries to  unmarshal an old EventListener, it fails since it cannot parse the deleted `params` field.

2. The new event listener sink image expects `/etc/config-logging` to be mounted. However the reconciler code does not add the `volumeMount` for any existing sink deployments. So, the new pods go into a crashloop

To fix this, this commit does the following:
1. Add back the `params` field. Also, update the mutating webhook to delete any set `params` field in existing eventlisteners.
2. Add volumeMount for existing deployments if not present.

Fixes #366

Co-Authored-by: Brandon Walker <bcwalker@ibm.com>
Signed-off-by: Dibyo Mukherjee <dibyo@google.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
