### PR TITLE
Allow creating v1beta1 resources

### DIFF
--- a/docs/getting-started/ingress-run.yaml
+++ b/docs/getting-started/ingress-run.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
   name: create-ingress-run
@@ -6,7 +6,6 @@ metadata:
 spec:
   taskRef:
     name: create-ingress
-  inputs:
     params:
     - name: CreateCertificate
       value: "true"

--- a/docs/getting-started/pipeline.yaml
+++ b/docs/getting-started/pipeline.yaml
@@ -5,7 +5,7 @@
 # - source is built into an image by img
 # - image output is pushed to ECR
 # - cloudevent emitted
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: getting-started-pipeline
@@ -50,18 +50,17 @@ spec:
           - name: event-to-sink
             resource: event-to-sink
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: deploy-locally
   namespace: getting-started
 spec:
-  inputs:
-    resources:
+  resources:
+    inputs:
       - name: image-source
         type: image
-  outputs:
-    resources:
+    outputs:
     - name: event-to-sink
       type: cloudEvent
   steps:
@@ -72,26 +71,25 @@ spec:
         - "run"
         - "tekton-triggers-built-me"
         - "--image"
-        - "${inputs.resources.image-source.url}"
+        - "${resources.inputs.image-source.url}"
         - "--env=PORT=8080"
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: build-docker-image
   namespace: getting-started
 spec:
-  inputs:
-    resources:
+  params:
+  - name: pathToContext
+    description:
+      The build directory used by img
+    default: /workspace/source-repo
+  resources:
+    inputs:
       - name: source-repo
         type: git
-    params:
-      - name: pathToContext
-        description:
-          The build directory used by img
-        default: /workspace/source-repo
-  outputs:
-    resources:
+    outputs:
       - name: builtImage
         type: image
   steps:
@@ -102,9 +100,9 @@ spec:
       args:
         - build
         - -t
-        - "${outputs.resources.builtImage.url}"
+        - "$(resources.outputs.builtImage.url)"
         - --no-cache
-        - "${inputs.params.pathToContext}"
+        - "$(params.pathToContext)"
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: Condition
@@ -118,7 +116,7 @@ spec:
   check:
     image: golang
     command: ["go"]
-    args: ['test', "$(inputs.resources.source-repo.path)/..."]
+    args: ['test', "$(resources.source-repo.path)/..."]
 ---
 # Finally, we need something to receive our cloudevent announcing success!
 # That is this services only purpose

--- a/docs/getting-started/webhook-run.yaml
+++ b/docs/getting-started/webhook-run.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
   name: create-webhook-run
@@ -6,7 +6,6 @@ metadata:
 spec:
   taskRef:
     name: create-webhook
-  inputs:
     params:
     - name: GitHubOrg
       value: "iancoffey"

--- a/docs/triggertemplates.md
+++ b/docs/triggertemplates.md
@@ -24,7 +24,7 @@ spec:
   - name: contenttype
     description: The Content-Type of the event
   resourcetemplates:
-  - apiVersion: tekton.dev/v1alpha1
+  - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
       generateName: simple-pipeline-run-

--- a/examples/example-pipeline.yaml
+++ b/examples/example-pipeline.yaml
@@ -1,14 +1,14 @@
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: say-hello
 spec:
-  inputs:
-    params:
-    - name: contenttype
-      description: The Content-Type of the event
-      type: string
-    resources:
+  params:
+  - name: contenttype
+    description: The Content-Type of the event
+    type: string
+  resources:
+    inputs:
       - name: git-source
         type: git
   steps:
@@ -16,20 +16,20 @@ spec:
     image: bash
     command: ["bash", "-c"]
     args:
-      - echo -e 'Hello Triggers!\nContent-Type is $(inputs.params.contenttype)'
+      - echo -e 'Hello Triggers!\nContent-Type is $(params.contenttype)'
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: say-message
 spec:
-  inputs:
-    params:
-    - name: message
-      description: The message to print
-      default: This is the default message
-      type: string
-    resources:
+  params:
+  - name: message
+    description: The message to print
+    default: This is the default message
+    type: string
+  resources:
+    inputs:
     - name: git-source
       type: git
   steps:
@@ -37,15 +37,15 @@ spec:
     image: bash
     command: ["bash", "-c"]
     args:
-      - echo '$(inputs.params.message)'
+      - echo '$(params.message)'
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: say-bye
 spec:
-  inputs:
-    resources:
+  resources:
+    inputs:
     - name: git-source
       type: git
   steps:
@@ -55,7 +55,7 @@ spec:
     args:
     - echo 'Goodbye Triggers!'
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: simple-pipeline

--- a/examples/triggertemplates/triggertemplate.yaml
+++ b/examples/triggertemplates/triggertemplate.yaml
@@ -15,7 +15,7 @@ spec:
   - name: contenttype
     description: The Content-Type of the event
   resourcetemplates:
-  - apiVersion: tekton.dev/v1alpha1
+  - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
       generateName: simple-pipeline-run-

--- a/examples/v1alpha1-task/README.md
+++ b/examples/v1alpha1-task/README.md
@@ -1,0 +1,47 @@
+## v1alpha1 Task EventListener
+
+Creates an EventListener that creates a v1alpha1 TaskRun.
+
+### Try it out locally:
+
+1. Create the service account:
+
+   ```shell script
+   kubectl apply -f examples/role-resources/triggerbinding-roles
+   kubectl apply -f examples/role-resources/
+   ```
+
+1. Create the v1alpha1 EventListener:
+
+   ```shell script
+   kubectl apply -f examples/v1alpha1-task/v1alpha1-task-listener.yaml
+   ```
+
+1. Port forward:
+
+   ```shell script
+   kubectl port-forward \
+    "$(kubectl get pod --selector=eventlistener=v1alpha1-task-listener -oname)" \
+     8080
+   ```
+
+   **Note**: Instead of port forwarding, you can set the
+   [`serviceType`](https://github.com/tektoncd/triggers/blob/master/docs/eventlisteners.md#serviceType)
+   to `LoadBalancer` to expose the EventListener with a public IP.
+
+1. Test by sending the sample payload.
+
+   ```shell script
+   curl -v \
+   -H 'Content-Type: application/json' \
+   --data "{}" \
+   http://localhost:8080
+   ```
+
+   The response status code should be `201 Created`
+
+1. You should see a new TaskRun that got created:
+
+   ```shell script
+   kubectl get taskruns | grep v1alpha1-task-run-
+   ```

--- a/examples/v1alpha1-task/v1alpha1-task-listener.yaml
+++ b/examples/v1alpha1-task/v1alpha1-task-listener.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: v1alpha1-task-template
+spec:
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1alpha1
+    kind: TaskRun
+    metadata:
+      generateName: v1alpha1-task-run-
+    spec:
+      taskSpec:
+        steps:
+        - name: "hellothere"
+          image: ubuntu
+          script: echo "hello there"
+---
+apiVersion: tekton.dev/v1alpha1
+kind: EventListener
+metadata:
+  name: v1alpha1-task-listener
+spec:
+  # from examples/role-resources/servicaccount.yaml
+  serviceAccountName: tekton-triggers-example-sa
+  triggers:
+    - name: v1alpha1-task-trigger
+      template:
+        name: v1alpha1-task-template

--- a/pkg/apis/triggers/v1alpha1/event_listener_types.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_types.go
@@ -19,7 +19,7 @@ package v1alpha1
 import (
 	"fmt"
 
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"net/http"
 
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"knative.dev/pkg/apis"
 )

--- a/pkg/apis/triggers/v1alpha1/trigger_binding_types.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_binding_types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )

--- a/pkg/apis/triggers/v1alpha1/trigger_binding_validation.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_binding_validation.go
@@ -19,7 +19,7 @@ package v1alpha1
 import (
 	"context"
 
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"knative.dev/pkg/apis"
 )
 
@@ -36,7 +36,7 @@ func (s *TriggerBindingSpec) Validate(ctx context.Context) *apis.FieldError {
 	return nil
 }
 
-func validateParams(params []v1alpha1.Param) *apis.FieldError {
+func validateParams(params []v1beta1.Param) *apis.FieldError {
 	// Ensure there aren't multiple params with the same name.
 	seen := map[string]struct{}{}
 	for _, param := range params {

--- a/pkg/apis/triggers/v1alpha1/trigger_template_types.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_template_types.go
@@ -17,7 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	pipelinev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -33,15 +34,19 @@ var Decoder runtime.Decoder
 
 func init() {
 	scheme := runtime.NewScheme()
-	utilruntime.Must(pipelinev1.AddToScheme(scheme))
+	utilruntime.Must(pipelinev1alpha1.AddToScheme(scheme))
+	utilruntime.Must(pipelinev1beta1.AddToScheme(scheme))
 	codec := serializer.NewCodecFactory(scheme)
-	Decoder = codec.UniversalDecoder(pipelinev1.SchemeGroupVersion)
+	Decoder = codec.UniversalDecoder(
+		pipelinev1alpha1.SchemeGroupVersion,
+		pipelinev1beta1.SchemeGroupVersion,
+	)
 }
 
 // TriggerTemplateSpec holds the desired state of TriggerTemplate
 type TriggerTemplateSpec struct {
-	Params            []pipelinev1.ParamSpec    `json:"params,omitempty"`
-	ResourceTemplates []TriggerResourceTemplate `json:"resourcetemplates,omitempty"`
+	Params            []pipelinev1beta1.ParamSpec `json:"params,omitempty"`
+	ResourceTemplates []TriggerResourceTemplate   `json:"resourcetemplates,omitempty"`
 }
 
 // TriggerResourceTemplate describes a resource to create

--- a/pkg/apis/triggers/v1alpha1/trigger_template_validation.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_template_validation.go
@@ -22,7 +22,7 @@ import (
 	"regexp"
 	"strings"
 
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/apis/triggers/v1alpha1/trigger_template_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_template_validation_test.go
@@ -32,6 +32,9 @@ import (
 var simpleResourceTemplate = runtime.RawExtension{
 	Raw: []byte(`{"kind":"PipelineRun","apiVersion":"tekton.dev/v1alpha1","metadata":{"creationTimestamp":null},"spec":{},"status":{}}`),
 }
+var v1beta1ResourceTemplate = runtime.RawExtension{
+	Raw: []byte(`{"kind":"PipelineRun","apiVersion":"tekton.dev/v1beta1","metadata":{"creationTimestamp":null},"spec":{},"status":{}}`),
+}
 var paramResourceTemplate = runtime.RawExtension{
 	Raw: []byte(`{"kind":"PipelineRun","apiVersion":"tekton.dev/v1alpha1","metadata":{"creationTimestamp":null},"spec": "$(params.foo)","status":{}}`),
 }
@@ -69,6 +72,12 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 			template: b.TriggerTemplate("tt", "foo", b.TriggerTemplateSpec(
 				b.TriggerTemplateParam("foo", "desc", "val"),
 				b.TriggerResourceTemplate(simpleResourceTemplate))),
+			want: nil,
+		}, {
+			name: "valid v1beta1 template",
+			template: b.TriggerTemplate("tt", "foo", b.TriggerTemplateSpec(
+				b.TriggerTemplateParam("foo", "desc", "val"),
+				b.TriggerResourceTemplate(v1beta1ResourceTemplate))),
 			want: nil,
 		}, {
 			name: "missing resource template",

--- a/pkg/client/dynamic/clientset/tekton/tekton.go
+++ b/pkg/client/dynamic/clientset/tekton/tekton.go
@@ -9,6 +9,7 @@ import (
 
 var allowedTektonTypes = map[string][]string{
 	"v1alpha1": {"pipelineresources", "pipelineruns", "taskruns", "pipelines", "clustertasks", "tasks", "conditions"},
+	"v1beta1":  {"pipelineruns", "taskruns", "pipelines", "clustertasks", "tasks"},
 }
 
 // WithClient adds Tekton related clients to the Dynamic client.

--- a/pkg/interceptors/webhook/webhook.go
+++ b/pkg/interceptors/webhook/webhook.go
@@ -24,7 +24,7 @@ import (
 	"net/url"
 	"time"
 
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/triggers/pkg/interceptors"
 	corev1 "k8s.io/api/core/v1"
 

--- a/pkg/interceptors/webhook/webhook_test.go
+++ b/pkg/interceptors/webhook/webhook_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 )

--- a/pkg/template/event.go
+++ b/pkg/template/event.go
@@ -22,7 +22,7 @@ import (
 	"net/http"
 	"strings"
 
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 )
 

--- a/pkg/template/event_test.go
+++ b/pkg/template/event_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	"github.com/tektoncd/triggers/test"
 	bldr "github.com/tektoncd/triggers/test/builder"

--- a/pkg/template/resource.go
+++ b/pkg/template/resource.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"strings"
 
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/pkg/template/resource_test.go
+++ b/pkg/template/resource_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	"github.com/tektoncd/triggers/test"
 	bldr "github.com/tektoncd/triggers/test/builder"
@@ -32,78 +32,78 @@ import (
 
 func Test_MergeInDefaultParams(t *testing.T) {
 	var (
-		oneParam = pipelinev1.Param{
+		oneParam = pipelinev1beta1.Param{
 			Name:  "oneid",
-			Value: pipelinev1.ArrayOrString{StringVal: "onevalue"},
+			Value: pipelinev1beta1.ArrayOrString{StringVal: "onevalue"},
 		}
-		oneParamSpec = pipelinev1.ParamSpec{
+		oneParamSpec = pipelinev1beta1.ParamSpec{
 			Name:    "oneid",
-			Default: &pipelinev1.ArrayOrString{StringVal: "onedefault"},
+			Default: &pipelinev1beta1.ArrayOrString{StringVal: "onedefault"},
 		}
-		wantDefaultOneParam = pipelinev1.Param{
+		wantDefaultOneParam = pipelinev1beta1.Param{
 			Name:  "oneid",
-			Value: pipelinev1.ArrayOrString{StringVal: "onedefault"},
+			Value: pipelinev1beta1.ArrayOrString{StringVal: "onedefault"},
 		}
-		twoParamSpec = pipelinev1.ParamSpec{
+		twoParamSpec = pipelinev1beta1.ParamSpec{
 			Name:    "twoid",
-			Default: &pipelinev1.ArrayOrString{StringVal: "twodefault"},
+			Default: &pipelinev1beta1.ArrayOrString{StringVal: "twodefault"},
 		}
-		wantDefaultTwoParam = pipelinev1.Param{
+		wantDefaultTwoParam = pipelinev1beta1.Param{
 			Name:  "twoid",
-			Value: pipelinev1.ArrayOrString{StringVal: "twodefault"},
+			Value: pipelinev1beta1.ArrayOrString{StringVal: "twodefault"},
 		}
-		threeParamSpec = pipelinev1.ParamSpec{
+		threeParamSpec = pipelinev1beta1.ParamSpec{
 			Name:    "threeid",
-			Default: &pipelinev1.ArrayOrString{StringVal: "threedefault"},
+			Default: &pipelinev1beta1.ArrayOrString{StringVal: "threedefault"},
 		}
-		wantDefaultThreeParam = pipelinev1.Param{
+		wantDefaultThreeParam = pipelinev1beta1.Param{
 			Name:  "threeid",
-			Value: pipelinev1.ArrayOrString{StringVal: "threedefault"},
+			Value: pipelinev1beta1.ArrayOrString{StringVal: "threedefault"},
 		}
-		noDefaultParamSpec = pipelinev1.ParamSpec{
+		noDefaultParamSpec = pipelinev1beta1.ParamSpec{
 			Name: "nodefault",
 		}
 	)
 	type args struct {
-		params     []pipelinev1.Param
-		paramSpecs []pipelinev1.ParamSpec
+		params     []pipelinev1beta1.Param
+		paramSpecs []pipelinev1beta1.ParamSpec
 	}
 	tests := []struct {
 		name string
 		args args
-		want []pipelinev1.Param
+		want []pipelinev1beta1.Param
 	}{
 		{
 			name: "add one default param",
 			args: args{
-				params:     []pipelinev1.Param{},
-				paramSpecs: []pipelinev1.ParamSpec{oneParamSpec},
+				params:     []pipelinev1beta1.Param{},
+				paramSpecs: []pipelinev1beta1.ParamSpec{oneParamSpec},
 			},
-			want: []pipelinev1.Param{wantDefaultOneParam},
+			want: []pipelinev1beta1.Param{wantDefaultOneParam},
 		},
 		{
 			name: "add multiple default params",
 			args: args{
-				params:     []pipelinev1.Param{},
-				paramSpecs: []pipelinev1.ParamSpec{oneParamSpec, twoParamSpec, threeParamSpec},
+				params:     []pipelinev1beta1.Param{},
+				paramSpecs: []pipelinev1beta1.ParamSpec{oneParamSpec, twoParamSpec, threeParamSpec},
 			},
-			want: []pipelinev1.Param{wantDefaultOneParam, wantDefaultTwoParam, wantDefaultThreeParam},
+			want: []pipelinev1beta1.Param{wantDefaultOneParam, wantDefaultTwoParam, wantDefaultThreeParam},
 		},
 		{
 			name: "do not override existing value",
 			args: args{
-				params:     []pipelinev1.Param{oneParam},
-				paramSpecs: []pipelinev1.ParamSpec{oneParamSpec},
+				params:     []pipelinev1beta1.Param{oneParam},
+				paramSpecs: []pipelinev1beta1.ParamSpec{oneParamSpec},
 			},
-			want: []pipelinev1.Param{oneParam},
+			want: []pipelinev1beta1.Param{oneParam},
 		},
 		{
 			name: "add no default params",
 			args: args{
-				params:     []pipelinev1.Param{},
-				paramSpecs: []pipelinev1.ParamSpec{noDefaultParamSpec},
+				params:     []pipelinev1beta1.Param{},
+				paramSpecs: []pipelinev1beta1.ParamSpec{noDefaultParamSpec},
 			},
-			want: []pipelinev1.Param{},
+			want: []pipelinev1beta1.Param{},
 		},
 	}
 	for _, tt := range tests {
@@ -118,9 +118,9 @@ func Test_MergeInDefaultParams(t *testing.T) {
 
 func Test_applyParamToResourceTemplate(t *testing.T) {
 	var (
-		oneParam = pipelinev1.Param{
+		oneParam = pipelinev1beta1.Param{
 			Name:  "oneid",
-			Value: pipelinev1.ArrayOrString{StringVal: "onevalue"},
+			Value: pipelinev1beta1.ArrayOrString{StringVal: "onevalue"},
 		}
 		rtNoParamVars             = json.RawMessage(`{"foo": "bar"}`)
 		wantRtNoParamVars         = json.RawMessage(`{"foo": "bar"}`)
@@ -132,7 +132,7 @@ func Test_applyParamToResourceTemplate(t *testing.T) {
 		wantRtMultipleParamVars   = json.RawMessage(`{"onevalue": "bar-onevalue-onevalueonevalueonevalue-onevalue-bar"}`)
 	)
 	type args struct {
-		param pipelinev1.Param
+		param pipelinev1beta1.Param
 		rt    json.RawMessage
 	}
 	tests := []struct {
@@ -174,9 +174,9 @@ func Test_applyParamToResourceTemplate(t *testing.T) {
 		}, {
 			name: "espcae quotes in param val",
 			args: args{
-				param: pipelinev1.Param{
+				param: pipelinev1beta1.Param{
 					Name: "p1",
-					Value: pipelinev1.ArrayOrString{
+					Value: pipelinev1beta1.ArrayOrString{
 						StringVal: `{"a":"b"}`,
 					},
 				},
@@ -198,7 +198,7 @@ func Test_applyParamToResourceTemplate(t *testing.T) {
 func Test_ApplyParamsToResourceTemplate(t *testing.T) {
 	rt := json.RawMessage(`{"oneparam": "$(params.oneid)", "twoparam": "$(params.twoid)", "threeparam": "$(params.threeid)"`)
 	type args struct {
-		params []pipelinev1.Param
+		params []pipelinev1beta1.Param
 		rt     json.RawMessage
 	}
 	tests := []struct {
@@ -209,7 +209,7 @@ func Test_ApplyParamsToResourceTemplate(t *testing.T) {
 		{
 			name: "no params",
 			args: args{
-				params: []pipelinev1.Param{},
+				params: []pipelinev1beta1.Param{},
 				rt:     rt,
 			},
 			want: rt,
@@ -217,8 +217,8 @@ func Test_ApplyParamsToResourceTemplate(t *testing.T) {
 		{
 			name: "one param",
 			args: args{
-				params: []pipelinev1.Param{
-					{Name: "oneid", Value: pipelinev1.ArrayOrString{StringVal: "onevalue"}},
+				params: []pipelinev1beta1.Param{
+					{Name: "oneid", Value: pipelinev1beta1.ArrayOrString{StringVal: "onevalue"}},
 				},
 				rt: rt,
 			},
@@ -227,10 +227,10 @@ func Test_ApplyParamsToResourceTemplate(t *testing.T) {
 		{
 			name: "multiple params",
 			args: args{
-				params: []pipelinev1.Param{
-					{Name: "oneid", Value: pipelinev1.ArrayOrString{StringVal: "onevalue"}},
-					{Name: "twoid", Value: pipelinev1.ArrayOrString{StringVal: "twovalue"}},
-					{Name: "threeid", Value: pipelinev1.ArrayOrString{StringVal: "threevalue"}},
+				params: []pipelinev1beta1.Param{
+					{Name: "oneid", Value: pipelinev1beta1.ArrayOrString{StringVal: "onevalue"}},
+					{Name: "twoid", Value: pipelinev1beta1.ArrayOrString{StringVal: "twovalue"}},
+					{Name: "threeid", Value: pipelinev1beta1.ArrayOrString{StringVal: "threevalue"}},
 				},
 				rt: rt,
 			},
@@ -255,10 +255,10 @@ var (
 		"tb-params": {
 			ObjectMeta: metav1.ObjectMeta{Name: "tb-params"},
 			Spec: triggersv1.TriggerBindingSpec{
-				Params: []pipelinev1.Param{{
+				Params: []pipelinev1beta1.Param{{
 					Name: "foo",
-					Value: pipelinev1.ArrayOrString{
-						Type:      pipelinev1.ParamTypeString,
+					Value: pipelinev1beta1.ArrayOrString{
+						Type:      pipelinev1beta1.ParamTypeString,
 						StringVal: "bar",
 					},
 				}},
@@ -276,10 +276,10 @@ var (
 		"ctb-params": {
 			ObjectMeta: metav1.ObjectMeta{Name: "ctb-params"},
 			Spec: triggersv1.TriggerBindingSpec{
-				Params: []pipelinev1.Param{{
+				Params: []pipelinev1beta1.Param{{
 					Name: "foo-ctb",
-					Value: pipelinev1.ArrayOrString{
-						Type:      pipelinev1.ParamTypeString,
+					Value: pipelinev1beta1.ArrayOrString{
+						Type:      pipelinev1beta1.ParamTypeString,
 						StringVal: "bar-ctb",
 					},
 				}},
@@ -525,7 +525,7 @@ func TestMergeBindingParams(t *testing.T) {
 		name            string
 		bindings        []*triggersv1.TriggerBinding
 		clusterBindings []*triggersv1.ClusterTriggerBinding
-		want            []pipelinev1.Param
+		want            []pipelinev1beta1.Param
 		wantErr         bool
 	}{{
 		name:            "empty bindings",
@@ -534,7 +534,7 @@ func TestMergeBindingParams(t *testing.T) {
 			bldr.TriggerBinding("", "", bldr.TriggerBindingSpec()),
 			bldr.TriggerBinding("", "", bldr.TriggerBindingSpec()),
 		},
-		want: []pipelinev1.Param{},
+		want: []pipelinev1beta1.Param{},
 	}, {
 		name:            "single binding with multiple params",
 		clusterBindings: []*triggersv1.ClusterTriggerBinding{},
@@ -544,12 +544,12 @@ func TestMergeBindingParams(t *testing.T) {
 				bldr.TriggerBindingParam("param2", "value2"),
 			)),
 		},
-		want: []pipelinev1.Param{{
+		want: []pipelinev1beta1.Param{{
 			Name:  "param1",
-			Value: pipelinev1.ArrayOrString{StringVal: "value1", Type: pipelinev1.ParamTypeString},
+			Value: pipelinev1beta1.ArrayOrString{StringVal: "value1", Type: pipelinev1beta1.ParamTypeString},
 		}, {
 			Name:  "param2",
-			Value: pipelinev1.ArrayOrString{StringVal: "value2", Type: pipelinev1.ParamTypeString},
+			Value: pipelinev1beta1.ArrayOrString{StringVal: "value2", Type: pipelinev1beta1.ParamTypeString},
 		}},
 	}, {
 		name: "single cluster type binding with multiple params",
@@ -560,12 +560,12 @@ func TestMergeBindingParams(t *testing.T) {
 			)),
 		},
 		bindings: []*triggersv1.TriggerBinding{},
-		want: []pipelinev1.Param{{
+		want: []pipelinev1beta1.Param{{
 			Name:  "param1",
-			Value: pipelinev1.ArrayOrString{StringVal: "value1", Type: pipelinev1.ParamTypeString},
+			Value: pipelinev1beta1.ArrayOrString{StringVal: "value1", Type: pipelinev1beta1.ParamTypeString},
 		}, {
 			Name:  "param2",
-			Value: pipelinev1.ArrayOrString{StringVal: "value2", Type: pipelinev1.ParamTypeString},
+			Value: pipelinev1beta1.ArrayOrString{StringVal: "value2", Type: pipelinev1beta1.ParamTypeString},
 		}},
 	}, {
 		name: "multiple bindings each with multiple params",
@@ -585,24 +585,24 @@ func TestMergeBindingParams(t *testing.T) {
 				bldr.TriggerBindingParam("param4", "value4"),
 			)),
 		},
-		want: []pipelinev1.Param{{
+		want: []pipelinev1beta1.Param{{
 			Name:  "param1",
-			Value: pipelinev1.ArrayOrString{StringVal: "value1", Type: pipelinev1.ParamTypeString},
+			Value: pipelinev1beta1.ArrayOrString{StringVal: "value1", Type: pipelinev1beta1.ParamTypeString},
 		}, {
 			Name:  "param2",
-			Value: pipelinev1.ArrayOrString{StringVal: "value2", Type: pipelinev1.ParamTypeString},
+			Value: pipelinev1beta1.ArrayOrString{StringVal: "value2", Type: pipelinev1beta1.ParamTypeString},
 		}, {
 			Name:  "param3",
-			Value: pipelinev1.ArrayOrString{StringVal: "value3", Type: pipelinev1.ParamTypeString},
+			Value: pipelinev1beta1.ArrayOrString{StringVal: "value3", Type: pipelinev1beta1.ParamTypeString},
 		}, {
 			Name:  "param4",
-			Value: pipelinev1.ArrayOrString{StringVal: "value4", Type: pipelinev1.ParamTypeString},
+			Value: pipelinev1beta1.ArrayOrString{StringVal: "value4", Type: pipelinev1beta1.ParamTypeString},
 		}, {
 			Name:  "param5",
-			Value: pipelinev1.ArrayOrString{StringVal: "value1", Type: pipelinev1.ParamTypeString},
+			Value: pipelinev1beta1.ArrayOrString{StringVal: "value1", Type: pipelinev1beta1.ParamTypeString},
 		}, {
 			Name:  "param6",
-			Value: pipelinev1.ArrayOrString{StringVal: "value2", Type: pipelinev1.ParamTypeString},
+			Value: pipelinev1beta1.ArrayOrString{StringVal: "value2", Type: pipelinev1beta1.ParamTypeString},
 		}},
 	}, {
 		name:            "multiple bindings with duplicate params",

--- a/test/builder/clustertriggerbinding_test.go
+++ b/test/builder/clustertriggerbinding_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/test/builder/eventlistener.go
+++ b/test/builder/eventlistener.go
@@ -1,7 +1,7 @@
 package builder
 
 import (
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/builder/eventlistener_test.go
+++ b/test/builder/eventlistener_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/builder/param.go
+++ b/test/builder/param.go
@@ -1,12 +1,12 @@
 package builder
 
-import "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+import "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 
-func Param(name, value string) v1alpha1.Param {
-	return v1alpha1.Param{
+func Param(name, value string) v1beta1.Param {
+	return v1beta1.Param{
 		Name: name,
-		Value: v1alpha1.ArrayOrString{
-			Type:      v1alpha1.ParamTypeString,
+		Value: v1beta1.ArrayOrString{
+			Type:      v1beta1.ParamTypeString,
 			StringVal: value,
 		},
 	}

--- a/test/builder/param_test.go
+++ b/test/builder/param_test.go
@@ -4,16 +4,16 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
 
 func TestParam(t *testing.T) {
 	got := Param("foo", "bar")
 
-	want := v1alpha1.Param{
+	want := v1beta1.Param{
 		Name: "foo",
-		Value: v1alpha1.ArrayOrString{
-			Type:      v1alpha1.ParamTypeString,
+		Value: v1beta1.ArrayOrString{
+			Type:      v1beta1.ParamTypeString,
 			StringVal: "bar",
 		},
 	}

--- a/test/builder/triggerbinding.go
+++ b/test/builder/triggerbinding.go
@@ -1,7 +1,7 @@
 package builder
 
 import (
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/test/builder/triggerbinding_test.go
+++ b/test/builder/triggerbinding_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/test/builder/triggertemplate.go
+++ b/test/builder/triggertemplate.go
@@ -1,7 +1,7 @@
 package builder
 
 import (
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/test/builder/triggertemplate_test.go
+++ b/test/builder/triggertemplate_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/test/params.go
+++ b/test/params.go
@@ -17,7 +17,7 @@ limitations under the License.
 package test
 
 import (
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
 
 // CompareParams can be used with comparison options such as `cmpopts.SortSlices`


### PR DESCRIPTION
# Changes

- Update examples to use v1beta1 by default.
- Add an explicit v1alpha1 example.
- Use v1beta1 Pipeline types for Params and tests.

Fixes #481

Followup cleanup: #494


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Triggers can now create both v1alpha1 and v1beta1 Pipeline resources.

```
