### PR TITLE
Remove deprecated Params field from EventListener

### DIFF
--- a/pkg/apis/triggers/v1alpha1/event_listener_defaults.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_defaults.go
@@ -22,16 +22,10 @@ import (
 
 // SetDefaults sets the defaults on the object.
 func (el *EventListener) SetDefaults(ctx context.Context) {
-
-	// set defaults
-	for i := range el.Spec.Triggers {
-		defaultBindings(&el.Spec.Triggers[i])
-	}
-
 	if IsUpgradeViaDefaulting(ctx) {
-		// Most likely the EventListener passed here is already running
+		// set defaults
 		for i := range el.Spec.Triggers {
-			removeParams(&el.Spec.Triggers[i])
+			defaultBindings(&el.Spec.Triggers[i])
 		}
 	}
 }
@@ -44,11 +38,5 @@ func defaultBindings(t *EventListenerTrigger) {
 				b.Kind = NamespacedTriggerBindingKind
 			}
 		}
-	}
-}
-
-func removeParams(t *EventListenerTrigger) {
-	if t.DeprecatedParams != nil {
-		t.DeprecatedParams = nil
 	}
 }

--- a/pkg/apis/triggers/v1alpha1/event_listener_defaults_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_defaults_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 )
 
@@ -52,6 +51,7 @@ func TestEventListenerSetDefaults(t *testing.T) {
 				}},
 			},
 		},
+		wc: v1alpha1.WithUpgradeViaDefaulting,
 		want: &v1alpha1.EventListener{
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
@@ -72,27 +72,6 @@ func TestEventListenerSetDefaults(t *testing.T) {
 				}},
 			},
 		},
-	}, {
-		name: "with upgrade context - deprecated params",
-		in: &v1alpha1.EventListener{
-			Spec: v1alpha1.EventListenerSpec{
-				Triggers: []v1alpha1.EventListenerTrigger{{
-					DeprecatedParams: []pipelinev1.Param{{
-						Name: "param-name",
-						Value: pipelinev1.ArrayOrString{
-							Type:      "string",
-							StringVal: "static",
-						},
-					},
-					}},
-				}},
-		},
-		want: &v1alpha1.EventListener{
-			Spec: v1alpha1.EventListenerSpec{
-				Triggers: []v1alpha1.EventListenerTrigger{{}},
-			},
-		},
-		wc: v1alpha1.WithUpgradeViaDefaulting,
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/apis/triggers/v1alpha1/event_listener_types.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_types.go
@@ -67,10 +67,6 @@ type EventListenerTrigger struct {
 	// +optional
 	Name         string              `json:"name,omitempty"`
 	Interceptors []*EventInterceptor `json:"interceptors,omitempty"`
-
-	// TODO(#): Remove this before 0.3 release
-	// DEPRECATED: Use TriggerBindings with static values instead
-	DeprecatedParams []pipelinev1.Param `json:"params,omitempty"`
 }
 
 // EventInterceptor provides a hook to intercept and pre-process events

--- a/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
@@ -337,13 +337,6 @@ func (in *EventListenerTrigger) DeepCopyInto(out *EventListenerTrigger) {
 			}
 		}
 	}
-	if in.DeprecatedParams != nil {
-		in, out := &in.DeprecatedParams, &out.DeprecatedParams
-		*out = make([]v1alpha2.Param, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
-	}
 	return
 }
 


### PR DESCRIPTION


# Changes

The field was replaced with static binding values in TriggerBindings.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
The deperecated Params field has been removed from the EventListener. Use a TriggerBinding with static values instead.
```
