### PR TITLE
Stop marking dynamic client as generated code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@
 
 **/zz_generated.*.go linguist-generated=true
 /pkg/client/** linguist-generated=true
+/pkg/client/dynamic/** linguist-generated=false

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -31,7 +31,7 @@ source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/presubmit-te
 
 function post_build_tests() {
     return_code=0
-    golangci-lint run --deadline=2m || return_code=1
+    golangci-lint run --deadline=5m || return_code=1
     echo "Diffing against the documentation yaml"
     ${REPO_ROOT_DIR}/hack/update-docs.sh -d || return_code=1
     return ${return_code}


### PR DESCRIPTION
# Changes

Most code in pkg/client is generated. But pkg/client/dyanmic is not. 

Also, increase linter timeout to 5m. Temporary fix for intermittent build timeouts.
Full fix coming soon via plumbing#241

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._
