### PR TITLE
Use the same generate scripts as pipeline ⚙

### DIFF
--- a/hack/generate-groups.sh
+++ b/hack/generate-groups.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+
+# generate-groups generates everything for a project with external types only, e.g. a project based
+# on CustomResourceDefinitions.
+
+if [ "$#" -lt 4 ] || [ "${1}" == "--help" ]; then
+  cat <<EOF
+Usage: $(basename "$0") <generators> <output-package> <apis-package> <groups-versions> ...
+  <generators>        the generators comma separated to run (deepcopy,defaulter,client,lister,informer) or "all".
+  <output-package>    the output package name (e.g. github.com/example/project/pkg/generated).
+  <apis-package>      the external types dir (e.g. github.com/example/api or github.com/example/project/pkg/apis).
+  <groups-versions>   the groups and their versions in the format "groupA:v1,v2 groupB:v1 groupC:v2", relative
+                      to <api-package>.
+  ...                 arbitrary flags passed to all generator binaries.
+Examples:
+  $(basename "$0") all             github.com/example/project/pkg/client github.com/example/project/pkg/apis "foo:v1 bar:v1alpha1,v1beta1"
+  $(basename "$0") deepcopy,client github.com/example/project/pkg/client github.com/example/project/pkg/apis "foo:v1 bar:v1alpha1,v1beta1"
+EOF
+  exit 0
+fi
+
+GENS="$1"
+OUTPUT_PKG="$2"
+APIS_PKG="$3"
+GROUPS_WITH_VERSIONS="$4"
+shift 4
+
+# FIXME(vdemeester) Uncomment that when switching to go modules
+#(
+#  # To support running this script from anywhere, we have to first cd into this directory
+#  # so we can install the tools.
+#  cd "$(dirname "${0}")"
+#  go install k8s.io/code-generator/cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}
+#)
+
+function codegen::join() { local IFS="$1"; shift; echo "$*"; }
+
+# enumerate group versions
+FQ_APIS=() # e.g. k8s.io/api/apps/v1
+for GVs in ${GROUPS_WITH_VERSIONS}; do
+  IFS=: read -r G Vs <<<"${GVs}"
+
+  # enumerate versions
+  for V in ${Vs//,/ }; do
+    FQ_APIS+=("${APIS_PKG}/${G}/${V}")
+  done
+done
+
+if [ "${GENS}" = "all" ] || grep -qw "deepcopy" <<<"${GENS}"; then
+  echo "Generating deepcopy funcs for ${GROUPS_WITH_VERSIONS}"
+  "deepcopy-gen" --input-dirs "$(codegen::join , "${FQ_APIS[@]}")" -O zz_generated.deepcopy --bounding-dirs "${APIS_PKG}" "$@"
+fi
+
+if [ "${GENS}" = "all" ] || grep -qw "client" <<<"${GENS}"; then
+  echo "Generating clientset for ${GROUPS_WITH_VERSIONS} at ${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset}"
+  "client-gen" --clientset-name "${CLIENTSET_NAME_VERSIONED:-versioned}" --input-base "" --input "$(codegen::join , "${FQ_APIS[@]}")" --output-package "${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset}" "$@"
+fi
+
+if [ "${GENS}" = "all" ] || grep -qw "lister" <<<"${GENS}"; then
+  echo "Generating listers for ${GROUPS_WITH_VERSIONS} at ${OUTPUT_PKG}/listers"
+  "lister-gen" --input-dirs "$(codegen::join , "${FQ_APIS[@]}")" --output-package "${OUTPUT_PKG}/listers" "$@"
+fi
+
+if [ "${GENS}" = "all" ] || grep -qw "informer" <<<"${GENS}"; then
+  echo "Generating informers for ${GROUPS_WITH_VERSIONS} at ${OUTPUT_PKG}/informers"
+  "informer-gen" \
+           --input-dirs "$(codegen::join , "${FQ_APIS[@]}")" \
+           --versioned-clientset-package "${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset}/${CLIENTSET_NAME_VERSIONED:-versioned}" \
+           --listers-package "${OUTPUT_PKG}/listers" \
+           --output-package "${OUTPUT_PKG}/informers" \
+           "$@"
+fi

--- a/hack/generate-knative.sh
+++ b/hack/generate-knative.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Knative Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# generate-groups generates everything for a project with external types only, e.g. a project based
+# on CustomResourceDefinitions.
+
+if [ "$#" -lt 4 ] || [ "${1}" == "--help" ]; then
+  cat <<EOF
+Usage: $(basename $0) <generators> <client-package> <apis-package> <groups-versions> ...
+  <generators>        the generators comma separated to run (deepcopy,defaulter,client,lister,informer) or "all".
+  <client-package>    the client package dir (e.g. github.com/example/project/pkg/clientset).
+  <apis-package>      the external types dir (e.g. github.com/example/api or github.com/example/project/pkg/apis).
+  <groups-versions>   the groups and their versions in the format "groupA:v1,v2 groupB:v1 groupC:v2", relative
+                      to <api-package>.
+  ...                 arbitrary flags passed to all generator binaries.
+Examples:
+  $(basename $0) all             github.com/example/project/pkg/client github.com/example/project/pkg/apis "foo:v1 bar:v1alpha1,v1beta1"
+  $(basename $0) injection,foo   github.com/example/project/pkg/client github.com/example/project/pkg/apis "foo:v1 bar:v1alpha1,v1beta1"
+EOF
+  exit 0
+fi
+
+GENS="$1"
+CLIENT_PKG="$2"
+APIS_PKG="$3"
+GROUPS_WITH_VERSIONS="$4"
+shift 4
+
+# FIXME(vdemeester) Uncomment that when switching to go modules
+#(
+  # To support running this script from anywhere, we have to first cd into this directory
+  # so we can install the tools.
+#  cd $(dirname "${0}")
+#  go install knative.dev/pkg/codegen/cmd/injection-gen
+#)
+
+function codegen::join() { local IFS="$1"; shift; echo "$*"; }
+
+# enumerate group versions
+FQ_APIS=() # e.g. k8s.io/api/apps/v1
+for GVs in ${GROUPS_WITH_VERSIONS}; do
+  IFS=: read G Vs <<<"${GVs}"
+
+  # enumerate versions
+  for V in ${Vs//,/ }; do
+    FQ_APIS+=(${APIS_PKG}/${G}/${V})
+  done
+done
+
+
+if grep -qw "injection" <<<"${GENS}"; then
+  if [[ -z "${OUTPUT_PKG:-}" ]]; then
+    OUTPUT_PKG="${CLIENT_PKG}/injection"
+  fi
+
+  if [[ -z "${VERSIONED_CLIENTSET_PKG:-}" ]]; then
+    VERSIONED_CLIENTSET_PKG="${CLIENT_PKG}/clientset/versioned"
+  fi
+
+  if [[ -z "${EXTERNAL_INFORMER_PKG:-}" ]]; then
+    EXTERNAL_INFORMER_PKG="${CLIENT_PKG}/informers/externalversions"
+  fi
+
+  echo "Generating injection for ${GROUPS_WITH_VERSIONS} at ${OUTPUT_PKG}"
+
+  # Clear old injection
+  rm -rf ${OUTPUT_PKG}
+
+  injection-gen \
+    --input-dirs $(codegen::join , "${FQ_APIS[@]}") \
+    --versioned-clientset-package ${VERSIONED_CLIENTSET_PKG} \
+    --external-versions-informers-package ${EXTERNAL_INFORMER_PKG} \
+    --output-package ${OUTPUT_PKG} \
+    "$@"
+fi

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -18,23 +18,25 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/library.sh
+source $(git rev-parse --show-toplevel)/vendor/github.com/tektoncd/plumbing/scripts/library.sh
 
 CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../../../k8s.io/code-generator)}
+KNATIVE_CODEGEN_PKG=${KNATIVE_CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 ./vendor/knative.dev/pkg/codegen 2>/dev/null || echo ../pkg)}
 
-KNATIVE_CODEGEN_PKG=${KNATIVE_CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 ./vendor/knative.dev/pkg 2>/dev/null || echo ../pkg)}
+go install ${CODEGEN_PKG}/cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}
+go install ${KNATIVE_CODEGEN_PKG}/cmd/injection-gen
 
 # generate the code with:
 # --output-base    because this script should also be able to run inside the vendor dir of
 #                  k8s.io/kubernetes. The output-base is needed for the generators to output into the vendor dir
 #                  instead of the $GOPATH directly. For normal projects this can be dropped.
-${CODEGEN_PKG}/generate-groups.sh "deepcopy,client,informer,lister" \
+bash ${REPO_ROOT_DIR}/hack/generate-groups.sh "deepcopy,client,informer,lister" \
   github.com/tektoncd/triggers/pkg/client github.com/tektoncd/triggers/pkg/apis \
   triggers:v1alpha1 \
   --go-header-file ${REPO_ROOT_DIR}/hack/boilerplate/boilerplate.go.txt
 
 # Knative Injection
-${KNATIVE_CODEGEN_PKG}/hack/generate-knative.sh "injection" \
+bash ${REPO_ROOT_DIR}/hack/generate-knative.sh "injection" \
   github.com/tektoncd/triggers/pkg/client github.com/tektoncd/triggers/pkg/apis \
   "triggers:v1alpha1" \
   --go-header-file ${REPO_ROOT_DIR}/hack/boilerplate/boilerplate.go.txt


### PR DESCRIPTION

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

This imports the scripts from knative and k8s in `./hack` the same way
we did for `tektoncd/pipeline`. It also fixes the `${GOPATH}/bin`
calls on the CI (see https://github.com/tektoncd/pipeline/pull/2486).

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @dibyom @ncskier 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._
