### PR TITLE
Fix a few docs issues

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -7,7 +7,6 @@ resources will be created (or at least attempted) with. The service account must
 have the following role bound.
 
 <!-- FILE: examples/role-resources/role.yaml -->
-
 ```YAML
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -19,13 +18,14 @@ rules:
   resources: ["eventlisteners", "triggerbindings", "triggertemplates", "tasks", "taskruns"]
   verbs: ["get"]
 - apiGroups: [""]
-  resources: ["configmaps"]
+  resources: ["configmaps", "secrets"] # secrets are only needed for Github/Gitlab interceptors
   verbs: ["get", "list", "watch"]
 # Permissions to create resources in associated TriggerTemplates
 - apiGroups: ["tekton.dev"]
   resources: ["pipelineruns", "pipelineresources", "taskruns"]
   verbs: ["create"]
 ```
+
 
 Note that currently, JSON is the only accepted MIME type for events.
 
@@ -60,7 +60,8 @@ resources created:
 | tekton.dev/eventid       | UID of the incoming event.                             |
 
 Since the EventListener name and trigger name are used as label values, they
-must adhere to the [Kubernetes syntax and character set requirements](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set)
+must adhere to the
+[Kubernetes syntax and character set requirements](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set)
 for label values.
 
 ## Event Interceptors
@@ -113,7 +114,6 @@ To be an Event Interceptor, a Kubernetes object should:
   the body, it can simply return the body that it received.
 
 <!-- FILE: examples/eventlisteners/eventlistener-interceptor.yaml -->
-
 ```YAML
 ---
 apiVersion: tekton.dev/v1alpha1
@@ -144,6 +144,7 @@ spec:
         name: pipeline-template
 ```
 
+
 ### GitHub Interceptors
 
 GitHub interceptors contain logic to validate and filter webhooks that come from
@@ -165,7 +166,6 @@ The body/header of the incoming request will be preserved in this interceptor's
 response.
 
 <!-- FILE: examples/eventlisteners/github-eventlistener-interceptor.yaml -->
-
 ```YAML
 ---
 apiVersion: tekton.dev/v1alpha1
@@ -181,7 +181,6 @@ spec:
             secretRef:
               secretName: foo
               secretKey: bar
-              namespace: baz
             eventTypes:
               - pull_request
       bindings:
@@ -189,6 +188,7 @@ spec:
       template:
         name: pipeline-template
 ```
+
 
 ### GitLab Interceptors
 
@@ -212,7 +212,6 @@ The body/header of the incoming request will be preserved in this interceptor's
 response.
 
 <!-- FILE: examples/eventlisteners/gitlab-eventlistener-interceptor.yaml -->
-
 ```YAML
 ---
 apiVersion: tekton.dev/v1alpha1
@@ -228,7 +227,6 @@ spec:
             secretRef:
               secretName: foo
               secretKey: bar
-              namespace: baz
             eventTypes:
               - Push Hook
       bindings:
@@ -236,6 +234,7 @@ spec:
       template:
         name: pipeline-template
 ```
+
 
 ### CEL Interceptors
 
@@ -249,7 +248,6 @@ The body/header of the incoming request will be preserved in this interceptor's
 response.
 
 <!-- FILE: examples/eventlisteners/cel-eventlistener-interceptor.yaml -->
-
 ```YAML
 apiVersion: tekton.dev/v1alpha1
 kind: EventListener
@@ -267,6 +265,7 @@ spec:
       template:
         name: pipeline-template
 ```
+
 
 The `expression` must return a `true` value, otherwise the request will be
 filtered out.

--- a/docs/triggerbindings.md
+++ b/docs/triggerbindings.md
@@ -6,7 +6,6 @@ parameters. The separation of `TriggerBinding`s from `TriggerTemplate`s was
 deliberate to encourage reuse between them.
 
 <!-- FILE: examples/triggerbindings/triggerbinding.yaml -->
-
 ```YAML
 apiVersion: tekton.dev/v1alpha1
 kind: TriggerBinding
@@ -21,6 +20,7 @@ spec:
   - name: contenttype
     value: $(header.Content-Type)
 ```
+
 
 `TriggerBinding`s are connected to `TriggerTemplate`s within an
 [`EventListener`](eventlisteners.md), which is where the pod is actually
@@ -50,8 +50,8 @@ These are invalid expressions:
 $({body) # INVALID - Ending curly brace absent
 ```
 
-If the `$()` is embedded inside another `$()` we will use the contents of the innermost
-`$()` as the JSONPath expression
+If the `$()` is embedded inside another `$()` we will use the contents of the
+innermost `$()` as the JSONPath expression
 
 ```shell script
 $($(body.b)) -> $(body.b)

--- a/docs/triggertemplates.md
+++ b/docs/triggertemplates.md
@@ -5,7 +5,6 @@ A `TriggerTemplate` is a resource that can template resources.
 **anywhere** within the resource template.
 
 <!-- FILE: examples/triggertemplates/triggertemplate.yaml -->
-
 ```YAML
 apiVersion: tekton.dev/v1alpha1
 kind: TriggerTemplate
@@ -46,6 +45,7 @@ spec:
           - name: url
             value: $(params.gitrepositoryurl)
 ```
+
 
 Similar to
 [Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md),`TriggerTemplate`s

--- a/examples/eventlisteners/eventlistener-multiinterceptor.yaml
+++ b/examples/eventlisteners/eventlistener-multiinterceptor.yaml
@@ -12,7 +12,6 @@ spec:
             secretRef:
               secretName: foo
               secretKey: bar
-              namespace: baz
             eventTypes:
               - pull_request
         - webhook:

--- a/examples/eventlisteners/github-eventlistener-interceptor.yaml
+++ b/examples/eventlisteners/github-eventlistener-interceptor.yaml
@@ -12,7 +12,6 @@ spec:
             secretRef:
               secretName: foo
               secretKey: bar
-              namespace: baz
             eventTypes:
               - pull_request
       bindings:

--- a/examples/eventlisteners/gitlab-eventlistener-interceptor.yaml
+++ b/examples/eventlisteners/gitlab-eventlistener-interceptor.yaml
@@ -12,7 +12,6 @@ spec:
             secretRef:
               secretName: foo
               secretKey: bar
-              namespace: baz
             eventTypes:
               - Push Hook
       bindings:

--- a/examples/role-resources/role.yaml
+++ b/examples/role-resources/role.yaml
@@ -8,7 +8,7 @@ rules:
   resources: ["eventlisteners", "triggerbindings", "triggertemplates", "tasks", "taskruns"]
   verbs: ["get"]
 - apiGroups: [""]
-  resources: ["configmaps"]
+  resources: ["configmaps", "secrets"] # secrets are only needed for Github/Gitlab interceptors
   verbs: ["get", "list", "watch"]
 # Permissions to create resources in associated TriggerTemplates
 - apiGroups: ["tekton.dev"]

--- a/tekton/README.md
+++ b/tekton/README.md
@@ -24,7 +24,7 @@ To start from scratch and use these Pipelines and Tasks:
 ## Create an official release
 
 Official releases are performed from
-[the `prow` cluster](https://github.com/tektoncd/plumbing#prow)
+[the `dogfooding` cluster](https://github.com/tektoncd/plumbing)
 [in the `tekton-releases` GCP project](https://github.com/tektoncd/plumbing/blob/master/gcp.md).
 This cluster
 [already has the correct version of Tekton installed](#install-tekton).
@@ -70,8 +70,8 @@ To use [`tkn`](https://github.com/tektoncd/cli) to run the
    ```
 
 1. To run against your own infrastructure (if you are running
-   [in the production cluster](https://github.com/tektoncd/plumbing#prow) the
-   default account should already have these creds, this is just a bonus - plus
+   [in the dogfooding cluster](https://github.com/tektoncd/plumbing) the default
+   account should already have these creds, this is just a bonus - plus
    `release-right-meow` might already exist in the cluster!), also setup the
    required credentials for the `release-right-meow` service account, either:
 
@@ -83,13 +83,13 @@ To use [`tkn`](https://github.com/tektoncd/cli) to run the
      [your own GCP service account](https://cloud.google.com/iam/docs/creating-managing-service-accounts)
      if running against your own infrastructure
 
-1. [Connect to the production cluster](https://github.com/tektoncd/plumbing#prow):
+1. Connect to the dogfooding cluster:
 
    ```bash
    gcloud container clusters get-credentials prow --zone us-central1-a --project tekton-releases
    ```
 
-1. Run the `release-pipeline` (assuming you are using the production cluster and
+1. Run the `release-pipeline` (assuming you are using the dogfooding cluster and
    [all the Tasks and Pipelines already exist](#setup)):
 
    ```shell
@@ -101,14 +101,14 @@ To use [`tkn`](https://github.com/tektoncd/cli) to run the
    export VERSION_TAG=v0.X.Y
 
    tkn pipeline start \
-   \
-   \
-   \
-   \
-   \
+    --param=versionTag=${VERSION_TAG} \
+    --serviceaccount=release-right-meow \
+    --resource=source-repo=tekton-triggers-git \
+    --resource=bucket=tekton-bucket \
+    --resource=builtEventListenerSinkImage=event-listener-sink-image \
     --resource=builtControllerImage=triggers-controller-image \
-   \
-   e
+    --resource=builtWebhookImage=triggers-webhook-image \
+    triggers-release
    ```
 
 _TODO(tektoncd/pipeline#569): Normally we'd use the image `PipelineResources` to


### PR DESCRIPTION
# Changes

- Example Service Account now has get role on secrets (for Github and Gitlab
  interceptors)

- Update release docs to indicate that releases use the dogfooding cluster and
  not the prow cluster

- Add back tkn command that got removed by the bot running `prettier` command
  on markdown files

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes
