### PR TITLE
Add example to print entire request body $(body)

### DIFF
--- a/examples/use-entire-request-body/README.md
+++ b/examples/use-entire-request-body/README.md
@@ -1,0 +1,69 @@
+## Example: Use Entire Request Body
+
+This example demonstrates how a user can use `$(body)` in a [TriggerBinding](https://github.com/tektoncd/triggers/blob/master/docs/triggerbindings.md) to pass the entire request body as a single parameter. The example creates a TaskRun that prints the entire body of the HTTP request.
+
+### Try it out locally
+
+1. Create the ServiceAccount, Role, and RoleBinding:
+
+   ```shell script
+   kubectl apply -f examples/role-resources/triggerbinding-roles
+   kubectl apply -f examples/role-resources/
+   ```
+
+1. Create the TriggerTemplate, TriggerBinding, and EventListener:
+
+   ```shell script
+   kubectl apply -f examples/use-entire-request-body/use-entire-request-body.yaml
+   ```
+
+1. Port forward:
+
+   ```shell script
+   kubectl port-forward \
+    "$(kubectl get pod --selector=eventlistener=use-entire-request-body -oname)" \
+     8080
+   ```
+
+   **Note**: Instead of port forwarding, you can set the
+   [`serviceType`](https://github.com/tektoncd/triggers/blob/master/docs/eventlisteners.md#serviceType)
+   to `LoadBalancer` to expose the EventListener with a public IP.
+
+1. Test by sending an HTTP request to the EventListener:
+
+   ```shell script
+   curl -v -X POST http://localhost:8080 \
+   -d '{
+      "hello":
+      {
+         "this": "is"
+      },
+      "a":
+      {
+         "test": "."
+      }
+   }'
+   ```
+
+   The response status code should be `201 Created`
+
+1. You should see a new TaskRun that got created:
+
+   ```shell script
+   kubectl get taskruns | grep use-entire-request-body
+   ```
+
+1. View the TaskRun logs to see that the request body is printed in the TaskRun:
+
+   The end of the TaskRun logs will print the following:
+
+   ```
+   {
+     "a": {
+       "test": "."
+     },
+     "hello": {
+       "this": "is"
+     }
+   }
+   ```

--- a/examples/use-entire-request-body/use-entire-request-body.yaml
+++ b/examples/use-entire-request-body/use-entire-request-body.yaml
@@ -1,0 +1,47 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: use-entire-request-body
+spec:
+  params:
+  - name: body
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    metadata:
+      generateName: use-entire-request-body-
+    spec:
+      taskSpec:
+        params:
+        - name: body
+        steps:
+          - name: echo-body
+            image: ubuntu
+            script: |
+              #! /bin/bash
+              apt-get update && apt-get install -y -q --no-install-recommends jq
+              echo '$(inputs.params.body)' | jq '.'
+      params:
+      - name: body
+        value: $(params.body)
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: use-entire-request-body
+spec:
+  params:
+  - name: body
+    value: $(body)
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: EventListener
+metadata:
+  name: use-entire-request-body
+spec:
+  triggers:
+    - name: use-entire-request-body
+      bindings:
+        - name: use-entire-request-body
+      template:
+        name: use-entire-request-body


### PR DESCRIPTION
# Changes
This adds an example demonstrating how the user can use `$(body)` in a
TriggerBinding to pass the entire request body as a single parameter.
The example creates a TaskRun that prints the entire body of the HTTP
request.

This example addresses some of the concerns raised in issue https://github.com/tektoncd/triggers/issues/485

@dalefwillis can I add you as a co-author for this PR for your contribution of the `jq` part of this example (taken from our discussion in issue #485)?

/hold

Also, for feedback, does anyone have a better idea for naming these resources than `use-entire-request-body`? I'm trying to come up with a descriptive file/resource name, but this one's pretty clunky 😅 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._
