### PR TITLE
Add omitempty tag to Status field

### DIFF
--- a/pkg/apis/triggers/v1alpha1/cluster_trigger_binding_types.go
+++ b/pkg/apis/triggers/v1alpha1/cluster_trigger_binding_types.go
@@ -43,7 +43,7 @@ type ClusterTriggerBinding struct {
 	Spec TriggerBindingSpec `json:"spec,omitempty"`
 
 	// +optional
-	Status TriggerBindingStatus `json:"status"`
+	Status TriggerBindingStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/triggers/v1alpha1/event_listener_types.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_types.go
@@ -47,7 +47,7 @@ type EventListener struct {
 	// +optional
 	Spec EventListenerSpec `json:"spec"`
 	// +optional
-	Status EventListenerStatus `json:"status"`
+	Status EventListenerStatus `json:"status,omitempty"`
 }
 
 // EventListenerSpec defines the desired state of the EventListener, represented

--- a/pkg/apis/triggers/v1alpha1/trigger_binding_types.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_binding_types.go
@@ -62,7 +62,7 @@ type TriggerBinding struct {
 	// +optional
 	Spec TriggerBindingSpec `json:"spec"`
 	// +optional
-	Status TriggerBindingStatus `json:"status"`
+	Status TriggerBindingStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/triggers/v1alpha1/trigger_template_types.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_template_types.go
@@ -70,7 +70,7 @@ type TriggerTemplate struct {
 	// +optional
 	Spec TriggerTemplateSpec `json:"spec"`
 	// +optional
-	Status TriggerTemplateStatus `json:"status"`
+	Status TriggerTemplateStatus `json:"status,omitempty"`
 }
 
 // TriggerTemplateList contains a list of TriggerTemplate


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Added `omitempty` tags to `status` fields of event-listeners, bindings, templates and cluster trigger bindings. Adding `omitempty` tag would allow omitting the `status` field if it has an empty value.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes
