### PR TITLE
Resolve TriggerBindings with no Kind set in sink

### DIFF
--- a/pkg/template/resource.go
+++ b/pkg/template/resource.go
@@ -56,9 +56,7 @@ func ResolveTrigger(trigger triggersv1.EventListenerTrigger, getTB getTriggerBin
 				return ResolvedTrigger{}, fmt.Errorf("error getting ClusterTriggerBinding %s: %w", b.Name, err)
 			}
 			ctb = append(ctb, ctb2)
-		}
-
-		if b.Kind == triggersv1.NamespacedTriggerBindingKind {
+		} else {
 			tb2, err := getTB(b.Name, metav1.GetOptions{})
 			if err != nil {
 				return ResolvedTrigger{}, fmt.Errorf("error getting TriggerBinding %s: %w", b.Name, err)

--- a/pkg/template/resource_test.go
+++ b/pkg/template/resource_test.go
@@ -399,6 +399,24 @@ func Test_ResolveTrigger(t *testing.T) {
 				TriggerTemplate: &tt,
 			},
 		},
+		{
+			name: "missing kind implies namespacedTriggerBinding",
+			trigger: triggersv1.EventListenerTrigger{
+				Bindings: []*triggersv1.EventListenerBinding{{
+					Name:       "my-triggerbinding",
+					APIVersion: "v1alpha1",
+				}},
+				Template: triggersv1.EventListenerTemplate{
+					Name:       "my-triggertemplate",
+					APIVersion: "v1alpha1",
+				},
+			},
+			want: ResolvedTrigger{
+				TriggerBindings:        []*triggersv1.TriggerBinding{tb},
+				ClusterTriggerBindings: []*triggersv1.ClusterTriggerBinding{},
+				TriggerTemplate:        &tt,
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
# Changes

When upgrading from 0.2.1 to 0.3, the Sink might have
to process a Binding that has no `Kind` set. This is
because, we only persist the default Kind when the Binding
object is created/updated. The reconciler also sets the defaults
by calling `SetDefaults` but that change is not persisted to etcd.

In the future, we might want to consider updating the object from the
reconciler itself if any default values were set.

Fixes: #459

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._
