### PR TITLE
Modify spec params to avoid confusion between resourcetemplates and triggertemplate params

### DIFF
--- a/docs/triggertemplates.md
+++ b/docs/triggertemplates.md
@@ -47,9 +47,9 @@ spec:
           type: git
           params:
           - name: revision
-            value: $(params.gitrevision)
+            value: $(tt.params.gitrevision)
           - name: url
-            value: $(params.gitrepositoryurl)
+            value: $(tt.params.gitrepositoryurl)
 ```
 
 `TriggerTemplates` currently support the following [Tekton Pipelines](https://github.com/tektoncd/pipelines) resources:
@@ -102,11 +102,11 @@ have an optional `description` and `default` value.
 substitution syntax, where `<name>` is the name of the parameter:
 
 ```YAML
-$(params.<name>)
+$(tt.params.<name>)
 ```
 
-`params` can be referenced in the `resourceTemplates` section of a
-`TriggerTemplate`. The purpose of `params` is to make `TriggerTemplates`
+`tt.params` can be referenced in the `resourceTemplates` section of a
+`TriggerTemplate`. The purpose of `tt.params` is to make `TriggerTemplates`
 reusable.
 
 ## Best Practices

--- a/examples/bitbucket/triggertemplate.yaml
+++ b/examples/bitbucket/triggertemplate.yaml
@@ -30,6 +30,6 @@ spec:
                 type: git
                 params:
                   - name: revision
-                    value: $(params.gitrevision)
+                    value: $(tt.params.gitrevision)
                   - name: url
-                    value: $(params.gitrepositoryurl)
+                    value: $(tt.params.gitrepositoryurl)

--- a/examples/github/triggertemplate.yaml
+++ b/examples/github/triggertemplate.yaml
@@ -32,4 +32,4 @@ spec:
                   - name: revision
                     value: $(params.gitrevision)
                   - name: url
-                    value: $(params.gitrepositoryurl)
+                    value: $(tt.params.gitrepositoryurl)

--- a/examples/gitlab/gitlab-push-listener.yaml
+++ b/examples/gitlab/gitlab-push-listener.yaml
@@ -29,9 +29,9 @@ spec:
                 type: git
                 params:
                   - name: revision
-                    value: $(params.gitrevision)
+                    value: $(tt.params.gitrevision)
                   - name: url
-                    value: $(params.gitrepositoryurl)
+                    value: $(tt.params.gitrepositoryurl)
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding

--- a/examples/triggertemplates/triggertemplate.yaml
+++ b/examples/triggertemplates/triggertemplate.yaml
@@ -33,6 +33,6 @@ spec:
           type: git
           params:
           - name: revision
-            value: $(params.gitrevision)
+            value: $(tt.params.gitrevision)
           - name: url
-            value: $(params.gitrepositoryurl)
+            value: $(tt.params.gitrepositoryurl)

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -153,7 +153,7 @@ func TestHandleEvent(t *testing.T) {
 			Kind:       "PipelineResource",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "$(params.name)",
+			Name:      "$(tt.params.name)",
 			Namespace: namespace,
 			Labels: map[string]string{
 				"app":  "$(params.foo)",
@@ -273,7 +273,7 @@ func TestHandleEventWithInterceptors(t *testing.T) {
 			Type: pipelinev1alpha1.PipelineResourceTypeGit,
 			Params: []pipelinev1alpha1.ResourceParam{{
 				Name:  "url",
-				Value: "$(params.url)",
+				Value: "$(tt.params.url)",
 			}},
 		},
 	}
@@ -413,7 +413,7 @@ func TestHandleEventWithWebhookInterceptors(t *testing.T) {
 			Kind:       "PipelineResource",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "$(params.name)",
+			Name:      "$(tt.params.name)",
 			Namespace: namespace,
 		},
 		Spec: pipelinev1alpha1.PipelineResourceSpec{
@@ -1001,7 +1001,7 @@ func getResources(t *testing.T, triggerBindingParam string) (*v1alpha1.TriggerBi
 			Type: pipelinev1.PipelineResourceTypeGit,
 			Params: []pipelinev1.ResourceParam{{
 				Name:  "url",
-				Value: "$(params.url)",
+				Value: "$(tt.params.url)",
 			}},
 		},
 	}

--- a/pkg/template/event_test.go
+++ b/pkg/template/event_test.go
@@ -395,8 +395,8 @@ func TestResolveResources(t *testing.T) {
 		template: bldr.TriggerTemplate("tt", ns, bldr.TriggerTemplateSpec(
 			bldr.TriggerTemplateParam("p1", "desc", ""),
 			bldr.TriggerTemplateParam("p2", "desc", ""),
-			bldr.TriggerResourceTemplate(runtime.RawExtension{Raw: []byte(`{"rt1": "$(params.p1)-$(params.p2)"}`)}),
-			bldr.TriggerResourceTemplate(runtime.RawExtension{Raw: []byte(`{"rt2": "$(params.p1)-$(params.p2)"}`)}),
+			bldr.TriggerResourceTemplate(runtime.RawExtension{Raw: []byte(`{"rt1": "$(tt.params.p1)-$(tt.params.p2)"}`)}),
+			bldr.TriggerResourceTemplate(runtime.RawExtension{Raw: []byte(`{"rt2": "$(tt.params.p1)-$(tt.params.p2)"}`)}),
 		)),
 		params: []triggersv1.Param{
 			bldr.Param("p1", "val1"),
@@ -410,7 +410,7 @@ func TestResolveResources(t *testing.T) {
 		name: "replace JSON string in templates",
 		template: bldr.TriggerTemplate("tt", ns, bldr.TriggerTemplateSpec(
 			bldr.TriggerTemplateParam("p1", "desc", ""),
-			bldr.TriggerResourceTemplate(runtime.RawExtension{Raw: []byte(`{"rt1": "$(params.p1)"}`)}),
+			bldr.TriggerResourceTemplate(runtime.RawExtension{Raw: []byte(`{"rt1": "$(tt.params.p1)"}`)}),
 		)),
 		params: []triggersv1.Param{
 			bldr.Param("p1", `{"a": "b"}`),
@@ -423,7 +423,7 @@ func TestResolveResources(t *testing.T) {
 		name: "replace JSON string with special chars in templates",
 		template: bldr.TriggerTemplate("tt", ns, bldr.TriggerTemplateSpec(
 			bldr.TriggerTemplateParam("p1", "desc", ""),
-			bldr.TriggerResourceTemplate(runtime.RawExtension{Raw: []byte(`{"rt1": "$(params.p1)"}`)}),
+			bldr.TriggerResourceTemplate(runtime.RawExtension{Raw: []byte(`{"rt1": "$(tt.params.p1)"}`)}),
 		)),
 		params: []triggersv1.Param{
 			bldr.Param("p1", `{"a": "v\\r\\n烈"}`),

--- a/pkg/template/resource.go
+++ b/pkg/template/resource.go
@@ -110,12 +110,17 @@ func ApplyParamsToResourceTemplate(params []triggersv1.Param, rt json.RawMessage
 // applyParamToResourceTemplate returns the TriggerResourceTemplate with the
 // param value substituted for all matching param variables in the template
 func applyParamToResourceTemplate(param triggersv1.Param, rt json.RawMessage) json.RawMessage {
-	// Assume the param is valid
-	paramVariable := fmt.Sprintf("$(params.%s)", param.Name)
-	// Escape quotes so that that JSON strings can be appended to regular strings.
-	// See #257 for discussion on this behavior.
-	paramValue := strings.Replace(param.Value, `"`, `\"`, -1)
-	return bytes.Replace(rt, []byte(paramVariable), []byte(paramValue), -1)
+	// The changes are for backward compatibility with both $(params) and $(tt.params)
+	// TODO(#606)
+	for _, tag := range []string{"params", "tt.params"} {
+		// Assume the param is valid
+		paramVariable := fmt.Sprintf("$(%s.%s)", tag, param.Name)
+		// Escape quotes so that that JSON strings can be appended to regular strings.
+		// See #257 for discussion on this behavior.
+		paramValue := strings.Replace(param.Value, `"`, `\"`, -1)
+		rt = bytes.Replace(rt, []byte(paramVariable), []byte(paramValue), -1)
+	}
+	return rt
 }
 
 // UID generates a random string like the Kubernetes apiserver generateName metafield postfix.

--- a/test/eventlistener_test.go
+++ b/test/eventlistener_test.go
@@ -85,7 +85,7 @@ func TestEventListenerCreate(t *testing.T) {
 			Name:      "pr1",
 			Namespace: namespace,
 			Labels: map[string]string{
-				"$(params.oneparam)": "$(params.oneparam)",
+				"$(tt.params.oneparam)": "$(tt.params.oneparam)",
 			},
 		},
 		Spec: v1alpha1.PipelineResourceSpec{
@@ -107,15 +107,15 @@ func TestEventListenerCreate(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "pr2",
 			Labels: map[string]string{
-				"$(params.twoparamname)": "$(params.twoparamvalue)",
+				"$(tt.params.twoparamname)": "$(tt.params.twoparamvalue)",
 			},
 		},
 		Spec: v1alpha1.PipelineResourceSpec{
 			Type: "git",
 			Params: []v1alpha1.ResourceParam{
-				{Name: "license", Value: "$(params.license)"},
-				{Name: "header", Value: "$(params.header)"},
-				{Name: "prmessage", Value: "$(params.prmessage)"},
+				{Name: "license", Value: "$(tt.params.license)"},
+				{Name: "header", Value: "$(tt.params.header)"},
+				{Name: "prmessage", Value: "$(tt.params.prmessage)"},
 			},
 		},
 	}


### PR DESCRIPTION
# Changes
PR helps to avoid confusion from `TriggerTemplate params` to `resourceTemplate params`
by keeping params of spec as it is and using $(tt.params.) for the substitution.

So, this way we no need to handle the backward compatibility as per the discussion over the [comments](https://github.com/tektoncd/triggers/pull/589#issuecomment-646129728)
 
Fixes https://github.com/tektoncd/triggers/issues/508

Tried to do tag configurable, given the way ObjectDefaulter and SetDefaults work, neither could accomplish the switch properly. ObjectDefaulter could have done it, but the way the tests are configured do not cause the Defaults to be executed since the objects aren't actually decoded.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

The substitution for `params` modified from `$(params.gitrevision)` to `$(tt.params.gitrevision)` . 
And the the examples

```
apiVersion: triggers.tekton.dev/v1alpha1
kind: TriggerTemplate
metadata:
  name: github-template
spec:
  params:
    - name: gitrevision
    - name: gitrepositoryurl
  resourcetemplates:
    - apiVersion: tekton.dev/v1alpha1
      kind: TaskRun
      metadata:
        generateName: github-run-
      spec:
        taskSpec:
          inputs:
            resources:
              - name: source
                type: git
          steps:
            - image: ubuntu
              script: |
                #! /bin/bash
                ls -al $(inputs.resources.source.path)
        inputs:
          resources:
            - name: source
              resourceSpec:
                type: git
                params:
                  - name: revision
                    value: $(tt.params.gitrevision)
                  - name: url
                    value: $(tt.params.gitrepositoryurl)
```
For a release or two $(params) supported and later it will be deprecated.
Created [issue](https://github.com/tektoncd/triggers/issues/606) to track the same

cc @dibyom 