### PR TITLE
Delete clusterscoped resource in teardown

### DIFF
--- a/test/init_test.go
+++ b/test/init_test.go
@@ -101,6 +101,19 @@ func tearDown(t *testing.T, cs *clients, namespace string) {
 	if err := cs.KubeClient.CoreV1().Namespaces().Delete(namespace, &metav1.DeleteOptions{}); err != nil {
 		t.Errorf("Failed to delete namespace %s: %s", namespace, err)
 	}
+
+	t.Logf("Deleting Clusterscoped resource")
+	if err := cs.KubeClient.RbacV1().ClusterRoles().Delete("my-role", &metav1.DeleteOptions{}); err != nil {
+		t.Errorf("Failed to delete clusterrole my-role: %s", err)
+	}
+
+	if err := cs.KubeClient.RbacV1().ClusterRoleBindings().Delete("my-rolebinding", &metav1.DeleteOptions{}); err != nil {
+		t.Errorf("Failed to delete clusterrolebinding my-rolebinding: %s", err)
+	}
+
+	if err := cs.TriggersClient.TektonV1alpha1().ClusterTriggerBindings().Delete("my-clustertriggerbinding", &metav1.DeleteOptions{}); err != nil {
+		t.Errorf("Failed to delete clustertriggerbinding my-clustertriggerbinding: %s", err)
+	}
 }
 
 func header(logf logging.FormatLogger, text string) {


### PR DESCRIPTION
This will delete the clusterscoped resources we are creating
in event listener e2e tests during teardown

Fix #418

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

