### PR TITLE
Add recommended k8s labels

### DIFF
--- a/config/101-podsecuritypolicy.yaml
+++ b/config/101-podsecuritypolicy.yaml
@@ -16,6 +16,9 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: tekton-triggers
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers
 spec:
   privileged: false
   allowPrivilegeEscalation: false

--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -16,6 +16,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: tekton-triggers-admin
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers
 rules:
   - apiGroups: [""]
     resources: ["configmaps", "secrets", "services"]

--- a/config/200-serviceaccount.yaml
+++ b/config/200-serviceaccount.yaml
@@ -17,3 +17,6 @@ kind: ServiceAccount
 metadata:
   name: tekton-triggers-controller
   namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers

--- a/config/201-clusterrolebinding.yaml
+++ b/config/201-clusterrolebinding.yaml
@@ -16,6 +16,9 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: tekton-triggers-controller-admin
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers
 subjects:
   - kind: ServiceAccount
     name: tekton-triggers-controller

--- a/config/300-clustertriggerbinding.yaml
+++ b/config/300-clustertriggerbinding.yaml
@@ -17,6 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: clustertriggerbindings.triggers.tekton.dev
   labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers
     triggers.tekton.dev/release: "devel"
     version: "devel"
 spec:

--- a/config/300-eventlistener.yaml
+++ b/config/300-eventlistener.yaml
@@ -17,6 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: eventlisteners.triggers.tekton.dev
   labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers
     triggers.tekton.dev/release: "devel"
     version: "devel"
 spec:

--- a/config/300-triggerbinding.yaml
+++ b/config/300-triggerbinding.yaml
@@ -17,6 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: triggerbindings.triggers.tekton.dev
   labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers
     triggers.tekton.dev/release: "devel"
     version: "devel"
 spec:

--- a/config/300-triggertemplate.yaml
+++ b/config/300-triggertemplate.yaml
@@ -17,6 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: triggertemplates.triggers.tekton.dev
   labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers
     triggers.tekton.dev/release: "devel"
     version: "devel"
 spec:

--- a/config/500-webhooks.yaml
+++ b/config/500-webhooks.yaml
@@ -18,6 +18,9 @@ metadata:
   name: triggers-webhook-certs
   namespace: tekton-pipelines
   labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers
     triggers.tekton.dev/release: devel
 # The data is populated at install time.
 
@@ -27,6 +30,9 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.triggers.tekton.dev
   labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers
     triggers.tekton.dev/release: devel
 webhooks:
 - admissionReviewVersions:
@@ -45,6 +51,9 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.triggers.tekton.dev
   labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers
     triggers.tekton.dev/release: devel
 webhooks:
 - admissionReviewVersions:
@@ -62,6 +71,9 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.triggers.tekton.dev
   labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers
     triggers.tekton.dev/release: devel
 webhooks:
 - admissionReviewVersions:

--- a/config/clusterrole-aggregate-edit.yaml
+++ b/config/clusterrole-aggregate-edit.yaml
@@ -3,6 +3,8 @@ kind: ClusterRole
 metadata:
   name: tekton-triggers-aggregate-edit
   labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:

--- a/config/clusterrole-aggregate-view.yaml
+++ b/config/clusterrole-aggregate-view.yaml
@@ -3,6 +3,8 @@ kind: ClusterRole
 metadata:
   name: tekton-triggers-aggregate-view
   labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups:

--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -17,6 +17,9 @@ kind: ConfigMap
 metadata:
   name: config-logging-triggers
   namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers
 data:
   # Common configuration for all knative codebase
   zap-logger-config: |

--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -17,7 +17,9 @@ kind: ConfigMap
 metadata:
   name: config-observability-triggers
   namespace: tekton-pipelines
-
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers
 data:
   _example: |
     ################################

--- a/config/controller-service.yaml
+++ b/config/controller-service.yaml
@@ -16,9 +16,14 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: tekton-triggers
+    triggers.tekton.dev/release: "devel"
     app: tekton-triggers-controller
     version: "devel"
-    triggers.tekton.dev/release: "devel"
   name: tekton-triggers-controller
   namespace: tekton-pipelines
 spec:
@@ -28,4 +33,7 @@ spec:
     protocol: TCP
     targetPort: 9090
   selector:
-    app: tekton-triggers-controller
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -18,20 +18,31 @@ metadata:
   name: tekton-triggers-controller
   namespace: tekton-pipelines
   labels:
-    app.kubernetes.io/name: tekton-triggers
+    app.kubernetes.io/name: controller
     app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: tekton-triggers
     # tekton.dev/release value replaced with inputs.params.versionTag in triggers/tekton/publish.yaml
     triggers.tekton.dev/release: "devel"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: tekton-triggers-controller
+      app.kubernetes.io/name: controller
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: default
+      app.kubernetes.io/part-of: tekton-triggers
   template:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
+        app.kubernetes.io/name: controller
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: default
+        app.kubernetes.io/version: devel
+        app.kubernetes.io/part-of: tekton-triggers
         app: tekton-triggers-controller
         triggers.tekton.dev/release: "devel"
         # version value replaced with inputs.params.versionTag in triggers/tekton/publish.yaml

--- a/config/webhook-service.yaml
+++ b/config/webhook-service.yaml
@@ -1,16 +1,24 @@
 apiVersion: v1
 kind: Service
 metadata:
+  name: tekton-triggers-webhook
+  namespace: tekton-pipelines
   labels:
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: tekton-triggers
     app: tekton-triggers-webhook
     version: "devel"
     triggers.tekton.dev/release: "devel"
-  name: tekton-triggers-webhook
-  namespace: tekton-pipelines
 spec:
   ports:
     - name: https-webhook
       port: 443
       targetPort: 8443
   selector:
-    app: tekton-triggers-webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -18,27 +18,35 @@ metadata:
   name: tekton-triggers-webhook
   namespace: tekton-pipelines
   labels:
-    app.kubernetes.io/name: tekton-triggers
-    app.kubernetes.io/component: webhook-controller
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: tekton-triggers
     # tekton.dev/release value replaced with inputs.params.versionTag in triggers/tekton/publish.yaml
     triggers.tekton.dev/release: "devel"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: tekton-triggers-webhook
+      app.kubernetes.io/name: webhook
+      app.kubernetes.io/component: webhook
+      app.kubernetes.io/instance: default
+      app.kubernetes.io/part-of: tekton-triggers
   template:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
+        app.kubernetes.io/name: webhook
+        app.kubernetes.io/component: webhook
+        app.kubernetes.io/instance: default
+        app.kubernetes.io/version: devel
+        app.kubernetes.io/part-of: tekton-triggers
         app: tekton-triggers-webhook
         triggers.tekton.dev/release: "devel"
         # version value replaced with inputs.params.versionTag in triggers/tekton/publish.yaml
         version: "devel"
-        role: webhook
-        app.kubernetes.io/name: tekton-triggers
-        app.kubernetes.io/component: webhook-controller
     spec:
       serviceAccountName: tekton-triggers-controller
       containers:


### PR DESCRIPTION
This PR adds recommended k8s labels on resources.
Implementation for proposal https://github.com/tektoncd/pipeline/issues/2497

Related PR in pipelines: https://github.com/tektoncd/pipeline/pull/2501

Base: added labels and updated selectors for all resources in `/config`

NOTE: this will introduce a breaking change when trying to update deployments as label selectors have changed.