### PR TITLE
Use static selector labels for EL svc/deployments

### DIFF
--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
@@ -175,7 +175,7 @@ func (c *Reconciler) reconcileService(el *v1alpha1.EventListener) error {
 	service := &corev1.Service{
 		ObjectMeta: generateObjectMeta(el),
 		Spec: corev1.ServiceSpec{
-			Selector: mergeLabels(el.Labels, GenerateResourceLabels(el.Name)),
+			Selector: GenerateResourceLabels(el.Name),
 			Type:     el.Spec.ServiceType,
 			Ports: []corev1.ServicePort{
 				{
@@ -300,7 +300,7 @@ func (c *Reconciler) reconcileDeployment(el *v1alpha1.EventListener) error {
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: GenerateResourceLabels(el.Name),
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
@@ -148,7 +148,7 @@ func Test_reconcileService(t *testing.T) {
 	}
 	service2 := service1.DeepCopy()
 	service2.Labels = mergeLabels(generatedLabels, updateLabel)
-	service2.Spec.Selector = mergeLabels(generatedLabels, updateLabel)
+	service2.Spec.Selector = generatedLabels
 
 	service3 := service1.DeepCopy()
 	service3.Spec.Ports[0].NodePort = 30000
@@ -344,7 +344,7 @@ func Test_reconcileDeployment(t *testing.T) {
 	// deployment 2 == initial deployment + labels from eventListener
 	deployment2 := deployment1.DeepCopy()
 	deployment2.Labels = mergeLabels(generatedLabels, updateLabel)
-	deployment2.Spec.Selector.MatchLabels = mergeLabels(generatedLabels, updateLabel)
+	deployment2.Spec.Selector.MatchLabels = generatedLabels
 	deployment2.Spec.Template.Labels = mergeLabels(generatedLabels, updateLabel)
 
 	// deployment 3 == initial deployment + updated replicas
@@ -604,7 +604,7 @@ func TestReconcile(t *testing.T) {
 
 	deployment2 := deployment1.DeepCopy()
 	deployment2.Labels = mergeLabels(updateLabel, generatedLabels)
-	deployment2.Spec.Selector.MatchLabels = mergeLabels(updateLabel, generatedLabels)
+	deployment2.Spec.Selector.MatchLabels = generatedLabels
 	deployment2.Spec.Template.Labels = mergeLabels(updateLabel, generatedLabels)
 
 	deployment3 := deployment2.DeepCopy()
@@ -630,7 +630,7 @@ func TestReconcile(t *testing.T) {
 
 	service2 := service1.DeepCopy()
 	service2.Labels = mergeLabels(updateLabel, generatedLabels)
-	service2.Spec.Selector = mergeLabels(updateLabel, generatedLabels)
+	service2.Spec.Selector = generatedLabels
 
 	service3 := service2.DeepCopy()
 	service3.Spec.Type = corev1.ServiceTypeNodePort
@@ -660,12 +660,16 @@ func TestReconcile(t *testing.T) {
 	}, {
 		name: "update-eventlistener-labels",
 		key:  reconcileKey,
+		// Resources before reconcile starts: EL has extra label that deployment/svc does not
 		startResources: test.Resources{
 			Namespaces:     []*corev1.Namespace{namespaceResource},
 			EventListeners: []*v1alpha1.EventListener{eventListener2},
 			Deployments:    []*appsv1.Deployment{deployment1},
 			Services:       []*corev1.Service{service1},
 		},
+		// We expect the deployment and services to propagate the extra label
+		// but the selectors in both Service and deployment should have the same
+		// label
 		endResources: test.Resources{
 			Namespaces:     []*corev1.Namespace{namespaceResource},
 			EventListeners: []*v1alpha1.EventListener{eventListener2},


### PR DESCRIPTION
Previously, if a user added an extra label, we'd propagate that to the
deployment and services.  However, in addition, we'd also update the selector
fields in both deployments and services to use this additional label. This is
unnecessary since the static set of default labels that we add on each resource
is enough to match and do not need to be updated throughout the lifecycle of
the resources.

Fixes #463

This PR replaces #510. Changes are:

1. E2E test removed: The test was port-forwarding to the pod which does not test the failure scenario described in #463 i.e. the service cannot forward to the Pods due to mismatched selector labels. The reconciler test has been updated to ensure that the service/deployment selector matches. Also, verified manually by updating labels, and triggering the EL via the service address (as opposed to port-forwarding to the Pod)

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._
