### PR TITLE
Fix inaccurate docs about TriggerTemplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,7 @@ architecture with the following CRDs:
 
 Using `tektoncd/triggers` in conjunction with `tektoncd/pipeline` enables you to
 easily create full-fledged CI/CD systems where the execution is defined
-**entirely** through Kubernetes resources. This repo draws inspiration from
-`Tekton`, but can used stand alone since `TriggerTemplates` can create any
-Kubernetes resource.
+**entirely** through Kubernetes resources.
 
 You can learn more by checking out the [docs](docs/README.md)
 

--- a/docs/triggertemplates.md
+++ b/docs/triggertemplates.md
@@ -72,8 +72,8 @@ templates:
 To enable support for arbitrary resource types, the resource templates are
 internally resolved as byte blobs. As a result, validation on these resources is
 only done at event processing time (rather than during `TriggerTemplate`
-creation). As on now, only Tekton resources can be defined within a
-`TriggerTemplate`.
+creation). :rotating_light: As of now, only Tekton resources can be defined within a
+`TriggerTemplate` :rotating_light:
 
 ## Parameters
 


### PR DESCRIPTION
# Changes

- Fix inaccurate main README which said
  > TriggerTemplates can create any Kubernetes resource.
- Make it more visible that TriggerTemplates can only create Tekton resources.

Issue https://github.com/tektoncd/triggers/issues/476 was raised because our docs have inaccurate information about what K8s resources TriggerTemplates can create.

/cc @disposab1e
/cc @dibyom 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

