### PR TITLE
Clean up sink_test.go

### DIFF
--- a/pkg/sink/initialization.go
+++ b/pkg/sink/initialization.go
@@ -31,9 +31,9 @@ import (
 
 const (
 	// Flag definitions
-	name      = "el-name"
-	namespace = "el-namespace"
-	port      = "port"
+	name        = "el-name"
+	elNamespace = "el-namespace"
+	port        = "port"
 )
 
 var (
@@ -71,7 +71,7 @@ func GetArgs() (Args, error) {
 		return Args{}, xerrors.Errorf("-%s arg not found", name)
 	}
 	if *namespaceFlag == "" {
-		return Args{}, xerrors.Errorf("-%s arg not found", namespace)
+		return Args{}, xerrors.Errorf("-%s arg not found", elNamespace)
 	}
 	if *portFlag == "" {
 		return Args{}, xerrors.Errorf("-%s arg not found", port)

--- a/pkg/sink/initialization_test.go
+++ b/pkg/sink/initialization_test.go
@@ -25,7 +25,7 @@ func Test_GetArgs(t *testing.T) {
 	if err := flag.Set(name, "elname"); err != nil {
 		t.Errorf("Error setting flag el-name: %s", err)
 	}
-	if err := flag.Set(namespace, "elnamespace"); err != nil {
+	if err := flag.Set(elNamespace, "elnamespace"); err != nil {
 		t.Errorf("Error setting flag el-namespace: %s", err)
 	}
 	if err := flag.Set(port, "port"); err != nil {

--- a/test/controller_test.go
+++ b/test/controller_test.go
@@ -114,6 +114,12 @@ func TestGetResourcesFromClients(t *testing.T) {
 			Name:      "my-config-map-1",
 		},
 	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+			Name:      "such-secret",
+		},
+	}
 
 	tests := []struct {
 		name      string
@@ -199,6 +205,12 @@ func TestGetResourcesFromClients(t *testing.T) {
 			Resources: Resources{
 				Namespaces: []*corev1.Namespace{nsFoo, nsTektonPipelines},
 				ConfigMaps: []*corev1.ConfigMap{configMap1},
+			},
+		}, {
+			name: "only secrets (and namespaces)",
+			Resources: Resources{
+				Namespaces: []*corev1.Namespace{nsFoo},
+				Secrets:    []*corev1.Secret{secret},
 			},
 		},
 	}


### PR DESCRIPTION
# Changes

This commit refactors sink_test:
1. Common setup/comparison extracted to helper methods
2. Removes some redundant params from the test resources
3. Remove the test that checks that we respond in 1s or less.
Since we are using fake clients in these examples, this test is
not as useful as it being in an e2e test.

Part of #394

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._
