### PR TITLE
Add helper function to triggerbinding in order to support params of type array

### DIFF
--- a/pkg/apis/triggers/v1alpha1/trigger_binding_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_binding_validation_test.go
@@ -38,6 +38,7 @@ func Test_TriggerBindingValidate(t *testing.T) {
 				bldr.TriggerBindingParam("param1", "$(body.input1)"),
 				bldr.TriggerBindingParam("param2", "$(body.input2)"),
 				bldr.TriggerBindingParam("param3", "$(body.input3)"),
+				bldr.TriggerBindingArrayParam("param4", []string{"$(body.input4)"}),
 			)),
 	}, {
 		name: "multiple params case sensitive",

--- a/pkg/template/resource_test.go
+++ b/pkg/template/resource_test.go
@@ -568,6 +568,26 @@ func TestMergeBindingParams(t *testing.T) {
 			Value: pipelinev1beta1.ArrayOrString{StringVal: "value2", Type: pipelinev1beta1.ParamTypeString},
 		}},
 	}, {
+		name: "multiple param type binding with multiple params",
+		clusterBindings: []*triggersv1.ClusterTriggerBinding{
+			bldr.ClusterTriggerBinding("", bldr.ClusterTriggerBindingSpec(
+				bldr.TriggerBindingParam("param1", "value1"),
+				bldr.TriggerBindingParam("param2", "value2"),
+				bldr.TriggerBindingArrayParam("param3", []string{"value3"}),
+			)),
+		},
+		bindings: []*triggersv1.TriggerBinding{},
+		want: []pipelinev1beta1.Param{{
+			Name:  "param1",
+			Value: pipelinev1beta1.ArrayOrString{StringVal: "value1", Type: pipelinev1beta1.ParamTypeString},
+		}, {
+			Name:  "param2",
+			Value: pipelinev1beta1.ArrayOrString{StringVal: "value2", Type: pipelinev1beta1.ParamTypeString},
+		}, {
+			Name:  "param3",
+			Value: pipelinev1beta1.ArrayOrString{ArrayVal: []string{"value3"}, Type: pipelinev1beta1.ParamTypeArray},
+		}},
+	}, {
 		name: "multiple bindings each with multiple params",
 		clusterBindings: []*triggersv1.ClusterTriggerBinding{
 			bldr.ClusterTriggerBinding("", bldr.ClusterTriggerBindingSpec(

--- a/test/builder/triggerbinding.go
+++ b/test/builder/triggerbinding.go
@@ -66,3 +66,17 @@ func TriggerBindingParam(name, value string) TriggerBindingSpecOp {
 			})
 	}
 }
+
+// TriggerBindingArrayParam adds a param of type array to the TriggerBindingSpec.
+func TriggerBindingArrayParam(name string, value []string) TriggerBindingSpecOp {
+	return func(spec *v1alpha1.TriggerBindingSpec) {
+		spec.Params = append(spec.Params,
+			pipelinev1.Param{
+				Name: name,
+				Value: pipelinev1.ArrayOrString{
+					ArrayVal: value,
+					Type:     pipelinev1.ParamTypeArray,
+				},
+			})
+	}
+}

--- a/test/builder/triggerbinding_test.go
+++ b/test/builder/triggerbinding_test.go
@@ -111,6 +111,31 @@ func TestTriggerBindingBuilder(t *testing.T) {
 				),
 			),
 		},
+		{
+			name: "Param of Array type",
+			normal: &v1alpha1.TriggerBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "namespace",
+				},
+				Spec: v1alpha1.TriggerBindingSpec{
+					Params: []pipelinev1.Param{
+						{
+							Name: "param1",
+							Value: pipelinev1.ArrayOrString{
+								ArrayVal: []string{"value1"},
+								Type:     pipelinev1.ParamTypeArray,
+							},
+						},
+					},
+				},
+			},
+			builder: TriggerBinding("name", "namespace",
+				TriggerBindingSpec(
+					TriggerBindingArrayParam("param1", []string{"value1"}),
+				),
+			),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION

# Changes

Add helper function to `triggerbinding` to support `params` of type array 

**Background:**
Need to add test case for [triggerbinding describe](https://github.com/tektoncd/cli/pull/912) and did not find helper function for params fo Array type

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
