### PR TITLE
Remove debug print statement in sink_test.go

### DIFF
--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -458,8 +458,7 @@ func (f *nameInterceptor) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	// Write the name to the body
 	body := fmt.Sprintf(`{"name": "%s"}`, name)
-	fmt.Printf("~~~ body: %s\n", body)
-	w.Write([]byte(body))
+	_, _ = w.Write([]byte(body))
 }
 
 func TestHandleEventWithWebhookInterceptors(t *testing.T) {


### PR DESCRIPTION
# Changes
Remove debug print statement in `sink_test.go`. Cleanup from PR https://github.com/tektoncd/triggers/pull/393.

Sorry, I need to look over my PRs more thoroughly for comments & debug logs 😅 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)