### PR TITLE
Add test builder and default values to triggertemplate params

### DIFF
--- a/pkg/apis/triggers/v1alpha1/trigger_template_defaults.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_template_defaults.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package v1alpha1
 
 import (
@@ -5,4 +21,13 @@ import (
 )
 
 // SetDefaults initializes TriggerTemplate with default values.
-func (tt *TriggerTemplate) SetDefaults(ctx context.Context) {}
+func (tt *TriggerTemplate) SetDefaults(ctx context.Context) {
+	tt.Spec.SetDefaults(ctx)
+}
+
+// SetDefaults set any defaults for the params
+func (tts *TriggerTemplateSpec) SetDefaults(ctx context.Context) {
+	for i := range tts.Params {
+		tts.Params[i].SetDefaults(ctx)
+	}
+}

--- a/pkg/apis/triggers/v1alpha1/trigger_template_defaults_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_template_defaults_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+)
+
+func TestTriggerTemplateSetDefaults(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *v1alpha1.TriggerTemplate
+		want *v1alpha1.TriggerTemplate
+	}{{
+		name: "empty params defaults to params of type to string",
+		in: &v1alpha1.TriggerTemplate{
+			Spec: v1alpha1.TriggerTemplateSpec{
+				Params: []pipelinev1beta1.ParamSpec{{}},
+			},
+		},
+		want: &v1alpha1.TriggerTemplate{
+			Spec: v1alpha1.TriggerTemplateSpec{
+				Params: []pipelinev1beta1.ParamSpec{{
+					Type: pipelinev1beta1.ParamTypeString,
+				}},
+			},
+		},
+	}, {
+		name: "params of type array",
+		in: &v1alpha1.TriggerTemplate{
+			Spec: v1alpha1.TriggerTemplateSpec{
+				Params: []pipelinev1beta1.ParamSpec{{
+					Name:        "contenttype",
+					Type:        pipelinev1beta1.ParamTypeArray,
+					Description: "The Content-Type of the event",
+				}},
+			},
+		},
+		want: &v1alpha1.TriggerTemplate{
+			Spec: v1alpha1.TriggerTemplateSpec{
+				Params: []pipelinev1beta1.ParamSpec{{
+					Name:        "contenttype",
+					Type:        pipelinev1beta1.ParamTypeArray,
+					Description: "The Content-Type of the event",
+				}},
+			},
+		},
+	}}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.in
+			got.SetDefaults(context.Background())
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("SetDefaults (-want, +got) = %v", diff)
+			}
+		})
+	}
+}

--- a/test/builder/triggertemplate.go
+++ b/test/builder/triggertemplate.go
@@ -81,3 +81,18 @@ func TriggerTemplateParam(name, description, defaultValue string) TriggerTemplat
 			})
 	}
 }
+
+// TriggerTemplateArrayParam adds a ParamSpec of array type to the TriggerTemplateSpec.
+func TriggerTemplateArrayParam(name, description string, value []string) TriggerTemplateSpecOp {
+	return func(spec *v1alpha1.TriggerTemplateSpec) {
+		spec.Params = append(spec.Params,
+			pipelinev1.ParamSpec{
+				Name:        name,
+				Description: description,
+				Default: &pipelinev1.ArrayOrString{
+					ArrayVal: value,
+					Type:     pipelinev1.ParamTypeArray,
+				},
+			})
+	}
+}

--- a/test/builder/triggertemplate_test.go
+++ b/test/builder/triggertemplate_test.go
@@ -93,6 +93,41 @@ func TestTriggerTemplateBuilder(t *testing.T) {
 			),
 		},
 		{
+			name: "Both string and array Param",
+			normal: &v1alpha1.TriggerTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "namespace",
+				},
+				Spec: v1alpha1.TriggerTemplateSpec{
+					Params: []pipelinev1.ParamSpec{
+						{
+							Name:        "param1",
+							Description: "description",
+							Default: &pipelinev1.ArrayOrString{
+								StringVal: "value1",
+								Type:      pipelinev1.ParamTypeString,
+							},
+						},
+						{
+							Name:        "param2",
+							Description: "description",
+							Default: &pipelinev1.ArrayOrString{
+								ArrayVal: []string{"value2", "value3"},
+								Type:     pipelinev1.ParamTypeArray,
+							},
+						},
+					},
+				},
+			},
+			builder: TriggerTemplate("name", "namespace",
+				TriggerTemplateSpec(
+					TriggerTemplateParam("param1", "description", "value1"),
+					TriggerTemplateArrayParam("param2", "description", []string{"value2", "value3"}),
+				),
+			),
+		},
+		{
 			name: "One Resource Template",
 			normal: &v1alpha1.TriggerTemplate{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Issue: https://github.com/tektoncd/triggers/issues/549
# Changes

1. Added defaults to triggertemplate params
2. Added test builder for the params of type `Array`

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

