### PR TITLE
Remove deprecated binding

### DIFF
--- a/pkg/apis/triggers/v1alpha1/event_listener_defaults.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_defaults.go
@@ -25,29 +25,15 @@ func (el *EventListener) SetDefaults(ctx context.Context) {
 
 	// set defaults
 	for i := range el.Spec.Triggers {
-		t := &el.Spec.Triggers[i]
-		// TODO(#290): Remove this before 0.3 release.
-		defaultDeprecatedBinding(t)
-		defaultBindings(t)
+		defaultBindings(&el.Spec.Triggers[i])
 	}
 
 	if IsUpgradeViaDefaulting(ctx) {
 		// Most likely the EventListener passed here is already running
 		for i := range el.Spec.Triggers {
 			t := &el.Spec.Triggers[i]
-			upgradeBinding(t)
 			upgradeInterceptor(t)
 			removeParams(t)
-		}
-	}
-}
-
-// set default TriggerBinding kind for depcrecatedBinding
-// TODO(#290): Remove this before 0.3 release.
-func defaultDeprecatedBinding(t *EventListenerTrigger) {
-	if t.DeprecatedBinding != nil {
-		if t.DeprecatedBinding.Kind == "" {
-			t.DeprecatedBinding.Kind = NamespacedTriggerBindingKind
 		}
 	}
 }
@@ -59,21 +45,6 @@ func defaultBindings(t *EventListenerTrigger) {
 			if b.Kind == "" {
 				b.Kind = NamespacedTriggerBindingKind
 			}
-		}
-	}
-}
-
-func upgradeBinding(t *EventListenerTrigger) {
-	if t.DeprecatedBinding != nil {
-		if len(t.Bindings) > 0 {
-			// Do nothing since it will be a Validation Error.
-		} else {
-			// Set the binding to bindings
-			t.Bindings = append(t.Bindings, &EventListenerBinding{
-				Name: t.DeprecatedBinding.Name,
-				Kind: t.DeprecatedBinding.Kind,
-			})
-			t.DeprecatedBinding = nil
 		}
 	}
 }

--- a/pkg/apis/triggers/v1alpha1/event_listener_defaults_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_defaults_test.go
@@ -32,183 +32,104 @@ func TestEventListenerSetDefaults(t *testing.T) {
 		want *v1alpha1.EventListener
 		wc   func(context.Context) context.Context
 	}{{
-		name: "with upgrade context - binding present",
+		name: "default binding",
 		in: &v1alpha1.EventListener{
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
-					DeprecatedBinding: &v1alpha1.EventListenerBinding{
-						Name: "my-binding",
-					},
-				}},
-			},
-		},
-		want: &v1alpha1.EventListener{
-			Spec: v1alpha1.EventListenerSpec{
-				Triggers: []v1alpha1.EventListenerTrigger{{
-					Bindings: []*v1alpha1.EventListenerBinding{{
-						Name: "my-binding",
-						Kind: v1alpha1.NamespacedTriggerBindingKind,
-					}},
-				}},
-			},
-		},
-		wc: v1alpha1.WithUpgradeViaDefaulting,
-	}, {
-		name: "with upgrade context - cluster binding present",
-		in: &v1alpha1.EventListener{
-			Spec: v1alpha1.EventListenerSpec{
-				Triggers: []v1alpha1.EventListenerTrigger{{
-					DeprecatedBinding: &v1alpha1.EventListenerBinding{
-						Name: "my-binding",
-						Kind: v1alpha1.ClusterTriggerBindingKind,
-					},
-				}},
-			},
-		},
-		want: &v1alpha1.EventListener{
-			Spec: v1alpha1.EventListenerSpec{
-				Triggers: []v1alpha1.EventListenerTrigger{{
-					Bindings: []*v1alpha1.EventListenerBinding{{
-						Name: "my-binding",
-						Kind: v1alpha1.ClusterTriggerBindingKind,
-					}},
-				}},
-			},
-		},
-		wc: v1alpha1.WithUpgradeViaDefaulting,
-	}, {
-		name: "with upgrade context - no binding present",
-		in: &v1alpha1.EventListener{
-			Spec: v1alpha1.EventListenerSpec{
-				Triggers: []v1alpha1.EventListenerTrigger{{
-					Bindings: []*v1alpha1.EventListenerBinding{{
-						Name: "my-binding",
-						Kind: "ClusterTriggerBinding",
-					}},
-				}},
-			},
-		},
-		want: &v1alpha1.EventListener{
-			Spec: v1alpha1.EventListenerSpec{
-				Triggers: []v1alpha1.EventListenerTrigger{{
-					Bindings: []*v1alpha1.EventListenerBinding{{
-						Name: "my-binding",
-						Kind: v1alpha1.ClusterTriggerBindingKind,
-					}},
-				}},
-			},
-		},
-		wc: v1alpha1.WithUpgradeViaDefaulting,
-	}, {
-		name: "with upgrade context - both binding and bindings present",
-		in: &v1alpha1.EventListener{
-			Spec: v1alpha1.EventListenerSpec{
-				Triggers: []v1alpha1.EventListenerTrigger{{
-					DeprecatedBinding: &v1alpha1.EventListenerBinding{
-						Name: "my-binding-1",
-					},
-					Bindings: []*v1alpha1.EventListenerBinding{{
-						Name: "my-binding",
-					}},
-				}},
-			},
-		},
-		want: &v1alpha1.EventListener{
-			Spec: v1alpha1.EventListenerSpec{
-				Triggers: []v1alpha1.EventListenerTrigger{{
-					DeprecatedBinding: &v1alpha1.EventListenerBinding{
-						Name: "my-binding-1",
-						Kind: v1alpha1.NamespacedTriggerBindingKind,
-					},
-					Bindings: []*v1alpha1.EventListenerBinding{{
-						Name: "my-binding",
-						Kind: v1alpha1.NamespacedTriggerBindingKind,
-					}},
-				}},
-			},
-		},
-		wc: v1alpha1.WithUpgradeViaDefaulting,
-	}, {
-		name: "no upgrade context",
-		in: &v1alpha1.EventListener{
-			Spec: v1alpha1.EventListenerSpec{
-				Triggers: []v1alpha1.EventListenerTrigger{{
-					DeprecatedBinding: &v1alpha1.EventListenerBinding{
-						Name: "my-binding",
-					},
-				}},
-			},
-		},
-		want: &v1alpha1.EventListener{
-			Spec: v1alpha1.EventListenerSpec{
-				Triggers: []v1alpha1.EventListenerTrigger{{
-					DeprecatedBinding: &v1alpha1.EventListenerBinding{
-						Name: "my-binding",
-						Kind: v1alpha1.NamespacedTriggerBindingKind,
-					},
-				}},
-			},
-		},
-	},
-		{
-			name: "with upgrade context - both interceptor and interceptors present",
-			in: &v1alpha1.EventListener{
-				Spec: v1alpha1.EventListenerSpec{
-					Triggers: []v1alpha1.EventListenerTrigger{{
-						DeprecatedInterceptor: &v1alpha1.EventInterceptor{Webhook: &v1alpha1.WebhookInterceptor{}},
-						Interceptors:          []*v1alpha1.EventInterceptor{{Webhook: &v1alpha1.WebhookInterceptor{}}},
-					}},
-				},
-			},
-			want: &v1alpha1.EventListener{
-				Spec: v1alpha1.EventListenerSpec{
-					Triggers: []v1alpha1.EventListenerTrigger{{
-						DeprecatedInterceptor: &v1alpha1.EventInterceptor{Webhook: &v1alpha1.WebhookInterceptor{}},
-						Interceptors:          []*v1alpha1.EventInterceptor{{Webhook: &v1alpha1.WebhookInterceptor{}}},
-					}},
-				},
-			},
-			wc: v1alpha1.WithUpgradeViaDefaulting,
-		},
-		{
-			name: "with upgrade context - deprecated interceptor",
-			in: &v1alpha1.EventListener{
-				Spec: v1alpha1.EventListenerSpec{
-					Triggers: []v1alpha1.EventListenerTrigger{{
-						DeprecatedInterceptor: &v1alpha1.EventInterceptor{Webhook: &v1alpha1.WebhookInterceptor{}},
-					}},
-				},
-			},
-			want: &v1alpha1.EventListener{
-				Spec: v1alpha1.EventListenerSpec{
-					Triggers: []v1alpha1.EventListenerTrigger{{
-						Interceptors: []*v1alpha1.EventInterceptor{{Webhook: &v1alpha1.WebhookInterceptor{}}},
-					}},
-				},
-			},
-			wc: v1alpha1.WithUpgradeViaDefaulting,
-		}, {
-			name: "with upgrade context - deprecated params",
-			in: &v1alpha1.EventListener{
-				Spec: v1alpha1.EventListenerSpec{
-					Triggers: []v1alpha1.EventListenerTrigger{{
-						DeprecatedParams: []pipelinev1.Param{{
-							Name: "param-name",
-							Value: pipelinev1.ArrayOrString{
-								Type:      "string",
-								StringVal: "static",
-							},
+					Bindings: []*v1alpha1.EventListenerBinding{
+						{
+							Name: "binding",
 						},
-						}},
+						{
+							Name: "namespace-binding",
+							Kind: v1alpha1.NamespacedTriggerBindingKind,
+						},
+						{
+							Name: "cluster-binding",
+							Kind: v1alpha1.ClusterTriggerBindingKind,
+						},
+					},
+				}},
+			},
+		},
+		want: &v1alpha1.EventListener{
+			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					Bindings: []*v1alpha1.EventListenerBinding{
+						{
+							Name: "binding",
+							Kind: v1alpha1.NamespacedTriggerBindingKind,
+						},
+						{
+							Name: "namespace-binding",
+							Kind: v1alpha1.NamespacedTriggerBindingKind,
+						},
+						{
+							Name: "cluster-binding",
+							Kind: v1alpha1.ClusterTriggerBindingKind,
+						},
+					},
+				}},
+			},
+		},
+	}, {
+		name: "with upgrade context - both interceptor and interceptors present",
+		in: &v1alpha1.EventListener{
+			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					DeprecatedInterceptor: &v1alpha1.EventInterceptor{Webhook: &v1alpha1.WebhookInterceptor{}},
+					Interceptors:          []*v1alpha1.EventInterceptor{{Webhook: &v1alpha1.WebhookInterceptor{}}},
+				}},
+			},
+		},
+		want: &v1alpha1.EventListener{
+			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					DeprecatedInterceptor: &v1alpha1.EventInterceptor{Webhook: &v1alpha1.WebhookInterceptor{}},
+					Interceptors:          []*v1alpha1.EventInterceptor{{Webhook: &v1alpha1.WebhookInterceptor{}}},
+				}},
+			},
+		},
+		wc: v1alpha1.WithUpgradeViaDefaulting,
+	}, {
+		name: "with upgrade context - deprecated interceptor",
+		in: &v1alpha1.EventListener{
+			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					DeprecatedInterceptor: &v1alpha1.EventInterceptor{Webhook: &v1alpha1.WebhookInterceptor{}},
+				}},
+			},
+		},
+		want: &v1alpha1.EventListener{
+			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					Interceptors: []*v1alpha1.EventInterceptor{{Webhook: &v1alpha1.WebhookInterceptor{}}},
+				}},
+			},
+		},
+		wc: v1alpha1.WithUpgradeViaDefaulting,
+	}, {
+		name: "with upgrade context - deprecated params",
+		in: &v1alpha1.EventListener{
+			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					DeprecatedParams: []pipelinev1.Param{{
+						Name: "param-name",
+						Value: pipelinev1.ArrayOrString{
+							Type:      "string",
+							StringVal: "static",
+						},
+					},
 					}},
+				}},
+		},
+		want: &v1alpha1.EventListener{
+			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{{}},
 			},
-			want: &v1alpha1.EventListener{
-				Spec: v1alpha1.EventListenerSpec{
-					Triggers: []v1alpha1.EventListenerTrigger{{}},
-				},
-			},
-			wc: v1alpha1.WithUpgradeViaDefaulting,
-		}}
+		},
+		wc: v1alpha1.WithUpgradeViaDefaulting,
+	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := tc.in

--- a/pkg/apis/triggers/v1alpha1/event_listener_types.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_types.go
@@ -72,9 +72,6 @@ type EventListenerTrigger struct {
 	DeprecatedInterceptor *EventInterceptor   `json:"interceptor,omitempty"`
 	Interceptors          []*EventInterceptor `json:"interceptors,omitempty"`
 
-	// TODO(#248): Remove this before 0.3 release.
-	DeprecatedBinding *EventListenerBinding `json:"binding,omitempty"`
-
 	// TODO(#): Remove this before 0.3 release
 	// DEPRECATED: Use TriggerBindings with static values instead
 	DeprecatedParams []pipelinev1.Param `json:"params,omitempty"`

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation.go
@@ -44,25 +44,9 @@ func (s *EventListenerSpec) validate(ctx context.Context, el *EventListener) *ap
 }
 
 func (t *EventListenerTrigger) validate(ctx context.Context) *apis.FieldError {
-	// Validate that only one of binding or bindings is set
-	if t.DeprecatedBinding != nil && len(t.Bindings) > 0 {
-		return apis.ErrMultipleOneOf("binding", "bindings")
-	}
 	// Validate that only one of interceptor or interceptors is set
 	if t.DeprecatedInterceptor != nil && len(t.Interceptors) > 0 {
 		return apis.ErrMultipleOneOf("interceptor", "interceptors")
-	}
-
-	// validate deprecatedBinding
-	// TODO(#290): Remove this before 0.3 release.
-	if t.DeprecatedBinding != nil {
-		if t.DeprecatedBinding.Name == "" {
-			return apis.ErrMissingField(t.DeprecatedBinding.Name)
-		}
-
-		if t.DeprecatedBinding.Kind != NamespacedTriggerBindingKind && t.DeprecatedBinding.Kind != ClusterTriggerBindingKind {
-			return apis.ErrInvalidValue(fmt.Errorf("invalid kind"), string("t.DeprecatedBinding.Kind"))
-		}
 	}
 
 	// Validate optional Bindings

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
@@ -166,34 +166,6 @@ func TestEventListenerValidate_error(t *testing.T) {
 			},
 		},
 	}, {
-		name: "Binding missing name",
-		el: &v1alpha1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
-			Spec: v1alpha1.EventListenerSpec{
-				Triggers: []v1alpha1.EventListenerTrigger{{
-					DeprecatedBinding: &v1alpha1.EventListenerBinding{Name: "", Kind: v1alpha1.NamespacedTriggerBindingKind},
-					Template:          v1alpha1.EventListenerTemplate{Name: "tt"},
-				}},
-			},
-		},
-	}, {
-		name: "Binding missing kind",
-		el: &v1alpha1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
-			Spec: v1alpha1.EventListenerSpec{
-				Triggers: []v1alpha1.EventListenerTrigger{{
-					DeprecatedBinding: &v1alpha1.EventListenerBinding{Name: "tb", Kind: ""},
-					Template:          v1alpha1.EventListenerTemplate{Name: "tt"},
-				}},
-			},
-		},
-	}, {
 		name: "Bindings missing name",
 		el: &v1alpha1.EventListener{
 			ObjectMeta: metav1.ObjectMeta{
@@ -218,21 +190,6 @@ func TestEventListenerValidate_error(t *testing.T) {
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{Name: "tb", Kind: ""}},
 					Template: v1alpha1.EventListenerTemplate{Name: "tt"},
-				}},
-			},
-		},
-	}, {
-		name: "Both Binding and Bindings Present",
-		el: &v1alpha1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
-			Spec: v1alpha1.EventListenerSpec{
-				Triggers: []v1alpha1.EventListenerTrigger{{
-					Bindings:          []*v1alpha1.EventListenerBinding{{Name: "tb"}},
-					DeprecatedBinding: &v1alpha1.EventListenerBinding{Name: "bar"},
-					Template:          v1alpha1.EventListenerTemplate{Name: "tt"},
 				}},
 			},
 		},

--- a/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
@@ -344,11 +344,6 @@ func (in *EventListenerTrigger) DeepCopyInto(out *EventListenerTrigger) {
 			}
 		}
 	}
-	if in.DeprecatedBinding != nil {
-		in, out := &in.DeprecatedBinding, &out.DeprecatedBinding
-		*out = new(EventListenerBinding)
-		**out = **in
-	}
 	if in.DeprecatedParams != nil {
 		in, out := &in.DeprecatedParams, &out.DeprecatedParams
 		*out = make([]v1alpha2.Param, len(*in))


### PR DESCRIPTION
This will remove the binding field we have deprecated
in 0.2 in favor of bindings

Fix #248 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Remove the deprecated field `Binding`
```
