### PR TITLE
Updated role permissions for tekton.dev API

### DIFF
--- a/examples/role-resources/triggerbinding-roles/role.yaml
+++ b/examples/role-resources/triggerbinding-roles/role.yaml
@@ -4,7 +4,7 @@ metadata:
   name: tekton-triggers-example-minimal
 rules:
 # Permissions for every EventListener deployment to function
-- apiGroups: ["triggers.tekton.dev"]
+- apiGroups: ["tekton.dev"]
   resources: ["eventlisteners", "triggerbindings", "triggertemplates"]
   verbs: ["get"]
 - apiGroups: [""]


### PR DESCRIPTION
Tekton trigger API changed


# Changes

Tested in Openshift 4.4
triggers.tekton.dev API does not exist anymore
All Tekton API are centralized in tekton.dev.


# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes


```
