### PR TITLE
Remove deprecated Interceptor

### DIFF
--- a/docs/clustertriggerbindings.md
+++ b/docs/clustertriggerbindings.md
@@ -6,7 +6,6 @@ designed to encourage reusability clusterwide. You can reference a
 ClusterTriggerBinding in any EventListener in any namespace.
 
 <!-- FILE: examples/clustertriggerbindings/clustertriggerbinding.yaml -->
-
 ```YAML
 apiVersion: tekton.dev/v1alpha1
 kind: ClusterTriggerBinding
@@ -22,6 +21,7 @@ spec:
       value: $(header.Content-Type)
 ```
 
+
 You can specify multiple ClusterTriggerBindings in a Trigger. You can use a
 ClusterTriggerBinding in multiple Triggers.
 
@@ -29,7 +29,6 @@ In case of using a ClusterTriggerBinding, the `Binding` kind should be added.
 The default kind is TriggerBinding which represents a namespaced TriggerBinding.
 
 <!-- FILE: examples/eventlisteners/eventlistener-clustertriggerbinding.yaml -->
-
 ```YAML
 ---
 apiVersion: tekton.dev/v1alpha1
@@ -48,3 +47,4 @@ spec:
       template:
         name: pipeline-template
 ```
+

--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -7,7 +7,6 @@ resources will be created (or at least attempted) with. The service account must
 have the following role bound.
 
 <!-- FILE: examples/role-resources/triggerbinding-roles/role.yaml -->
-
 ```YAML
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -26,6 +25,7 @@ rules:
   resources: ["pipelineruns", "pipelineresources", "taskruns"]
   verbs: ["create"]
 ```
+
 
 Note that currently, JSON is the only accepted MIME type for events.
 
@@ -115,7 +115,6 @@ To be an Event Interceptor, a Kubernetes object should:
   the body, it can simply return the body that it received.
 
 <!-- FILE: examples/eventlisteners/eventlistener-interceptor.yaml -->
-
 ```YAML
 ---
 apiVersion: tekton.dev/v1alpha1
@@ -146,6 +145,7 @@ spec:
         name: pipeline-template
 ```
 
+
 ### GitHub Interceptors
 
 GitHub interceptors contain logic to validate and filter webhooks that come from
@@ -167,7 +167,6 @@ The body/header of the incoming request will be preserved in this interceptor's
 response.
 
 <!-- FILE: examples/eventlisteners/github-eventlistener-interceptor.yaml -->
-
 ```YAML
 ---
 apiVersion: tekton.dev/v1alpha1
@@ -191,6 +190,7 @@ spec:
         name: pipeline-template
 ```
 
+
 ### GitLab Interceptors
 
 GitLab interceptors contain logic to validate and filter requests that come from
@@ -213,7 +213,6 @@ The body/header of the incoming request will be preserved in this interceptor's
 response.
 
 <!-- FILE: examples/eventlisteners/gitlab-eventlistener-interceptor.yaml -->
-
 ```YAML
 ---
 apiVersion: tekton.dev/v1alpha1
@@ -237,6 +236,7 @@ spec:
         name: pipeline-template
 ```
 
+
 ### CEL Interceptors
 
 CEL interceptors parse expressions to filter requests based on JSON bodies and
@@ -254,7 +254,6 @@ The body/header of the incoming request will be preserved in this interceptor's
 response.
 
 <!-- FILE: examples/eventlisteners/cel-eventlistener-interceptor.yaml -->
-
 ```YAML
 apiVersion: tekton.dev/v1alpha1
 kind: EventListener
@@ -284,13 +283,13 @@ spec:
         name: pipeline-template
 ```
 
+
 If no filter is provided, then the overlays will be applied to the body,
 
 With a filter, the `expression` must return a `true` value, otherwise the
 request will be filtered out.
 
 <!-- FILE: examples/eventlisteners/cel-eventlistener-no-filter.yaml -->
-
 ```YAML
 apiVersion: tekton.dev/v1alpha1
 kind: EventListener
@@ -310,3 +309,4 @@ spec:
       template:
         name: pipeline-template
 ```
+

--- a/docs/triggerbindings.md
+++ b/docs/triggerbindings.md
@@ -6,7 +6,6 @@ parameters. The separation of `TriggerBinding`s from `TriggerTemplate`s was
 deliberate to encourage reuse between them.
 
 <!-- FILE: examples/triggerbindings/triggerbinding.yaml -->
-
 ```YAML
 apiVersion: tekton.dev/v1alpha1
 kind: TriggerBinding
@@ -21,6 +20,7 @@ spec:
   - name: contenttype
     value: $(header.Content-Type)
 ```
+
 
 `TriggerBinding`s are connected to `TriggerTemplate`s within an
 [`EventListener`](eventlisteners.md), which is where the pod is actually

--- a/docs/triggertemplates.md
+++ b/docs/triggertemplates.md
@@ -5,7 +5,6 @@ A `TriggerTemplate` is a resource that can template resources.
 **anywhere** within the resource template.
 
 <!-- FILE: examples/triggertemplates/triggertemplate.yaml -->
-
 ```YAML
 apiVersion: tekton.dev/v1alpha1
 kind: TriggerTemplate
@@ -46,6 +45,7 @@ spec:
           - name: url
             value: $(params.gitrepositoryurl)
 ```
+
 
 Similar to
 [Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md),`TriggerTemplate`s

--- a/pkg/apis/triggers/v1alpha1/event_listener_defaults.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_defaults.go
@@ -31,9 +31,7 @@ func (el *EventListener) SetDefaults(ctx context.Context) {
 	if IsUpgradeViaDefaulting(ctx) {
 		// Most likely the EventListener passed here is already running
 		for i := range el.Spec.Triggers {
-			t := &el.Spec.Triggers[i]
-			upgradeInterceptor(t)
-			removeParams(t)
+			removeParams(&el.Spec.Triggers[i])
 		}
 	}
 }
@@ -46,18 +44,6 @@ func defaultBindings(t *EventListenerTrigger) {
 				b.Kind = NamespacedTriggerBindingKind
 			}
 		}
-	}
-}
-
-func upgradeInterceptor(t *EventListenerTrigger) {
-	if t.DeprecatedInterceptor != nil {
-		if len(t.Interceptors) > 0 {
-			// Do nothing since it will be a Validation Error.
-			return
-		}
-
-		t.Interceptors = []*EventInterceptor{t.DeprecatedInterceptor}
-		t.DeprecatedInterceptor = nil
 	}
 }
 

--- a/pkg/apis/triggers/v1alpha1/event_listener_defaults_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_defaults_test.go
@@ -73,42 +73,6 @@ func TestEventListenerSetDefaults(t *testing.T) {
 			},
 		},
 	}, {
-		name: "with upgrade context - both interceptor and interceptors present",
-		in: &v1alpha1.EventListener{
-			Spec: v1alpha1.EventListenerSpec{
-				Triggers: []v1alpha1.EventListenerTrigger{{
-					DeprecatedInterceptor: &v1alpha1.EventInterceptor{Webhook: &v1alpha1.WebhookInterceptor{}},
-					Interceptors:          []*v1alpha1.EventInterceptor{{Webhook: &v1alpha1.WebhookInterceptor{}}},
-				}},
-			},
-		},
-		want: &v1alpha1.EventListener{
-			Spec: v1alpha1.EventListenerSpec{
-				Triggers: []v1alpha1.EventListenerTrigger{{
-					DeprecatedInterceptor: &v1alpha1.EventInterceptor{Webhook: &v1alpha1.WebhookInterceptor{}},
-					Interceptors:          []*v1alpha1.EventInterceptor{{Webhook: &v1alpha1.WebhookInterceptor{}}},
-				}},
-			},
-		},
-		wc: v1alpha1.WithUpgradeViaDefaulting,
-	}, {
-		name: "with upgrade context - deprecated interceptor",
-		in: &v1alpha1.EventListener{
-			Spec: v1alpha1.EventListenerSpec{
-				Triggers: []v1alpha1.EventListenerTrigger{{
-					DeprecatedInterceptor: &v1alpha1.EventInterceptor{Webhook: &v1alpha1.WebhookInterceptor{}},
-				}},
-			},
-		},
-		want: &v1alpha1.EventListener{
-			Spec: v1alpha1.EventListenerSpec{
-				Triggers: []v1alpha1.EventListenerTrigger{{
-					Interceptors: []*v1alpha1.EventInterceptor{{Webhook: &v1alpha1.WebhookInterceptor{}}},
-				}},
-			},
-		},
-		wc: v1alpha1.WithUpgradeViaDefaulting,
-	}, {
 		name: "with upgrade context - deprecated params",
 		in: &v1alpha1.EventListener{
 			Spec: v1alpha1.EventListenerSpec{

--- a/pkg/apis/triggers/v1alpha1/event_listener_types.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_types.go
@@ -65,12 +65,8 @@ type EventListenerTrigger struct {
 	Bindings []*EventListenerBinding `json:"bindings"`
 	Template EventListenerTemplate   `json:"template"`
 	// +optional
-	Name string `json:"name,omitempty"`
-	// +optional
-	// DEPRECATED. Use Interceptors instead.
-	// TODO(#290): Remove this before 0.3 release.
-	DeprecatedInterceptor *EventInterceptor   `json:"interceptor,omitempty"`
-	Interceptors          []*EventInterceptor `json:"interceptors,omitempty"`
+	Name         string              `json:"name,omitempty"`
+	Interceptors []*EventInterceptor `json:"interceptors,omitempty"`
 
 	// TODO(#): Remove this before 0.3 release
 	// DEPRECATED: Use TriggerBindings with static values instead

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation.go
@@ -44,11 +44,6 @@ func (s *EventListenerSpec) validate(ctx context.Context, el *EventListener) *ap
 }
 
 func (t *EventListenerTrigger) validate(ctx context.Context) *apis.FieldError {
-	// Validate that only one of interceptor or interceptors is set
-	if t.DeprecatedInterceptor != nil && len(t.Interceptors) > 0 {
-		return apis.ErrMultipleOneOf("interceptor", "interceptors")
-	}
-
 	// Validate optional Bindings
 	for i, b := range t.Bindings {
 		if b.Name == "" {

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
@@ -337,22 +337,6 @@ func TestEventListenerValidate_error(t *testing.T) {
 			},
 		},
 	}, {
-		name: "Both Interceptor and Interceptors Present",
-		el: &v1alpha1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
-			Spec: v1alpha1.EventListenerSpec{
-				Triggers: []v1alpha1.EventListenerTrigger{{
-					Bindings:              []*v1alpha1.EventListenerBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind}},
-					Template:              v1alpha1.EventListenerTemplate{Name: "tt"},
-					DeprecatedInterceptor: &v1alpha1.EventInterceptor{},
-					Interceptors:          []*v1alpha1.EventInterceptor{{}, {}},
-				}},
-			},
-		},
-	}, {
 		name: "CEL interceptor with no filter or overlays",
 		el: &v1alpha1.EventListener{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
@@ -328,11 +328,6 @@ func (in *EventListenerTrigger) DeepCopyInto(out *EventListenerTrigger) {
 		}
 	}
 	out.Template = in.Template
-	if in.DeprecatedInterceptor != nil {
-		in, out := &in.DeprecatedInterceptor, &out.DeprecatedInterceptor
-		*out = new(EventInterceptor)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.Interceptors != nil {
 		in, out := &in.Interceptors, &out.Interceptors
 		*out = make([]*EventInterceptor, len(*in))


### PR DESCRIPTION
This will the deprecated field interceptor which
has been deprecated in 0.2 release in favor of
interceptors

Fix #290 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Remove deprecated field `Interceptor`
```
