### PR TITLE
Fix markdown formatting for install docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -14,34 +14,34 @@ Use this page to add the component to an existing Kubernetes cluster.
 
 ## Pre-requisites
 
-1. A Kubernetes cluster version 1.15 or later (_if you don't have an existing
-   cluster_):
+1.  A Kubernetes cluster version 1.15 or later (_if you don't have an existing
+    cluster_):
 
-   ```bash
-   # Example cluster creation command on GKE
-   gcloud container clusters create $CLUSTER_NAME \
-     --zone=$CLUSTER_ZONE
-   ```
+    ```bash
+    # Example cluster creation command on GKE
+    gcloud container clusters create $CLUSTER_NAME \
+      --zone=$CLUSTER_ZONE
+    ```
 
-2. Grant cluster-admin permissions to the current user:
+1.  Grant cluster-admin permissions to the current user:
 
-   ```bash
-   kubectl create clusterrolebinding cluster-admin-binding \
-   --clusterrole=cluster-admin \
-   --user=$(gcloud config get-value core/account)
-   ```
+    ```bash
+    kubectl create clusterrolebinding cluster-admin-binding \
+    --clusterrole=cluster-admin \
+    --user=$(gcloud config get-value core/account)
+    ```
 
-   _See
-   [Role-based access control](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#prerequisites_for_using_role-based_access_control)
-   for more information_.
+    _See
+    [Role-based access control](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#prerequisites_for_using_role-based_access_control)
+    for more information_.
 
-3) Install Tekton Pipelines. You can install the latest version using the
-   command below or follow the
-   [pipeline installation guide](https://github.com/tektoncd/pipeline/blob/master/docs/install.md):
+1.  Install Tekton Pipelines. You can install the latest version using the
+    command below or follow the
+    [pipeline installation guide](https://github.com/tektoncd/pipeline/blob/master/docs/install.md):
 
-   ```bash
-   kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
-   ```
+    ```bash
+    kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+    ```
 
 ## Versions
 
@@ -56,30 +56,30 @@ The versions of Tekton Triggers available are:
 
 To add the Tekton Triggers component to an existing cluster:
 
-1. Run the
-   [`kubectl apply`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#apply)
-   command to install [Tekton Triggers](https://github.com/tektoncd/triggers)
-   and its dependencies:
+1.  Run the
+    [`kubectl apply`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#apply)
+    command to install [Tekton Triggers](https://github.com/tektoncd/triggers)
+    and its dependencies:
 
-   ```bash
-   kubectl apply --filename https://storage.googleapis.com/tekton-releases/triggers/latest/release.yaml
-   ```
+    ```bash
+    kubectl apply --filename https://storage.googleapis.com/tekton-releases/triggers/latest/release.yaml
+    ```
 
-   _Previous versions will be available at `previous/$VERSION_NUMBER`, e.g.
-   https://storage.googleapis.com/tekton-releases/triggers/previous/v0.1.0/release.yaml_
+    _Previous versions will be available at `previous/$VERSION_NUMBER`, e.g.
+    https://storage.googleapis.com/tekton-releases/triggers/previous/v0.1.0/release.yaml_
 
-1. Run the
-   [`kubectl get`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#get)
-   command to monitor the Tekton Triggers components until all of the components
-   show a `STATUS` of `Running`:
+1.  Run the
+    [`kubectl get`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#get)
+    command to monitor the Tekton Triggers components until all of the components
+    show a `STATUS` of `Running`:
 
-   ```bash
-   kubectl get pods --namespace tekton-pipelines
-   ```
+    ```bash
+    kubectl get pods --namespace tekton-pipelines
+    ```
 
-   Tip: Instead of running the `kubectl get` command multiple times, you can
-   append the `--watch` flag to view the component's status updates in real
-   time. Use CTRL + C to exit watch mode.
+    Tip: Instead of running the `kubectl get` command multiple times, you can
+    append the `--watch` flag to view the component's status updates in real
+    time. Use CTRL + C to exit watch mode.
 
 You are now ready to create and run Tekton Triggers:
 


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/website/issues/64

Non-GitHub markdown parsers are less forgiving about formatting,
especially when it comes to lists and code blocks.

Code blocks must be indented by 4 spaces per list level in order
to be parsed and rendered correctly as part of the list item.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
