### PR TITLE
Rename match to matchHeader.

### DIFF
--- a/docs/cel_expressions.md
+++ b/docs/cel_expressions.md
@@ -52,8 +52,7 @@ NOTE: The header value is a Go `http.Header`, which is
 type Header map[string][]string
 ```
 
-i.e. the header is a mapping of strings, to arrays of strings, see the `match`
-function on headers below for an extension that makes looking up headers easier.
+i.e. the header is a mapping of strings, to arrays of strings, see the `canonicalMatch` function on header below for an extension that makes looking up headers easier.
 
 ### List of extension functions
 
@@ -69,7 +68,7 @@ interceptor.
   </tr>
   <tr>
     <th>
-      match
+      canonicalMatch
     </th>
     <td>
       header.(string, string) -> bool
@@ -78,7 +77,7 @@ interceptor.
       Uses the canonical header matching from Go's http.Request to match the header against the value.
     </td>
     <td>
-     <pre>header.match('x-test', 'test-value')</pre>
+     <pre>header.canonicalMatch('x-test', 'test-value')</pre>
     </td>
   </tr>
   <tr>

--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -256,7 +256,7 @@ spec:
     - name: cel-trig
       interceptors:
         - cel:
-            filter: "headers.matches('X-GitHub-Event', 'pull_request')"
+            filter: "header.canonicalMatch('X-GitHub-Event', 'pull_request')"
             overlays:
             - key: extensions.truncated_sha
               expression: "truncate(body.pull_request.head.sha, 7)"

--- a/examples/eventlisteners/cel-eventlistener-interceptor.yaml
+++ b/examples/eventlisteners/cel-eventlistener-interceptor.yaml
@@ -8,7 +8,7 @@ spec:
     - name: cel-trig
       interceptors:
         - cel:
-            filter: "headers.matches('X-GitHub-Event', 'pull_request')"
+            filter: "header.canonicalMatch('X-GitHub-Event', 'pull_request')"
             overlays:
             - key: extensions.truncated_sha
               expression: "truncate(body.pull_request.head.sha, 7)"

--- a/pkg/interceptors/cel/cel_test.go
+++ b/pkg/interceptors/cel/cel_test.go
@@ -41,7 +41,7 @@ func TestInterceptor_ExecuteTrigger(t *testing.T) {
 		{
 			name: "overloaded header check with case insensitive matching",
 			CEL: &triggersv1.CELInterceptor{
-				Filter: "header.match('x-test', 'test-value')",
+				Filter: "header.canonicalMatch('x-test', 'test-value')",
 			},
 			payload: ioutil.NopCloser(bytes.NewBufferString(`{}`)),
 			want:    []byte(`{}`),
@@ -49,7 +49,7 @@ func TestInterceptor_ExecuteTrigger(t *testing.T) {
 		{
 			name: "body and header check",
 			CEL: &triggersv1.CELInterceptor{
-				Filter: "header.match('x-test', 'test-value') && body.value == 'test'",
+				Filter: "header.canonicalMatch('x-test', 'test-value') && body.value == 'test'",
 			},
 			payload: ioutil.NopCloser(bytes.NewBufferString(`{"value":"test"}`)),
 			want:    []byte(`{"value":"test"}`),
@@ -89,7 +89,7 @@ func TestInterceptor_ExecuteTrigger(t *testing.T) {
 		},
 		{
 			name:    "nil body does not panic",
-			CEL:     &triggersv1.CELInterceptor{Filter: "header.match('x-test', 'test-value')"},
+			CEL:     &triggersv1.CELInterceptor{Filter: "header.canonicalMatch('x-test', 'test-value')"},
 			payload: nil,
 			want:    []byte(`{}`),
 		},
@@ -151,10 +151,10 @@ func TestInterceptor_ExecuteTrigger_Errors(t *testing.T) {
 		{
 			name: "overloaded header check with case insensitive failed match",
 			CEL: &triggersv1.CELInterceptor{
-				Filter: "header.match('x-test', 'no-match')",
+				Filter: "header.canonicalMatch('x-test', 'no-match')",
 			},
 			payload: []byte(`{}`),
-			want:    "expression header.match\\('x-test', 'no-match'\\) did not return true",
+			want:    "expression header.canonicalMatch\\('x-test', 'no-match'\\) did not return true",
 		},
 		{
 			name: "unable to parse the expression",
@@ -302,7 +302,7 @@ func TestExpressionEvaluation_Error(t *testing.T) {
 		},
 		{
 			name: "invalid function overloading",
-			expr: "body.match('testing', 'test')",
+			expr: "body.canonicalMatch('testing', 'test')",
 			want: "failed to convert to http.Header",
 		},
 	}


### PR DESCRIPTION
# Changes

Rename the overload on the http request in the CEL context from `match` to `matchHeader`.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Rename the `match` overlay on the http request to `matchHeader` in the CEL expression language.

NOTE: This is a breaking change.
```
