### PR TITLE
introduce authentication/authorization at the EventListenerTrigger le…

### DIFF
--- a/cmd/eventlistenersink/main.go
+++ b/cmd/eventlistenersink/main.go
@@ -92,6 +92,7 @@ func main() {
 		EventListenerName:      sinkArgs.ElName,
 		EventListenerNamespace: sinkArgs.ElNamespace,
 		Logger:                 logger,
+		Auth:                   sink.DefaultAuthOverride{},
 	}
 
 	// Listen and serve

--- a/docs/clustertriggerbindings.md
+++ b/docs/clustertriggerbindings.md
@@ -12,7 +12,6 @@ designed to encourage reusability clusterwide. You can reference a
 ClusterTriggerBinding in any EventListener in any namespace.
 
 <!-- FILE: examples/clustertriggerbindings/clustertriggerbinding.yaml -->
-
 ```YAML
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: ClusterTriggerBinding
@@ -28,6 +27,7 @@ spec:
       value: $(header.Content-Type)
 ```
 
+
 You can specify multiple ClusterTriggerBindings in a Trigger. You can use a
 ClusterTriggerBinding in multiple Triggers.
 
@@ -35,7 +35,6 @@ In case of using a ClusterTriggerBinding, the `Binding` kind should be added.
 The default kind is TriggerBinding which represents a namespaced TriggerBinding.
 
 <!-- FILE: examples/eventlisteners/eventlistener-clustertriggerbinding.yaml -->
-
 ```YAML
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
@@ -54,3 +53,4 @@ spec:
       template:
         name: pipeline-template
 ```
+

--- a/docs/triggerbindings.md
+++ b/docs/triggerbindings.md
@@ -12,7 +12,6 @@ parameters. The separation of `TriggerBinding`s from `TriggerTemplate`s was
 deliberate to encourage reuse between them.
 
 <!-- FILE: examples/triggerbindings/triggerbinding.yaml -->
-
 ```YAML
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding
@@ -27,6 +26,7 @@ spec:
   - name: contenttype
     value: $(header.Content-Type)
 ```
+
 
 `TriggerBinding`s are connected to `TriggerTemplate`s within an
 [`EventListener`](eventlisteners.md), which is where the pod is actually

--- a/docs/triggertemplates.md
+++ b/docs/triggertemplates.md
@@ -11,7 +11,6 @@ A `TriggerTemplate` is a resource that can template resources.
 **anywhere** within the resource template.
 
 <!-- FILE: examples/triggertemplates/triggertemplate.yaml -->
-
 ```YAML
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerTemplate
@@ -52,6 +51,7 @@ spec:
           - name: url
             value: $(params.gitrepositoryurl)
 ```
+
 
 Similar to
 [Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md),`TriggerTemplate`s

--- a/examples/role-resources/clustertriggerbinding-roles/clusterrole.yaml
+++ b/examples/role-resources/clustertriggerbinding-roles/clusterrole.yaml
@@ -8,7 +8,8 @@ rules:
   resources: ["clustertriggerbindings", "eventlisteners", "triggerbindings", "triggertemplates"]
   verbs: ["get"]
 - apiGroups: [""]
-  resources: ["configmaps", "secrets"]  # secrets are only needed for Github/Gitlab interceptors
+  # secrets are only needed for Github/Gitlab interceptors, serviceaccounts only for per trigger authorization
+  resources: ["configmaps", "secrets", "serviceaccounts"]
   verbs: ["get", "list", "watch"]
 # Permissions to create resources in associated TriggerTemplates
 - apiGroups: ["tekton.dev"]

--- a/examples/role-resources/triggerbinding-roles/role.yaml
+++ b/examples/role-resources/triggerbinding-roles/role.yaml
@@ -8,7 +8,8 @@ rules:
   resources: ["eventlisteners", "triggerbindings", "triggertemplates"]
   verbs: ["get"]
 - apiGroups: [""]
-  resources: ["configmaps", "secrets"]  # secrets are only needed for Github/Gitlab interceptors
+  # secrets are only needed for Github/Gitlab interceptors, serviceaccounts only for per trigger authorization
+  resources: ["configmaps", "secrets", "serviceaccounts"]
   verbs: ["get", "list", "watch"]
 # Permissions to create resources in associated TriggerTemplates
 - apiGroups: ["tekton.dev"]

--- a/pkg/apis/triggers/v1alpha1/event_listener_types.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_types.go
@@ -67,6 +67,15 @@ type EventListenerTrigger struct {
 	// +optional
 	Name         string              `json:"name,omitempty"`
 	Interceptors []*EventInterceptor `json:"interceptors,omitempty"`
+	// ServiceAccount optionally associates credentials with each trigger;
+	// more granular authorization for
+	// who is allowed to utilize the associated pipeline
+	// vs. defaulting to whatever permissions are associated
+	// with the entire EventListener and associated sink facilitates
+	// multi-tenant model based scenarios
+	// TODO do we want to restrict this to the event listener namespace and just ask for the service account name here?
+	// +optional
+	ServiceAccount *corev1.ObjectReference `json:"serviceAccount,omitempty"`
 }
 
 // EventInterceptor provides a hook to intercept and pre-process events

--- a/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
@@ -337,6 +337,11 @@ func (in *EventListenerTrigger) DeepCopyInto(out *EventListenerTrigger) {
 			}
 		}
 	}
+	if in.ServiceAccount != nil {
+		in, out := &in.ServiceAccount, &out.ServiceAccount
+		*out = new(v1.ObjectReference)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/resources/create.go
+++ b/pkg/resources/create.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"strings"
 
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+
 	"k8s.io/client-go/dynamic"
 
 	"go.uber.org/zap"
@@ -99,6 +101,9 @@ func Create(logger *zap.SugaredLogger, rt json.RawMessage, triggerName, eventID,
 	logger.Infof("For event ID %q creating resource %v", eventID, gvr)
 
 	if _, err := dc.Resource(gvr).Namespace(namespace).Create(data, metav1.CreateOptions{}); err != nil {
+		if kerrors.IsUnauthorized(err) || kerrors.IsForbidden(err) {
+			return err
+		}
 		return fmt.Errorf("couldn't create resource with group version kind %q: %v", gvr, err)
 	}
 	return nil

--- a/pkg/sink/auth_override.go
+++ b/pkg/sink/auth_override.go
@@ -1,0 +1,135 @@
+package sink
+
+import (
+	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	dynamicClientset "github.com/tektoncd/triggers/pkg/client/dynamic/clientset"
+	"github.com/tektoncd/triggers/pkg/client/dynamic/clientset/tekton"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	discoveryclient "k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+//AuthOverride is an interface that constructs a discovery client for the ServerResourceInterface
+//and a dynamic client for the Tekton Resources, using the token provide as the bearer token in the
+//REST config used to build those client.  The other non-credential related parameters for the
+//REST client used are copied from the in cluster config of the event sink.
+type AuthOverride interface {
+	OverrideAuthentication(token string,
+		log *zap.SugaredLogger,
+		defaultDiscoveryClient discoveryclient.ServerResourcesInterface,
+		defaultDynamicClient dynamic.Interface) (discoveryClient discoveryclient.ServerResourcesInterface,
+		dynamicClient dynamic.Interface,
+		err error)
+}
+
+func isServiceAccountToken(secret *corev1.Secret, sa *corev1.ServiceAccount) bool {
+	if secret.Type != corev1.SecretTypeServiceAccountToken {
+		return false
+	}
+
+	name := secret.Annotations[corev1.ServiceAccountNameKey]
+	uid := secret.Annotations[corev1.ServiceAccountUIDKey]
+	if name != sa.Name {
+		// Name must match
+		return false
+	}
+	if len(uid) > 0 && uid != string(sa.UID) {
+		// If UID is specified, it must match
+		return false
+	}
+
+	return true
+}
+
+func (r Sink) retrieveAuthToken(saRef *corev1.ObjectReference, eventLog *zap.SugaredLogger) (string, error) {
+	if saRef == nil {
+		return "", nil
+	}
+
+	if len(saRef.Name) == 0 || len(saRef.Namespace) == 0 {
+		return "", nil
+	}
+
+	var log *zap.SugaredLogger
+	if eventLog != nil {
+		log = eventLog.With(zap.String(triggersv1.TriggerLabelKey, "retriveAuthToken"))
+	}
+
+	sa, err := r.KubeClientSet.CoreV1().ServiceAccounts(saRef.Namespace).Get(saRef.Name, metav1.GetOptions{})
+	if err != nil {
+		if log != nil {
+			log.Error(err)
+		}
+		return "", err
+	}
+	var savedErr error
+	for _, ref := range sa.Secrets {
+		// secret ref namespace most likely won't be set, as the secret can only reside in
+		// sa's namespace, so use that
+		secret, err := r.KubeClientSet.CoreV1().Secrets(saRef.Namespace).Get(ref.Name, metav1.GetOptions{})
+		if err != nil {
+			if log != nil {
+				log.Error(err)
+			}
+			savedErr = err
+			continue
+		}
+		if isServiceAccountToken(secret, sa) {
+			token, exists := secret.Data[corev1.ServiceAccountTokenKey]
+			if log != nil {
+				log.Debugf("retrieveAuthToken found SA auth: %v", exists)
+			}
+			if !exists {
+				continue
+			}
+
+			return string(token), nil
+		}
+	}
+	return "", savedErr
+}
+
+func newConfig(newToken string, config *rest.Config) *rest.Config {
+	// first clean out all user credentials from the pods' in cluster config
+	newConfig := rest.AnonymousClientConfig(config)
+	// add the token from our interceptors
+	newConfig.BearerToken = newToken
+	return newConfig
+}
+
+type DefaultAuthOverride struct {
+}
+
+func (r DefaultAuthOverride) OverrideAuthentication(token string,
+	log *zap.SugaredLogger,
+	defaultDiscoverClient discoveryclient.ServerResourcesInterface,
+	defaultDynamicClient dynamic.Interface) (discoveryClient discoveryclient.ServerResourcesInterface,
+	dynamicClient dynamic.Interface,
+	err error) {
+	dynamicClient = defaultDynamicClient
+	discoveryClient = defaultDiscoverClient
+	clusterConfig, err := rest.InClusterConfig()
+	if err != nil {
+		log.Errorf("overrideAuthentication: problem getting in cluster config: %#v\n", err)
+		return
+	}
+	clusterConfig = newConfig(token, clusterConfig)
+	dc, err := dynamic.NewForConfig(clusterConfig)
+	if err != nil {
+		log.Errorf("overrideAuthentication: problem getting dynamic client set: %#v\n", err)
+		return
+	}
+	kubeClient, err := kubernetes.NewForConfig(clusterConfig)
+	if err != nil {
+		log.Errorf("overrideAuthentication: problem getting kube client: %#v\n", err)
+		return
+	}
+	dynamicClient = dynamicClientset.New(tekton.WithClient(dc))
+	discoveryClient = kubeClient.Discovery()
+
+	return
+}

--- a/test/builder/eventlistener.go
+++ b/test/builder/eventlistener.go
@@ -151,6 +151,16 @@ func EventListenerTriggerName(name string) EventListenerTriggerOp {
 	}
 }
 
+// EventListenerTriggerServiceAccount set the specified ServiceAccount of the EventListenerTrigger.
+func EventListenerTriggerServiceAccount(saName, namespace string) EventListenerTriggerOp {
+	return func(trigger *v1alpha1.EventListenerTrigger) {
+		trigger.ServiceAccount = &corev1.ObjectReference{
+			Namespace: saName,
+			Name:      namespace,
+		}
+	}
+}
+
 // EventListenerTriggerBinding adds a Binding to the Trigger in EventListenerSpec Triggers.
 func EventListenerTriggerBinding(name, kind, apiVersion string) EventListenerTriggerOp {
 	return func(trigger *v1alpha1.EventListenerTrigger) {

--- a/test/controller.go
+++ b/test/controller.go
@@ -45,6 +45,7 @@ import (
 	fakeconfigmapinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap/fake"
 	fakesecretinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/fake"
 	fakeserviceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/service/fake"
+	fakeserviceaccountinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	"knative.dev/pkg/controller"
 )
 
@@ -60,6 +61,7 @@ type Resources struct {
 	Services               []*corev1.Service
 	ConfigMaps             []*corev1.ConfigMap
 	Secrets                []*corev1.Secret
+	ServiceAccounts        []*corev1.ServiceAccount
 }
 
 // Clients holds references to clients which are useful for reconciler tests.
@@ -99,6 +101,7 @@ func SeedResources(t *testing.T, ctx context.Context, r Resources) Clients {
 	serviceInformer := fakeserviceinformer.Get(ctx)
 	configMapInformer := fakeconfigmapinformer.Get(ctx)
 	secretInformer := fakesecretinformer.Get(ctx)
+	saInformer := fakeserviceaccountinformer.Get(ctx)
 
 	// Create Namespaces
 	for _, ns := range r.Namespaces {
@@ -170,6 +173,14 @@ func SeedResources(t *testing.T, ctx context.Context, r Resources) Clients {
 			t.Fatal(err)
 		}
 		if _, err := c.Kube.CoreV1().Secrets(s.Namespace).Create(s); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, sa := range r.ServiceAccounts {
+		if err := saInformer.Informer().GetIndexer().Add(sa); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := c.Kube.CoreV1().ServiceAccounts(sa.Namespace).Create(sa); err != nil {
 			t.Fatal(err)
 		}
 	}


### PR DESCRIPTION
…vel (with default back to existing EventListener level)

# Changes

While this does not fully address https://github.com/tektoncd/triggers/issues/77, this change intends to provide more more granular authorization, besides just the `EventListener` service account,
and sets the stage for "multi-tenant themed" authorization around creating tekton resources 
from triggers and the `EventListener` sink.

As discussed in recent instances of the weekly project sync call, the actual employing of SubjectAccessReview checks (and the k8s admission related resources those would require) belongs in the https://github.com/tektoncd/pipelines project, where the identity and permissions
around the existing SA of the `EventListener` or the new SA for the `EventListenerTrigger` introduced here would be used for any SAR calls in the core pipeline controller.

As such, we could ultimately gate merging of this, if we reached consensus on this, on that tektoncd/pipeline work.  However, this change does not *require* that work.  And it provides an opt in
to finer grained control over which if the tekton CRD types can be created from a given trigger.

And certainly, while reviewing this, if finer grained authorization is deemed desirable at all, one possible outcome is that we want even finer grained control, and incorporate service account on objects with say the `EventListenerTrigger`

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [/] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [/] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [/] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

The specification of a service account on the `EventListenerTrigger` is now available as an override of the service account of the `EventListener` to facilitate permissions changes wrt creating Tekton objects as a result of the sink receiving an event.
