### PR TITLE
Add support for splitting strings to CEL expressions.

### DIFF
--- a/docs/cel_expressions.md
+++ b/docs/cel_expressions.md
@@ -95,5 +95,18 @@ interceptor.
      <pre>truncate(body.commit.sha, 5)</pre>
     </td>
   </tr>
-
+  <tr>
+    <th>
+      split
+    </th>
+    <td>
+      (string, string) -> string(dyn)
+    </td>
+    <td>
+      Splits a string on the provided separator value.
+    </td>
+    <td>
+     <pre>split(body.ref, '/')</pre>
+    </td>
+  </tr>
 </table>


### PR DESCRIPTION
# Changes

This adds an additional CEL function for splitting strings on a separator.

e.g. body.ref.split('/') would split the ref on '/' and return a list of strings.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
This adds a CEL expression function for splitting strings.

e.g. to extract the tag or branch from a hook event in an overlay:

            overlays:
            - key: intercepted.branch_name
              expression: "body.ref.split('/')[2]"
```
