### PR TITLE
Make webhook secret name overridable

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -105,11 +105,16 @@ func main() {
 		serviceName = "tekton-triggers-webhook"
 	}
 
+	secretName := os.Getenv("WEBHOOK_SECRET_NAME")
+	if secretName == "" {
+		secretName = "triggers-webhook-certs"
+	}
+
 	// Set up a signal context with our webhook options
 	ctx := webhook.WithOptions(signals.NewContext(), webhook.Options{
 		ServiceName: serviceName,
 		Port:        8443,
-		SecretName:  "triggers-webhook-certs",
+		SecretName:  secretName,
 	})
 
 	sharedmain.MainWithContext(ctx, "webhook",

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -55,6 +55,8 @@ spec:
           value: config-logging-triggers
         - name: WEBHOOK_SERVICE_NAME
           value: tekton-triggers-webhook
+        - name: WEBHOOK_SECRET_NAME
+          value: triggers-webhook-certs
         - name: METRICS_DOMAIN
           value: tekton.dev/triggers
         ports:


### PR DESCRIPTION
This pull request makes webhook secret name overridable.

It adds an environment variable `WEBHOOK_SECRET_NAME` to allow overriding the secret name.
If the env variable  is not set, the default secret name `triggers-webhook-certs` is used.

# Release Notes

```
The `WEBHOOK_SECRET_NAME`  environment variable  can now be used to configure the secret name for the webook.
```