### PR TITLE
Fix bug running multiple triggers

### DIFF
--- a/pkg/sink/sink.go
+++ b/pkg/sink/sink.go
@@ -87,15 +87,14 @@ func (r Sink) HandleEvent(response http.ResponseWriter, request *http.Request) {
 
 	result := make(chan int, 10)
 	// Execute each Trigger
-
 	for _, t := range el.Spec.Triggers {
-		go func(t *triggersv1.EventListenerTrigger) {
-			if err := r.processTrigger(t, request, event, eventID, eventLog); err != nil {
+		go func(t triggersv1.EventListenerTrigger) {
+			if err := r.processTrigger(&t, request, event, eventID, eventLog); err != nil {
 				result <- http.StatusAccepted
 				return
 			}
 			result <- http.StatusCreated
-		}(&t)
+		}(t)
 	}
 
 	//The eventlistener waits until all the trigger executions (up-to the creation of the resources) and


### PR DESCRIPTION
# Changes
Fixes #387
This PR fixes a pointer bug where an EventListener with `n` triggers
would have the last trigger execute `n` times instead of all `n`
triggers executing once.

This PR also updates the TestHandleEvent function to test multiple
triggers. In the future, it might be worth refactoring the
TestHandleEvent function into a testing table, so we can increase our
test coverage.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._
