### PR TITLE
Update eventlistener.yaml

### DIFF
--- a/examples/eventlisteners/eventlistener.yaml
+++ b/examples/eventlisteners/eventlistener.yaml
@@ -8,7 +8,7 @@ spec:
   triggers:
     - name: foo-trig
       bindings:
-        - ref: pipeline-binding
-        - ref: message-binding
+        - name: pipeline-binding
+        - name: message-binding
       template:
         name: pipeline-template


### PR DESCRIPTION
Using these examples currently fails with the error message below.  The current documentation in https://tekton.dev/docs/triggers/eventlisteners/ shows "name" as the attribute to set here instead of "ref".  NOTE: I didn't look at the other eventlistener examples exhaustively but it seems they all have the same problem.

Error from server (BadRequest): error when creating "test-event-listener.yaml": admission webhook "webhook.triggers.tekton.dev" denied the request: mutation failed: cannot decode incoming new object: json: unknown field "ref"

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
