### PR TITLE
Add version labels on CRDs 🏷

### DIFF
--- a/config/300-clustertriggerbinding.yaml
+++ b/config/300-clustertriggerbinding.yaml
@@ -16,6 +16,9 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clustertriggerbindings.triggers.tekton.dev
+  labels:
+    triggers.tekton.dev/release: "devel"
+    version: "devel"
 spec:
   group: triggers.tekton.dev
   scope: Cluster

--- a/config/300-eventlistener.yaml
+++ b/config/300-eventlistener.yaml
@@ -16,6 +16,9 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: eventlisteners.triggers.tekton.dev
+  labels:
+    triggers.tekton.dev/release: "devel"
+    version: "devel"
 spec:
   group: triggers.tekton.dev
   scope: Namespaced

--- a/config/300-triggerbinding.yaml
+++ b/config/300-triggerbinding.yaml
@@ -16,6 +16,9 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: triggerbindings.triggers.tekton.dev
+  labels:
+    triggers.tekton.dev/release: "devel"
+    version: "devel"
 spec:
   group: triggers.tekton.dev
   scope: Namespaced

--- a/config/300-triggertemplate.yaml
+++ b/config/300-triggertemplate.yaml
@@ -16,6 +16,9 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: triggertemplates.triggers.tekton.dev
+  labels:
+    triggers.tekton.dev/release: "devel"
+    version: "devel"
 spec:
   group: triggers.tekton.dev
   scope: Namespaced


### PR DESCRIPTION

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

The main reason is to make it easier for tooling to get the released
version that is serving the CRDs. Adding those to CRDs as there is a
higher chances for users to be able to get/list CRDs that to get/list
deployments on the `tekton-pipelines` namespace (or another one if
used).

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

Similar to tektoncd/pipeline#2470 but for triggers :stuck_out_tongue: 

/cc @bobcatfish @dibyom 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Add pipleine versions information to the CRDs labels in addition to the deployments
```
