### PR TITLE
Fix e2e tests

### DIFF
--- a/test/e2e-tests-ingress.sh
+++ b/test/e2e-tests-ingress.sh
@@ -162,7 +162,7 @@ spec:
     - name: ServiceUID
       value: ${SERVICE_UID}
   timeout: 1000s
-  serviceAccount: default
+  serviceAccountName: default
 DONE
 wait_until_taskrun_completed ${INGRESS_TASKRUN_NAME}
 


### PR DESCRIPTION
Fix the url of pipeline release.yaml as it was pointing to old
release urls and was installing 0.7 till now, as 0.10.1 got released to
both url's today, tests started failing

So better fetch the latest release yaml from last release on github

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

