### PR TITLE
Add Regression test for large number of Triggers

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -117,6 +117,13 @@ be used to run only [the unit tests](#unit-tests), i.e.:
 // +build e2e
 ```
 
+#### Cleaning up cluster-scoped resources
+
+Each integration test runs in its own Namespace; each Namespace is torn down
+after its integration test completes. However, cluster-scoped resources will not
+be deleted when the Namespace is deleted. So, each test must delete all the
+cluster-scoped resources that it creates.
+
 #### Setup tests
 
 The `setup` function in [init_tests.go](./init_test.go) will initialize client

--- a/test/eventlistener_scale_test.go
+++ b/test/eventlistener_scale_test.go
@@ -1,0 +1,62 @@
+// +build e2e
+
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"fmt"
+	"testing"
+
+	bldr "github.com/tektoncd/triggers/test/builder"
+	knativetest "knative.dev/pkg/test"
+)
+
+/*
+ * Test creating an EventListener with a large number of Triggers.
+ * This is a regression test for issue #356.
+ */
+func TestEventListenerScale(t *testing.T) {
+	c, namespace := setup(t)
+	t.Parallel()
+
+	defer tearDown(t, c, namespace)
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
+
+	t.Log("Start EventListener Scale e2e test")
+
+	// Create an EventListener with 1000 Triggers
+	var err error
+	el := bldr.EventListener("my-eventlistener", namespace)
+	for i := 0; i < 1000; i++ {
+		trigger := bldr.Trigger("my-triggertemplate", "v1alpha1",
+			bldr.EventListenerTriggerBinding("my-triggerbinding", "", "v1alpha1"),
+		)
+		trigger.Name = fmt.Sprintf("%d", i)
+		el.Spec.Triggers = append(el.Spec.Triggers, trigger)
+	}
+	el, err = c.TriggersClient.TektonV1alpha1().EventListeners(namespace).Create(el)
+	if err != nil {
+		t.Fatalf("Error creating EventListener: %s", err)
+	}
+
+	// Verify that the EventListener was created properly
+	if err := WaitFor(eventListenerReady(t, c, namespace, el.Name)); err != nil {
+		t.Fatalf("EventListener is not ready: %s", err)
+	}
+	t.Log("EventListener is ready")
+}

--- a/test/eventlistener_test.go
+++ b/test/eventlistener_test.go
@@ -383,6 +383,18 @@ func TestEventListenerCreate(t *testing.T) {
 		t.Fatalf("Failed to delete EventListener Service: %s", err)
 	}
 	t.Log("EventListener's Service was deleted")
+
+	// Cleanup cluster-scoped resources
+	t.Logf("Deleting cluster-scoped resources")
+	if err := c.KubeClient.RbacV1().ClusterRoles().Delete("my-role", &metav1.DeleteOptions{}); err != nil {
+		t.Errorf("Failed to delete clusterrole my-role: %s", err)
+	}
+	if err := c.KubeClient.RbacV1().ClusterRoleBindings().Delete("my-rolebinding", &metav1.DeleteOptions{}); err != nil {
+		t.Errorf("Failed to delete clusterrolebinding my-rolebinding: %s", err)
+	}
+	if err := c.TriggersClient.TektonV1alpha1().ClusterTriggerBindings().Delete("my-clustertriggerbinding", &metav1.DeleteOptions{}); err != nil {
+		t.Errorf("Failed to delete clustertriggerbinding my-clustertriggerbinding: %s", err)
+	}
 }
 
 // The structure of this field corresponds to values for the `license` key in

--- a/test/init_test.go
+++ b/test/init_test.go
@@ -104,19 +104,6 @@ func tearDown(t *testing.T, cs *clients, namespace string) {
 			t.Errorf("Failed to delete namespace %s: %s", namespace, err)
 		}
 	}
-
-	t.Logf("Deleting Clusterscoped resource")
-	if err := cs.KubeClient.RbacV1().ClusterRoles().Delete("my-role", &metav1.DeleteOptions{}); err != nil {
-		t.Errorf("Failed to delete clusterrole my-role: %s", err)
-	}
-
-	if err := cs.KubeClient.RbacV1().ClusterRoleBindings().Delete("my-rolebinding", &metav1.DeleteOptions{}); err != nil {
-		t.Errorf("Failed to delete clusterrolebinding my-rolebinding: %s", err)
-	}
-
-	if err := cs.TriggersClient.TektonV1alpha1().ClusterTriggerBindings().Delete("my-clustertriggerbinding", &metav1.DeleteOptions{}); err != nil {
-		t.Errorf("Failed to delete clustertriggerbinding my-clustertriggerbinding: %s", err)
-	}
 }
 
 func header(logf logging.FormatLogger, text string) {


### PR DESCRIPTION
# Changes

Fixes #405

Issue #356 found a bug in Triggers v0.1.0 (fixed in v0.2.0) where the
admission webhook times out after adding around 35 Triggers to an
EventListener.

This PR adds a regression test where we create an EventListener with
1000 Triggers.

---

I also moved the clean up code for cluster-scoped resources (from https://github.com/tektoncd/triggers/commit/7ba80a7757fbcd537624f3e24daed5f213c4dd96) out of `init_test.go` and into `eventlistener_test.go`, because the code was cleaning up resources specific to the `eventlistener_test.go`. @dibyom do you think I should put this in a separate commit, or is it ok as it is?

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._
