### PR TITLE
Implement constant-time secret comparisons in CEL.

### DIFF
--- a/docs/cel_expressions.md
+++ b/docs/cel_expressions.md
@@ -148,7 +148,7 @@ interceptor.
       match
     </th>
     <td>
-      header.(string, string) -> bool
+      header.match(string, string) -> bool
     </td>
     <td>
       Uses the canonical header matching from Go's http.Request to match the header against the value.
@@ -162,7 +162,7 @@ interceptor.
       truncate
     </th>
     <td>
-      (string, uint) -> string
+      truncate(string, uint) -> string
     </td>
     <td>
       Truncates a string to no more than the specified length.
@@ -176,7 +176,7 @@ interceptor.
       split
     </th>
     <td>
-      (string, string) -> string(dyn)
+      split(string, string) -> string(dyn)
     </td>
     <td>
       Splits a string on the provided separator value.
@@ -189,7 +189,7 @@ interceptor.
       canonical
     </th>
     <td>
-      header.(string) -> string
+      header.canonical(string) -> string
     </td>
     <td>
       Uses the canonical header matching from Go's http.Request to get the provided header name.
@@ -212,4 +212,34 @@ interceptor.
      <pre>decodeb64(body.message.data)</pre>
     </td>
   </tr>
+  <tr>
+    <th>
+     compareSecret
+    </th>
+    <td>
+      string.compareSecret(string, string, string) -> bool
+    </td>
+    <td>
+      Constant-time comparison of strings against secrets, this will fetch the secret using the combination of namespace/name and compare the token key to the string using a cryptographic constant-time comparison..<p>
+      The event-listener service account must have access to the secret.
+    </td>
+    <td>
+     <pre>header.canonical('X-Secret-Token').compareSecret('', 'secret-name', 'namespace')</pre>
+    </td>
+  </tr>
+  <tr>
+    <th>
+     compareSecret
+    </th>
+    <td>
+      string.compareSecret(string, string) -> bool
+    </td>
+    <td>
+     This is almost identical to the version above, but only requires two arguments, the namespace is assumed to be the namespace for the event-listener.
+    </td>
+    <td>
+     <pre>header.canonical('X-Secret-Token').compareSecret('key', 'secret-name')</pre>
+    </td>
+  </tr>
+
 </table>

--- a/examples/eventlisteners/cel-eventlistener-interceptor-with-secret.yaml
+++ b/examples/eventlisteners/cel-eventlistener-interceptor-with-secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysecret
+type: Opaque
+data:
+  token: dGVzdC1zZWNyZXQ=
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: EventListener
+metadata:
+  name: cel-listener-interceptor-with-secret-comparison
+spec:
+  serviceAccountName: tekton-triggers-example-sa
+  triggers:
+    - name: cel-trig-with-matches
+      interceptors:
+        - cel:
+            filter: "'test-secret'.secretCompare('token', 'mysecret')"
+      bindings:
+      - name: pipeline-binding
+      template:
+        name: pipeline-template

--- a/pkg/interceptors/cel/functions.go
+++ b/pkg/interceptors/cel/functions.go
@@ -1,0 +1,145 @@
+package cel
+
+import (
+	"crypto/subtle"
+	"encoding/base64"
+	"net/http"
+	"reflect"
+	"strings"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/interpreter/functions"
+	"github.com/tektoncd/triggers/pkg/interceptors"
+	"k8s.io/client-go/kubernetes"
+
+	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+)
+
+func matchHeader(vals ...ref.Val) ref.Val {
+	h, err := vals[0].ConvertToNative(reflect.TypeOf(http.Header{}))
+	if err != nil {
+		return types.NewErr("failed to convert to http.Header: %w", err)
+	}
+
+	key, ok := vals[1].(types.String)
+	if !ok {
+		return types.ValOrErr(key, "unexpected type '%v' passed to match", vals[1].Type())
+	}
+
+	val, ok := vals[2].(types.String)
+	if !ok {
+		return types.ValOrErr(val, "unexpected type '%v' passed to match", vals[2].Type())
+	}
+
+	return types.Bool(h.(http.Header).Get(string(key)) == string(val))
+}
+
+func truncateString(lhs, rhs ref.Val) ref.Val {
+	str, ok := lhs.(types.String)
+	if !ok {
+		return types.ValOrErr(str, "unexpected type '%v' passed to truncate", lhs.Type())
+	}
+
+	n, ok := rhs.(types.Int)
+	if !ok {
+		return types.ValOrErr(n, "unexpected type '%v' passed to truncate", rhs.Type())
+	}
+
+	return types.String(str[:max(n, types.Int(len(str)))])
+}
+
+func splitString(lhs, rhs ref.Val) ref.Val {
+	str, ok := lhs.(types.String)
+	if !ok {
+		return types.ValOrErr(str, "unexpected type '%v' passed to splitString", lhs.Type())
+	}
+
+	splitStr, ok := rhs.(types.String)
+	if !ok {
+		return types.ValOrErr(str, "unexpected type '%v' passed to splitString", lhs.Type())
+	}
+
+	r := types.NewRegistry()
+	splitVals := strings.Split(string(str), string(splitStr))
+	return types.NewStringList(r, splitVals)
+}
+
+func canonicalHeader(lhs, rhs ref.Val) ref.Val {
+	h, err := lhs.ConvertToNative(reflect.TypeOf(http.Header{}))
+	if err != nil {
+		return types.NewErr("failed to convert to http.Header: %w", err)
+	}
+
+	key, ok := rhs.(types.String)
+	if !ok {
+		return types.ValOrErr(key, "unexpected type '%v' passed to canonical", rhs.Type())
+	}
+
+	return types.String(h.(http.Header).Get(string(key)))
+}
+
+func decodeB64String(val ref.Val) ref.Val {
+	str, ok := val.(types.String)
+	if !ok {
+		return types.ValOrErr(str, "unexpected type '%v' passed to decodeB64", val.Type())
+	}
+	dec, err := base64.StdEncoding.DecodeString(str.Value().(string))
+	if err != nil {
+		return types.NewErr("failed to decode '%v' in decodeB64: %w", str, err)
+	}
+	return types.Bytes(dec)
+}
+
+func makeCompareSecret(defaultNS string, k kubernetes.Interface) functions.FunctionOp {
+	return func(vals ...ref.Val) ref.Val {
+		var ok bool
+		compareString, ok := vals[0].(types.String)
+		if !ok {
+			return types.ValOrErr(compareString, "unexpected type '%v' passed to compareSecret", vals[0].Type())
+		}
+		paramCount := len(vals)
+
+		var secretNS types.String
+		if paramCount == 4 {
+			secretNS, ok = vals[3].(types.String)
+			if !ok {
+				return types.ValOrErr(secretNS, "unexpected type '%v' passed to compareSecret", vals[1].Type())
+			}
+		} else {
+			secretNS = types.String(defaultNS)
+		}
+
+		secretName, ok := vals[2].(types.String)
+		if !ok {
+			return types.ValOrErr(secretName, "unexpected type '%v' passed to match", vals[2].Type())
+		}
+
+		secretKey, ok := vals[1].(types.String)
+		if !ok {
+			return types.ValOrErr(secretKey, "unexpected type '%v' passed to match", vals[3].Type())
+		}
+
+		secretRef := &triggersv1.SecretRef{
+			SecretKey:  string(secretKey),
+			SecretName: string(secretName),
+			Namespace:  string(secretNS),
+		}
+		secretToken, err := interceptors.GetSecretToken(k, secretRef, string(secretNS))
+		if err != nil {
+			return types.NewErr("failed to find secret '%#v' in compareSecret: %w", *secretRef, err)
+		}
+		return types.Bool(subtle.ConstantTimeCompare([]byte(secretToken), []byte(compareString)) == 1)
+	}
+}
+
+func max(x, y types.Int) types.Int {
+	switch x.Compare(y) {
+	case types.IntNegOne:
+		return x
+	case types.IntOne:
+		return y
+	default:
+		return x
+	}
+}

--- a/pkg/sink/sink.go
+++ b/pkg/sink/sink.go
@@ -178,7 +178,7 @@ func (r Sink) executeInterceptors(t *triggersv1.EventListenerTrigger, in *http.R
 		case i.GitLab != nil:
 			interceptor = gitlab.NewInterceptor(i.GitLab, r.KubeClientSet, r.EventListenerNamespace, log)
 		case i.CEL != nil:
-			interceptor = cel.NewInterceptor(i.CEL, log)
+			interceptor = cel.NewInterceptor(i.CEL, r.KubeClientSet, r.EventListenerNamespace, log)
 		default:
 			return nil, nil, fmt.Errorf("unknown interceptor type: %v", i)
 		}


### PR DESCRIPTION
# Changes

This adds new compareSecret overload for strings in CEL, allowing comparison of a value against a secret.

This addresses #486 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
New CEL interceptor function `compareSecrets` for securely comparing strings to secrets in CEL expressions.
```
