### PR TITLE
Fix link to getting started guide on website

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -83,7 +83,7 @@ To add the Tekton Triggers component to an existing cluster:
 
 You are now ready to create and run Tekton Triggers:
 
-- See [Tekton Triggers Getting Started Guide](./getting-started/README.md) to
+- See [Tekton Triggers Getting Started Guide](./getting-started/) to
   get started.
 - Look at the
   [examples](https://github.com/tektoncd/triggers/tree/master/examples)


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/website/issues/126

Update the link to the getting started guide to drop README.md from
the URL, so that we can make this work on the website too.

The link from the markdown file in this repo will load the
getting-started folder, with the README.md as the default view below
the directory listing so users will still see the intended content.

On the website the file will be exposed at `/docs/triggers/getting-started/`

PR against the website repo to sync the getting-started guide will follow:
https://github.com/tektoncd/website/pull/128

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
