### PR TITLE
header key, case-insensitive match

### DIFF
--- a/docs/triggerbindings.md
+++ b/docs/triggerbindings.md
@@ -34,7 +34,7 @@ Each parameter has a `name` and a `value`.
 ## Event Variable Interpolation
 
 TriggerBindings can access values from the HTTP JSON body and the headers using
-JSONPath expressions wrapped in `$()`.
+JSONPath expressions wrapped in `$()`.  The key in the header is case-insensitive.  
 
 These are all valid expressions:
 
@@ -81,6 +81,8 @@ $(body.key4[0:2]) -> "{"value4", "value5"}"
 $(header) -> "{"One":["one"], "Two":["one","two","three"]}"
 
 $(header.One) -> "one"
+
+$(header.one) -> "one"
 
 $(header.Two) -> "one two three"
 

--- a/pkg/template/event.go
+++ b/pkg/template/event.go
@@ -88,13 +88,13 @@ func applyEventValuesToParams(params []pipelinev1.Param, body []byte, header htt
 	for idx, p := range params {
 		pValue := p.Value.StringVal
 		// Find all expressions wrapped in $() from the value
-		expressions := findTektonExpressions(pValue)
-		for _, expr := range expressions {
+		expressions, originals := findTektonExpressions(pValue)
+		for i, expr := range expressions {
 			val, err := ParseJSONPath(event, expr)
 			if err != nil {
 				return nil, fmt.Errorf("failed to replace JSONPath value for param %s: %s: %w", p.Name, p.Value, err)
 			}
-			pValue = strings.ReplaceAll(pValue, expr, val)
+			pValue = strings.ReplaceAll(pValue, originals[i], val)
 		}
 		params[idx].Value = pipelinev1.ArrayOrString{Type: pipelinev1.ParamTypeString, StringVal: pValue}
 	}

--- a/pkg/template/event_test.go
+++ b/pkg/template/event_test.go
@@ -58,30 +58,37 @@ func TestApplyEventValuesToParams(t *testing.T) {
 		name:   "header with single values",
 		params: []pipelinev1.Param{bldr.Param("foo", "$(header)")},
 		header: map[string][]string{
-			"header-one": {"val1", "val2"},
+			"Header-One": {"val1", "val2"},
 		},
-		want: []pipelinev1.Param{bldr.Param("foo", `{"header-one":"val1,val2"}`)},
+		want: []pipelinev1.Param{bldr.Param("foo", `{"Header-One":"val1,val2"}`)},
 	}, {
-		name:   "header keys",
+		name:   "header keys miss-match case",
 		params: []pipelinev1.Param{bldr.Param("foo", "$(header.header-one)")},
 		header: map[string][]string{
-			"header-one": {"val1"},
+			"Header-One": {"val1"},
+		},
+		want: []pipelinev1.Param{bldr.Param("foo", "val1")},
+	}, {
+		name:   "header keys match case",
+		params: []pipelinev1.Param{bldr.Param("foo", "$(header.Header-One)")},
+		header: map[string][]string{
+			"Header-One": {"val1"},
 		},
 		want: []pipelinev1.Param{bldr.Param("foo", "val1")},
 	}, {
 		name:   "headers - multiple values joined by comma",
 		params: []pipelinev1.Param{bldr.Param("foo", "$(header.header-one)")},
 		header: map[string][]string{
-			"header-one": {"val1", "val2"},
+			"Header-One": {"val1", "val2"},
 		},
 		want: []pipelinev1.Param{bldr.Param("foo", "val1,val2")},
 	}, {
 		name:   "header values",
 		params: []pipelinev1.Param{bldr.Param("foo", "$(header)")},
 		header: map[string][]string{
-			"header-one": {"val1", "val2"},
+			"Header-One": {"val1", "val2"},
 		},
-		want: []pipelinev1.Param{bldr.Param("foo", `{"header-one":"val1,val2"}`)},
+		want: []pipelinev1.Param{bldr.Param("foo", `{"Header-One":"val1,val2"}`)},
 	}, {
 		name:   "no body",
 		params: []pipelinev1.Param{bldr.Param("foo", "$(body)")},
@@ -145,7 +152,7 @@ func TestApplyEventValuesToParams(t *testing.T) {
 		},
 		body: json.RawMessage(`{"a": "val1"}`),
 		header: map[string][]string{
-			"header-1": {"val2"},
+			"Header-1": {"val2"},
 		},
 		want: []pipelinev1.Param{
 			bldr.Param("foo", `val1`),


### PR DESCRIPTION
# Changes

This resolve https://github.com/tektoncd/triggers/issues/458

Issue:
The keys in the request header are converted by `CanonicalMIMEHeaderKey` before they are passed to the event sink code.  So the cases of the key string are not same as sent from the source.  This causes failure of matching header key.  The `header.X-GitHub-Event` was not found because it was converted to `X-Github-Event`. 

Change:
The header keys specified in the TriggerBinding are converted with the same function before it is searched in the headers.  

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
- Bug fixes
The header key in the TriggerBinding is case insensitive
```
