### PR TITLE
Fix automatic deletion of Tekton logging ConfigMap.

### DIFF
--- a/pkg/reconciler/v1alpha1/eventlistener/controller.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/controller.go
@@ -18,6 +18,7 @@ package eventlistener
 
 import (
 	"context"
+	"os"
 	"time"
 
 	pipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
@@ -63,6 +64,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	c := &Reconciler{
 		Base:                reconciler.NewBase(opt, eventListenerAgentName),
 		eventListenerLister: eventListenerInformer.Lister(),
+		systemNamespace:     os.Getenv("SYSTEM_NAMESPACE"),
 	}
 	impl := controller.NewImpl(c, c.Logger, eventListenerControllerName)
 

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
@@ -83,6 +83,7 @@ type Reconciler struct {
 	*reconciler.Base
 	// listers index properties about resources
 	eventListenerLister listers.EventListenerLister
+	systemNamespace     string
 }
 
 // Check that our Reconciler implements controller.Reconciler
@@ -108,7 +109,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) (returnError err
 		if err != nil {
 			return err
 		}
-		if len(cfgs) > 0 {
+		if len(cfgs) > 0 || namespace == c.systemNamespace {
 			return nil
 		}
 		err = c.KubeClientSet.CoreV1().ConfigMaps(namespace).Delete(eventListenerConfigMapName, &metav1.DeleteOptions{})


### PR DESCRIPTION
# Changes
This addresses issue #523, using EventListeners in the controller's namespace
results in the logging ConfigMap being deleted whenever the EventListener is
deleted, as the last one in the namespace.

When processing the deletion of an EventListener, the logic that removes the
last ConfigMap is skipped if the deletion is occurring in the SYSTEM_NAMESPACE.
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Fix for issue #523 that was causing the Triggers logging configuration to be deleted when the last EventListener in the "tekton-triggers" namespace was deleted.
```
