### PR TITLE
Fix 'Edit this page' and 'Create an issue' links on the website

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,8 @@ linkTitle: "Triggers"
 weight: 3
 description: >
   Event Triggers
+cascade:
+  github_project_repo: https://github.com/tektoncd/triggers
 ---
 -->
 # Tekton Triggers


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/website/issues/65

Add a cascading page property to the frontmatter of docs/README.md
that will apply to all child pages displayed in the Triggers section
of the docs on the website.

This ensures the 'Edit this page' and 'Create an issue' links in
the sidebar point to the Triggers repo instead of the website repo.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

