### PR TITLE
Support JSON double values being reencoded in the CEL interceptor

### DIFF
--- a/pkg/interceptors/cel/cel.go
+++ b/pkg/interceptors/cel/cel.go
@@ -103,6 +103,12 @@ func (w *Interceptor) ExecuteTrigger(request *http.Request) (*http.Response, err
 			if err == nil {
 				b, err = json.Marshal(raw.(*structpb.Value).GetStringValue())
 			}
+		case types.Double, types.Int:
+			raw, err = val.ConvertToNative(reflect.TypeOf(&structpb.Value{}))
+			if err == nil {
+				b, err = json.Marshal(raw.(*structpb.Value).GetNumberValue())
+			}
+
 		default:
 			raw, err = val.ConvertToNative(reflect.TypeOf([]byte{}))
 			b = raw.([]byte)


### PR DESCRIPTION
# Changes
When the JSON value 2 is decoded, it is a Double, so arithmetic on it returns doubles.

This ensures that the double value is correctly reencoded for JSON.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Fix reencoding of numeric values coming from JSON bodies.
```
