### PR TITLE
Fix broken anchor link in EventListener docs

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -17,7 +17,7 @@ using [Event Interceptors](#Interceptors).
 - [Syntax](#syntax)
   - [ServiceAccountName](#serviceAccountName)
   - [Triggers](#triggers)
-    - [Interceptors](#Interceptors)
+    - [Interceptors](#interceptors)
 - [Logging](#logging)
 - [Labels](#labels)
 - [Examples](#examples)


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Just a trivial documentation fix - there's a broken link in the EventListener docs ToC - this change will properly link to the interceptors section down below.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

I don't think this is relevant but will fill out if maintainers disagree. I'm also happy to write a longer commit message but I think the change is pretty transparent ... 
