### PR TITLE
Add 2020 roadmap 🛣️

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ The contents of this repo originated from implementing
 (visible to members of
 [the Tekton mailing list](https://github.com/tektoncd/community/blob/master/contact.md#mailing-list)).
 
+* [Background](#background)
+* [Want to start using Triggers?](#want-to-start-using-tekton-triggers)
+* [Want to contribute?](#want-to-contribute)
+* [Project roadmap](roadmap.md)
+
 ## Background
 
 [Tekton](https://github.com/tektoncd/pipeline) is a **Kubernetes-native**,

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,0 +1,24 @@
+# Tekton Triggers Roadmap
+
+In 2019 we created a simple system for creating instances of Tekton resources, triggered
+by json payloads sent to HTTP endpoints (Tekton Triggers).
+
+In 2020 we would like to add missing features and then push for a `beta` release in the
+same year.
+
+We are targetting improving the experience for both end users and operators:
+
+* For end users:
+  * [Pluggable core interceptors](https://github.com/tektoncd/triggers/issues/271)
+  * [Increased expression support in TriggerBindings](https://github.com/tektoncd/triggers/issues/367)
+  * [Using TriggerTemplates outside the context of an event](https://github.com/tektoncd/triggers/issues/200)
+  * [Routing to multiple interceptors](https://github.com/tektoncd/triggers/issues/205)
+  * [Dynamic TriggerTemplate parameters](https://github.com/tektoncd/triggers/issues/87)
+  * Support for poll-based triggering (e.g. when a repo changes state)
+  * Support for additional expression languages
+  * [GitHub App support](https://github.com/tektoncd/triggers/issues/189)
+* For operators:
+  * [Improved support for many EventListeners](https://github.com/tektoncd/triggers/issues/370)
+  * Increased traceability (e.g. why did my interceptor reject the event?)
+  * [Performant Triggers](https://github.com/tektoncd/triggers/issues/406)
+  * A scale-to-zero `EventListener`


### PR DESCRIPTION
# Changes

In tektoncd/community#77 we started on a roadmap
for 2020 for all of Tekton but folks pointed out it makes more sense to
let each project's own roadmap live in the repo with them.

(Also included a TOC in the main README)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._
