### PR TITLE
Validate EventListener trigger name as label value

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -59,6 +59,10 @@ resources created:
 | tekton.dev/trigger       | Name of the trigger that generated the resource.       |
 | tekton.dev/eventid       | UID of the incoming event.                             |
 
+Since the EventListener name and trigger name are used as label values, they
+must adhere to the [Kubernetes syntax and character set requirements](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set)
+for label values.
+
 ## Event Interceptors
 
 Triggers within an `EventListener` can optionally specify interceptors, to

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
@@ -65,6 +65,11 @@ func Test_EventListenerValidate(t *testing.T) {
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
 					bldr.EventListenerCELInterceptor("body.value == 'test'")))),
+	}, {
+		name: "Valid EventListener with no trigger name",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tb", "tt", "v1alpha1"))),
 	}}
 
 	for _, test := range tests {
@@ -275,6 +280,18 @@ func TestEventListenerValidate_error(t *testing.T) {
 				}},
 			},
 		},
+	}, {
+		name: "Triggers name has invalid label characters",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
+					bldr.EventListenerTriggerName("github.com/tektoncd/triggers")))),
+	}, {
+		name: "Triggers name is longer than the allowable label value (63 characters)",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tb", "tt", "v1alpha1",
+					bldr.EventListenerTriggerName("1234567890123456789012345678901234567890123456789012345678901234")))),
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
# Changes
Fixes #382
Since we use the EventListener trigger name as the `tekton.dev/trigger`
label, we must validate the trigger name as if it is a label value.
This PR makes webhook validation fail when the trigger name is not a
valid k8s label value.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._