### PR TITLE
Update docs to specify k8s version 1.15 or greater

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -98,7 +98,7 @@ configuring Kubernetes resources.
 Docker for Desktop using an edge version has been proven to work for both
 developing and running Pipelines. The recommended configuration is:
 
-- Kubernetes version 1.11 or later
+- Kubernetes version 1.15 or later
 - 4 vCPU nodes (`n1-standard-4`)
 - Node autoscaling, up to 3 nodes
 - API scopes for cloud-platform
@@ -110,7 +110,7 @@ To setup a cluster with GKE:
    variable (e.g. `PROJECT_ID`).
 
 1. Create a GKE cluster (with `--cluster-version=latest` but you can use any
-   version 1.11 or later):
+   version 1.15 or later):
 
    ```bash
    export PROJECT_ID=my-gcp-project

--- a/docs/install.md
+++ b/docs/install.md
@@ -14,7 +14,7 @@ Use this page to add the component to an existing Kubernetes cluster.
 
 ## Pre-requisites
 
-1. A Kubernetes cluster version 1.11 or later (_if you don't have an existing
+1. A Kubernetes cluster version 1.15 or later (_if you don't have an existing
    cluster_):
 
    ```bash


### PR DESCRIPTION
# Changes

Fixes #517

Triggers now requires kubernetes version 1.15 or higher; this PR updates
the docs to reflect this.

/cc @dibyom 
/cc @joe-sonrichard

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Updates the minimum k8s version in the docs to 1.15.
```
