### PR TITLE
Add CEL function canonical.

### DIFF
--- a/docs/cel_expressions.md
+++ b/docs/cel_expressions.md
@@ -111,5 +111,18 @@ interceptor.
     <td>
      <pre>split(body.ref, '/')</pre>
     </td>
+</tr>
+    <th>
+      canonical
+    </th>
+    <td>
+      header.(string) -> string
+    </td>
+    <td>
+      Uses the canonical header matching from Go's http.Request to get the provided header name.
+    </td>
+    <td>
+     <pre>header.canonical('x-test')</pre>
+    </td>
   </tr>
 </table>

--- a/docs/clustertriggerbindings.md
+++ b/docs/clustertriggerbindings.md
@@ -6,7 +6,6 @@ designed to encourage reusability clusterwide. You can reference a
 ClusterTriggerBinding in any EventListener in any namespace.
 
 <!-- FILE: examples/clustertriggerbindings/clustertriggerbinding.yaml -->
-
 ```YAML
 apiVersion: tekton.dev/v1alpha1
 kind: ClusterTriggerBinding
@@ -22,6 +21,7 @@ spec:
       value: $(header.Content-Type)
 ```
 
+
 You can specify multiple ClusterTriggerBindings in a Trigger. You can use a
 ClusterTriggerBinding in multiple Triggers.
 
@@ -29,7 +29,6 @@ In case of using a ClusterTriggerBinding, the `Binding` kind should be added.
 The default kind is TriggerBinding which represents a namespaced TriggerBinding.
 
 <!-- FILE: examples/eventlisteners/eventlistener-clustertriggerbinding.yaml -->
-
 ```YAML
 ---
 apiVersion: tekton.dev/v1alpha1
@@ -48,3 +47,4 @@ spec:
       template:
         name: pipeline-template
 ```
+

--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -7,7 +7,6 @@ resources will be created (or at least attempted) with. The service account must
 have the following role bound.
 
 <!-- FILE: examples/role-resources/triggerbinding-roles/role.yaml -->
-
 ```YAML
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -26,6 +25,7 @@ rules:
   resources: ["pipelineruns", "pipelineresources", "taskruns"]
   verbs: ["create"]
 ```
+
 
 Note that currently, JSON is the only accepted MIME type for events.
 
@@ -115,7 +115,6 @@ To be an Event Interceptor, a Kubernetes object should:
   the body, it can simply return the body that it received.
 
 <!-- FILE: examples/eventlisteners/eventlistener-interceptor.yaml -->
-
 ```YAML
 ---
 apiVersion: tekton.dev/v1alpha1
@@ -146,6 +145,7 @@ spec:
         name: pipeline-template
 ```
 
+
 ### GitHub Interceptors
 
 GitHub interceptors contain logic to validate and filter webhooks that come from
@@ -167,7 +167,6 @@ The body/header of the incoming request will be preserved in this interceptor's
 response.
 
 <!-- FILE: examples/eventlisteners/github-eventlistener-interceptor.yaml -->
-
 ```YAML
 ---
 apiVersion: tekton.dev/v1alpha1
@@ -191,6 +190,7 @@ spec:
         name: pipeline-template
 ```
 
+
 ### GitLab Interceptors
 
 GitLab interceptors contain logic to validate and filter requests that come from
@@ -213,7 +213,6 @@ The body/header of the incoming request will be preserved in this interceptor's
 response.
 
 <!-- FILE: examples/eventlisteners/gitlab-eventlistener-interceptor.yaml -->
-
 ```YAML
 ---
 apiVersion: tekton.dev/v1alpha1
@@ -237,6 +236,7 @@ spec:
         name: pipeline-template
 ```
 
+
 ### CEL Interceptors
 
 CEL interceptors parse expressions to filter requests based on JSON bodies and
@@ -251,7 +251,6 @@ The body/header of the incoming request will be preserved in this interceptor's
 response.
 
 <!-- FILE: examples/eventlisteners/cel-eventlistener-interceptor.yaml -->
-
 ```YAML
 apiVersion: tekton.dev/v1alpha1
 kind: EventListener
@@ -260,7 +259,7 @@ metadata:
 spec:
   serviceAccountName: tekton-triggers-example-sa
   triggers:
-    - name: cel-trig
+    - name: cel-trig-with-matches
       interceptors:
         - cel:
             filter: "headers.matches('X-GitHub-Event', 'pull_request')"
@@ -271,7 +270,16 @@ spec:
       - name: pipeline-binding
       template:
         name: pipeline-template
+    - name: cel-trig-with-canonical
+      interceptors:
+        - cel:
+            filter: "headers.canonical('X-GitHub-Event') == 'push'"
+      bindings:
+      - name: pipeline-binding
+      template:
+        name: pipeline-template
 ```
+
 
 If no filter is provided, then the overlays will be applied to the body,
 
@@ -279,7 +287,6 @@ With a filter, the `expression` must return a `true` value, otherwise the
 request will be filtered out.
 
 <!-- FILE: examples/eventlisteners/cel-eventlistener-no-filter.yaml -->
-
 ```YAML
 apiVersion: tekton.dev/v1alpha1
 kind: EventListener
@@ -299,3 +306,4 @@ spec:
       template:
         name: pipeline-template
 ```
+

--- a/docs/triggerbindings.md
+++ b/docs/triggerbindings.md
@@ -6,7 +6,6 @@ parameters. The separation of `TriggerBinding`s from `TriggerTemplate`s was
 deliberate to encourage reuse between them.
 
 <!-- FILE: examples/triggerbindings/triggerbinding.yaml -->
-
 ```YAML
 apiVersion: tekton.dev/v1alpha1
 kind: TriggerBinding
@@ -21,6 +20,7 @@ spec:
   - name: contenttype
     value: $(header.Content-Type)
 ```
+
 
 `TriggerBinding`s are connected to `TriggerTemplate`s within an
 [`EventListener`](eventlisteners.md), which is where the pod is actually

--- a/docs/triggertemplates.md
+++ b/docs/triggertemplates.md
@@ -5,7 +5,6 @@ A `TriggerTemplate` is a resource that can template resources.
 **anywhere** within the resource template.
 
 <!-- FILE: examples/triggertemplates/triggertemplate.yaml -->
-
 ```YAML
 apiVersion: tekton.dev/v1alpha1
 kind: TriggerTemplate
@@ -46,6 +45,7 @@ spec:
           - name: url
             value: $(params.gitrepositoryurl)
 ```
+
 
 Similar to
 [Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md),`TriggerTemplate`s

--- a/examples/eventlisteners/cel-eventlistener-interceptor.yaml
+++ b/examples/eventlisteners/cel-eventlistener-interceptor.yaml
@@ -5,13 +5,21 @@ metadata:
 spec:
   serviceAccountName: tekton-triggers-example-sa
   triggers:
-    - name: cel-trig
+    - name: cel-trig-with-matches
       interceptors:
         - cel:
             filter: "headers.matches('X-GitHub-Event', 'pull_request')"
             overlays:
             - key: extensions.truncated_sha
               expression: "truncate(body.pull_request.head.sha, 7)"
+      bindings:
+      - name: pipeline-binding
+      template:
+        name: pipeline-template
+    - name: cel-trig-with-canonical
+      interceptors:
+        - cel:
+            filter: "headers.canonical('X-GitHub-Event') == 'push'"
       bindings:
       - name: pipeline-binding
       template:


### PR DESCRIPTION
# Changes

This adds an overlay function for CEL expressions, that accepts a header
name and does a canonical lookup on the value, returning a string.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
This adds a new canonical function on the header, making it easy to fetch a request header by name.
```
