### PR TITLE
Add decodeb64 function to CEL expressions.

### DIFF
--- a/docs/cel_expressions.md
+++ b/docs/cel_expressions.md
@@ -112,7 +112,7 @@ interceptor.
     <td>
      <pre>split(body.ref, '/')</pre>
     </td>
-</tr>
+  </tr>
     <th>
       canonical
     </th>
@@ -124,6 +124,20 @@ interceptor.
     </td>
     <td>
      <pre>header.canonical('x-test')</pre>
+    </td>
+  </tr>
+  <tr>
+    <th>
+      decodeb64
+    </th>
+    <td>
+      (string) -> string
+    </td>
+    <td>
+      Decodes a base64 encoded string.
+    </td>
+    <td>
+     <pre>decodeb64(body.message.data)</pre>
     </td>
   </tr>
 </table>

--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -266,7 +266,7 @@ spec:
     - name: cel-trig-with-matches
       interceptors:
         - cel:
-            filter: "headers.matches('X-GitHub-Event', 'pull_request')"
+            filter: "header.match('X-GitHub-Event', 'pull_request')"
             overlays:
             - key: extensions.truncated_sha
               expression: "truncate(body.pull_request.head.sha, 7)"
@@ -283,6 +283,7 @@ spec:
       template:
         name: pipeline-template
 ```
+
 
 If no filter is provided, then the overlays will be applied to the body,
 

--- a/examples/eventlisteners/cel-eventlistener-interceptor.yaml
+++ b/examples/eventlisteners/cel-eventlistener-interceptor.yaml
@@ -8,7 +8,7 @@ spec:
     - name: cel-trig-with-matches
       interceptors:
         - cel:
-            filter: "headers.matches('X-GitHub-Event', 'pull_request')"
+            filter: "header.match('X-GitHub-Event', 'pull_request')"
             overlays:
             - key: extensions.truncated_sha
               expression: "truncate(body.pull_request.head.sha, 7)"


### PR DESCRIPTION
# Changes

This adds a decodeb64 to the CEL functions, making it easy to decode Base64 encoded data in a hook payload.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Add function `decodeb64` to the CEL expressions usable by the overlay mechanism.
```
