### PR TITLE
Remove linting from release pipeline 🧹

### DIFF
--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -26,22 +26,7 @@ spec:
   - name: notification
     type: cloudEvent
   tasks:
-    - name: lint
-      taskRef:
-        name: golangci-lint
-      params:
-        - name: package
-          value: $(params.package)
-        - name: flags
-          value: "-v --timeout=30m"
-        - name: version
-          value: "v1.21.0"
-      resources:
-        inputs:
-          - name: source
-            resource: source-repo
     - name: unit-tests
-      runAfter: [lint]
       taskRef:
         name: golang-test
       params:
@@ -54,7 +39,6 @@ spec:
           - name: source
             resource: source-repo
     - name: build
-      runAfter: [lint]
       taskRef:
         name: golang-build
       params:


### PR DESCRIPTION
# Changes

Linting should never fail on a release Pipeline since any issues should
be caught in the PR. This linting is failing in the nightly release
pipeline for unknown reasons so let's remove it. We can keep debugging
the issue if we encounter it again somewhere that we actually need it.

I tested this by manually applying the pipelines and manually triggering
the nightly cron:

```
k --context dogfood create job --from cronjob/nightly-cron-trigger-triggers-nightly-release nightly-cron-trigger-triggers-nightly-release-manual-05282020
```

Fixes https://github.com/tektoncd/plumbing/issues/403

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._