### PR TITLE
Adds "commented" website front matter to docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,5 +28,5 @@ See the following links for more on each of the resources involved:
 
 ## Getting Started Tasks
 
-- [Create an Ingress on the EventListener Service](https://github.com/tektoncd/triggers/blob/master/docs/create-ingress.yaml)
-- [Create a GitHub webhook](https://github.com/tektoncd/triggers/blob/master/docs/create-webhook.yaml)
+- [Create an Ingress on the EventListener Service](create-ingress.yaml)
+- [Create a GitHub webhook](create-webhook.yaml)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,12 @@
+<!--
+---
+title: "Triggers and EventListeners"
+linkTitle: "Triggers"
+weight: 3
+description: >
+  Event Triggers
+---
+-->
 # Tekton Triggers
 
 Triggers enables users to map fields from an event payload into resource
@@ -6,7 +15,7 @@ themselves as Kubernetes resources. In the case of `tektoncd/pipeline`, this
 makes it easy to encapsulate configuration into `PipelineRun`s and
 `PipelineResource`s.
 
-![TriggerFlow](../images/TriggerFlow.png)
+![TriggerFlow](https://github.com/tektoncd/triggers/blob/master/images/TriggerFlow.png?raw=true)
 
 ## Learn More
 
@@ -19,5 +28,5 @@ See the following links for more on each of the resources involved:
 
 ## Getting Started Tasks
 
-- [Create an Ingress on the EventListener Service](create-ingress.yaml)
-- [Create a GitHub webhook](create-webhook.yaml)
+- [Create an Ingress on the EventListener Service](https://github.com/tektoncd/triggers/blob/master/docs/create-ingress.yaml)
+- [Create a GitHub webhook](https://github.com/tektoncd/triggers/blob/master/docs/create-webhook.yaml)

--- a/docs/cel_expressions.md
+++ b/docs/cel_expressions.md
@@ -1,3 +1,9 @@
+<!--
+---
+linkTitle: "CEL Expression Extensions"
+weight: 8
+---
+-->
 # CEL expression extensions
 
 The CEL expression is configured to expose parts of the request, and some custom

--- a/docs/clustertriggerbindings.md
+++ b/docs/clustertriggerbindings.md
@@ -1,3 +1,9 @@
+<!--
+---
+linkTitle: "Cluster Trigger Binding"
+weight: 7
+---
+-->
 # ClusterTriggerBindings
 
 `ClusterTriggerBindings` is similar to TriggerBinding which is used to extract

--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -1,3 +1,9 @@
+<!--
+---
+linkTitle: "Event Listeners"
+weight: 5
+---
+-->
 # EventListener
 
 EventListener is a Kubernetes custom resource that allows users a declarative
@@ -117,7 +123,7 @@ running the sink logic. The logging configuration can be controlled via the
 `config-logging-triggers` ConfigMap present in the namespace that the
 EventListener was created in. This ConfigMap is automatically created and
 contains the default values defined in
-[config-logging.yaml](../config/config-logging.yaml).
+[config-logging.yaml](https://github.com/tektoncd/triggers/blob/master/config/config-logging.yaml).
 
 To access logs for the EventListener sink, you can query for pods with the
 `eventlistener` label set to the name of your EventListener resource:

--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -123,7 +123,7 @@ running the sink logic. The logging configuration can be controlled via the
 `config-logging-triggers` ConfigMap present in the namespace that the
 EventListener was created in. This ConfigMap is automatically created and
 contains the default values defined in
-[config-logging.yaml](https://github.com/tektoncd/triggers/blob/master/config/config-logging.yaml).
+[config-logging.yaml](../config/config-logging.yaml).
 
 To access logs for the EventListener sink, you can query for pods with the
 `eventlistener` label set to the name of your EventListener resource:

--- a/docs/exposing-eventlisteners.md
+++ b/docs/exposing-eventlisteners.md
@@ -13,7 +13,7 @@ services can talk to it:
 ## Using an Ingress
 
 You can use an Ingress resource to expose the EventListener. The
-[`create-ingress`](https://github.com/tektoncd/triggers/blob/master/docs/create-ingress.yaml) Tekton task can help setup an ingress
+[`create-ingress`](./create-ingress.yaml) Tekton task can help setup an ingress
 resource using self-signed certs.
 
 **Note**: If you are using a cloud hosted Kubernetes solution such as GKE, the

--- a/docs/exposing-eventlisteners.md
+++ b/docs/exposing-eventlisteners.md
@@ -1,3 +1,9 @@
+<!--
+---
+linkTitle: "Exposing Event Listeners Externally"
+weight: 6
+---
+-->
 # Exposing EventListeners Externally
 
 By default, `ClusterIP` services such as the EventListener sink are accessible
@@ -7,7 +13,7 @@ services can talk to it:
 ## Using an Ingress
 
 You can use an Ingress resource to expose the EventListener. The
-[`create-ingress`](./create-ingress.yaml) Tekton task can help setup an ingress
+[`create-ingress`](https://github.com/tektoncd/triggers/blob/master/docs/create-ingress.yaml) Tekton task can help setup an ingress
 resource using self-signed certs.
 
 **Note**: If you are using a cloud hosted Kubernetes solution such as GKE, the

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,3 +1,9 @@
+<!--
+---
+linkTitle: "Installation"
+weight: 2
+---
+-->
 # Installing Tekton Triggers
 
 Use this page to add the component to an existing Kubernetes cluster.

--- a/docs/triggerbindings.md
+++ b/docs/triggerbindings.md
@@ -1,3 +1,9 @@
+<!--
+---
+linkTitle: "Trigger Bindings"
+weight: 4
+---
+-->
 # TriggerBindings
 
 As per the name, `TriggerBinding`s bind against events/triggers.

--- a/docs/triggertemplates.md
+++ b/docs/triggertemplates.md
@@ -1,3 +1,9 @@
+<!--
+---
+linkTitle: "Trigger Templates"
+weight: 3
+---
+-->
 # TriggerTemplates
 
 A `TriggerTemplate` is a resource that can template resources.

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation.go
@@ -62,7 +62,7 @@ func (t *EventListenerTrigger) validate(ctx context.Context) *apis.FieldError {
 		}
 	}
 	if t.Template.Name == "" {
-		return apis.ErrMissingField(fmt.Sprintf("template.name"))
+		return apis.ErrMissingField("template.name")
 	}
 	for i, interceptor := range t.Interceptors {
 		if err := interceptor.validate(ctx).ViaField(fmt.Sprintf("interceptors[%d]", i)); err != nil {


### PR DESCRIPTION
This change adds the front matter needed for the website without altering the site markdown or adding titles. It does this by adding the front matter in comment tags.

The tutorial and install are not part of the website currently so links to them under docs/ use absolute urls to allow them to work in both the website and in the pipeline repo

# Changes
update /docs markdown files with front matter


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

