### PR TITLE
Add a ServiceAccount to EventListenerScaleTest

### DIFF
--- a/test/eventlistener_scale_test.go
+++ b/test/eventlistener_scale_test.go
@@ -22,7 +22,11 @@ import (
 	"fmt"
 	"testing"
 
+	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	bldr "github.com/tektoncd/triggers/test/builder"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
 )
 
@@ -32,16 +36,20 @@ import (
  */
 func TestEventListenerScale(t *testing.T) {
 	c, namespace := setup(t)
-	t.Parallel()
 
 	defer tearDown(t, c, namespace)
 	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
 
 	t.Log("Start EventListener Scale e2e test")
 
+	saName := "scale-sa"
+	createServiceAccount(t, c, namespace, saName)
 	// Create an EventListener with 1000 Triggers
 	var err error
-	el := bldr.EventListener("my-eventlistener", namespace)
+	el := bldr.EventListener("my-eventlistener", namespace, bldr.EventListenerSpec(
+		bldr.EventListenerServiceAccount(saName)),
+	)
+
 	for i := 0; i < 1000; i++ {
 		trigger := bldr.Trigger("my-triggertemplate", "v1alpha1",
 			bldr.EventListenerTriggerBinding("my-triggerbinding", "", "v1alpha1"),
@@ -59,4 +67,53 @@ func TestEventListenerScale(t *testing.T) {
 		t.Fatalf("EventListener is not ready: %s", err)
 	}
 	t.Log("EventListener is ready")
+}
+
+func createServiceAccount(t *testing.T, c *clients, namespace, name string) {
+	t.Helper()
+	sa, err := c.KubeClient.CoreV1().ServiceAccounts(namespace).Create(
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+		},
+	)
+	if err != nil {
+		t.Fatalf("Error creating ServiceAccount: %s", err)
+	}
+	_, err = c.KubeClient.RbacV1().Roles(namespace).Create(
+		&rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{Name: "sa-role"},
+			Rules: []rbacv1.PolicyRule{{
+				APIGroups: []string{triggersv1.GroupName},
+				Resources: []string{"eventlisteners", "triggerbindings", "triggertemplates"},
+				Verbs:     []string{"get"},
+			}, {
+				APIGroups: []string{""},
+				Resources: []string{"configmaps"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("Error creating Role: %s", err)
+	}
+	_, err = c.KubeClient.RbacV1().RoleBindings(namespace).Create(
+		&rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "sa-rolebinding"},
+			Subjects: []rbacv1.Subject{{
+				Kind:      "ServiceAccount",
+				Name:      sa.Name,
+				Namespace: namespace,
+			}},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "Role",
+				Name:     "sa-role",
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("Error creating RoleBinding: %s", err)
+	}
+
 }


### PR DESCRIPTION
The Sink created by the test eventually goes into a CrashLoop because it lacks
the permissions needed to get the logging configMap resulting in the
LivenessProbe restarting it. However, there is a short delay initially when the
Sink is marked `Available` which is apparently enough for the test to pass. The
bug was discovered in #467 when adding a ReadinessProbe and running the test in
GKE make it consistently fail. This commit fixes the bug by adding a
ServiceAccount to the EL with permission to get the logging configMap in the
namespace.

Fixes #546


# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._
