### PR TITLE
Keeps Deployment Selector Static

### DIFF
--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
@@ -300,7 +300,7 @@ func (c *Reconciler) reconcileDeployment(el *v1alpha1.EventListener) error {
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: GenerateResourceLabels(el.Name),
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -332,10 +332,6 @@ func (c *Reconciler) reconcileDeployment(el *v1alpha1.EventListener) error {
 		updated := reconcileObjectMeta(&existingDeployment.ObjectMeta, deployment.ObjectMeta)
 		if existingDeployment.Spec.Replicas == nil || *existingDeployment.Spec.Replicas == 0 {
 			existingDeployment.Spec.Replicas = &replicas
-			updated = true
-		}
-		if existingDeployment.Spec.Selector != deployment.Spec.Selector {
-			existingDeployment.Spec.Selector = deployment.Spec.Selector
 			updated = true
 		}
 		if !reflect.DeepEqual(existingDeployment.Spec.Template.Labels, deployment.Spec.Template.Labels) {

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
@@ -344,7 +344,6 @@ func Test_reconcileDeployment(t *testing.T) {
 	// deployment 2 == initial deployment + labels from eventListener
 	deployment2 := deployment1.DeepCopy()
 	deployment2.Labels = mergeLabels(generatedLabels, updateLabel)
-	deployment2.Spec.Selector.MatchLabels = mergeLabels(generatedLabels, updateLabel)
 	deployment2.Spec.Template.Labels = mergeLabels(generatedLabels, updateLabel)
 
 	// deployment 3 == initial deployment + updated replicas
@@ -604,7 +603,6 @@ func TestReconcile(t *testing.T) {
 
 	deployment2 := deployment1.DeepCopy()
 	deployment2.Labels = mergeLabels(updateLabel, generatedLabels)
-	deployment2.Spec.Selector.MatchLabels = mergeLabels(updateLabel, generatedLabels)
 	deployment2.Spec.Template.Labels = mergeLabels(updateLabel, generatedLabels)
 
 	deployment3 := deployment2.DeepCopy()

--- a/test/eventlistener_scale_test.go
+++ b/test/eventlistener_scale_test.go
@@ -55,7 +55,7 @@ func TestEventListenerScale(t *testing.T) {
 	}
 
 	// Verify that the EventListener was created properly
-	if err := WaitFor(eventListenerReady(t, c, namespace, el.Name)); err != nil {
+	if err := WaitFor(eventListenerReady(t, c, namespace, el)); err != nil {
 		t.Fatalf("EventListener is not ready: %s", err)
 	}
 	t.Log("EventListener is ready")


### PR DESCRIPTION
# Changes
Fixes: https://github.com/tektoncd/triggers/issues/463

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
This PR keeps the Deployment selector static.  This selector does not need to change throughout the lifetime of the pods.
```go
type LabelSelector struct {
	// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
	// map is equivalent to an element of matchExpressions, whose key field is "key", the
	// operator is "In", and the values array contains only "value". The requirements are ANDed.
	// +optional
	MatchLabels map[string]string `json:"matchLabels,omitempty" protobuf:"bytes,1,rep,name=matchLabels"`
	// matchExpressions is a list of label selector requirements. The requirements are ANDed.
	// +optional
	MatchExpressions []LabelSelectorRequirement `json:"matchExpressions,omitempty" protobuf:"bytes,2,rep,name=matchExpressions"`
}
```
Since the requirements are `ANDed`, updated deployment selectors would then not correspond to the (old) pods they initially created.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._