### PR TITLE
cel langdef doc links

### DIFF
--- a/docs/cel_expressions.md
+++ b/docs/cel_expressions.md
@@ -3,6 +3,9 @@
 The CEL expression is configured to expose parts of the request, and some custom
 functions to make matching easier.
 
+In addition to the custom function extension listed below, you can craft any valid CEL 
+expression as defined by the [cel-spec language definition](https://github.com/google/cel-spec/blob/master/doc/langdef.md)
+
 ### List of extensions
 
 The body from the `http.Request` value is decoded to JSON and exposed, and the

--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -70,7 +70,7 @@ Triggers within an `EventListener` can optionally specify interceptors, to
 modify the behavior or payload of triggers.
 
 Event Interceptors can take several different forms today:
-
+ 
 - [Webhook Interceptors](#Webhook-Interceptors)
 - [GitHub Interceptors](#GitHub-Interceptors)
 - [GitLab Interceptors](#GitLab-Interceptors)
@@ -241,9 +241,11 @@ spec:
 
 CEL interceptors parse expressions to filter requests based on JSON bodies and
 request headers, using the [CEL](https://github.com/google/cel-go) expression
-language.
+language. Please read the [cel-spec language definition](https://github.com/google/cel-spec/blob/master/doc/langdef.md)
+for more details on the expression language syntax.
 
-Supported features include case-insensitive matching on request headers.
+In addition to the standard [CEL expression language syntax](https://github.com/google/cel-spec/blob/master/doc/langdef.md), additional 
+supported features include case-insensitive matching on request headers.
 
 The body/header of the incoming request will be preserved in this interceptor's
 response.


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Updated docs to include links to the actual CEL language specification as it is not clear from the docs in their current state what the standard CEL syntax actually is.

