### PR TITLE
Implement parseJSON for strings.

### DIFF
--- a/docs/cel_expressions.md
+++ b/docs/cel_expressions.md
@@ -241,5 +241,18 @@ interceptor.
      <pre>header.canonical('X-Secret-Token').compareSecret('key', 'secret-name')</pre>
     </td>
   </tr>
-
+  <tr>
+    <th>
+     parseJSON
+    </th>
+    <td>
+      parseJSON(string) -> map
+    </td>
+    <td>
+     This parses a string that contains a JSON body into a map which which can be subsequently used in other expressions.
+    </td>
+    <td>
+     <pre>parseJSON('{"testing":"value"}').testing == "value"</pre>
+    </td>
+  </tr>
 </table>

--- a/pkg/interceptors/cel/cel_test.go
+++ b/pkg/interceptors/cel/cel_test.go
@@ -288,7 +288,8 @@ func TestExpressionEvaluation(t *testing.T) {
 		"pull_request": map[string]interface{}{
 			"commits": 2,
 		},
-		"b64value": "ZXhhbXBsZQ==",
+		"b64value":  "ZXhhbXBsZQ==",
+		"json_body": `{"testing": "value"}`,
 	}
 	refParts := strings.Split(testRef, "/")
 	header := http.Header{}
@@ -376,6 +377,11 @@ func TestExpressionEvaluation(t *testing.T) {
 			expr:   "'secrettoken'.compareSecret('token', 'test-secret') ",
 			want:   types.Bool(true),
 			secret: makeSecret(),
+		},
+		{
+			name: "parse JSON body in a string",
+			expr: "parseJSON(body.json_body).testing == 'value'",
+			want: types.Bool(true),
 		},
 	}
 	for _, tt := range tests {
@@ -476,6 +482,11 @@ func TestExpressionEvaluation_Error(t *testing.T) {
 			expr:     "'testing'.compareSecret('testSecret', 'mytoken')",
 			secretNS: "another-ns",
 			want:     "failed to find secret.*another-ns.*",
+		},
+		{
+			name: "invalid parseJSON body",
+			expr: "parseJSON(body.value).test == 'test'",
+			want: "invalid character 'e' in literal",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/interceptors/cel/functions.go
+++ b/pkg/interceptors/cel/functions.go
@@ -3,6 +3,7 @@ package cel
 import (
 	"crypto/subtle"
 	"encoding/base64"
+	"encoding/json"
 	"net/http"
 	"reflect"
 	"strings"
@@ -89,6 +90,19 @@ func decodeB64String(val ref.Val) ref.Val {
 		return types.NewErr("failed to decode '%v' in decodeB64: %w", str, err)
 	}
 	return types.Bytes(dec)
+}
+
+func parseJSONString(val ref.Val) ref.Val {
+	str, ok := val.(types.String)
+	if !ok {
+		return types.ValOrErr(str, "unexpected type '%v' passed to parseJSON", val.Type())
+	}
+	decodedVal := map[string]interface{}{}
+	err := json.Unmarshal([]byte(str), &decodedVal)
+	if err != nil {
+		return types.NewErr("failed to decode '%v' in parseJSON: %w", str, err)
+	}
+	return types.NewDynamicMap(types.NewRegistry(), decodedVal)
 }
 
 func makeCompareSecret(defaultNS string, k kubernetes.Interface) functions.FunctionOp {


### PR DESCRIPTION
# Changes

This adds a CEL function "parseJSON" which can take a key and parse it into a dynamic map.

This is useful if you have embedded JSON inside a string in a request body.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
New CEL function `parseJSON` that can parse JSON embedded in a string in a request body.
```
