### PR TITLE
Publish both tagged and untagged images for releases

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -76,7 +76,12 @@ spec:
       OUTPUT_BUCKET_RELEASE_DIR="/workspace/output/bucket/previous/$(inputs.params.versionTag)"
 
       # Publish images and create release.yaml
-      ko resolve --preserve-import-paths -f /workspace/go/src/github.com/tektoncd/triggers/config/ > $OUTPUT_BUCKET_RELEASE_DIR/release.yaml
+      ko resolve --preserve-import-paths -t $(inputs.params.versionTag) -f /workspace/go/src/github.com/tektoncd/triggers/config/ > $OUTPUT_BUCKET_RELEASE_DIR/release.yaml
+
+      # Publish images and create release.notags.yaml
+      # This is useful if your container runtime doesn't support the `image-reference:tag@digest` notation
+      # This is currently the case for `cri-o` (and most likely others)
+      ko resolve --preserve-import-paths -f /workspace/go/src/github.com/tektoncd/triggers/config/ > $OUTPUT_BUCKET_RELEASE_DIR/release.notags.yaml
     volumeMounts:
       - name: gcp-secret
         mountPath: /secret
@@ -94,6 +99,7 @@ spec:
         OUTPUT_BUCKET_RELEASE_DIR="/workspace/output/bucket/previous/$(inputs.params.versionTag)"
         OUTPUT_BUCKET_LATEST_DIR="/workspace/output/bucket/latest"
         cp "$OUTPUT_BUCKET_RELEASE_DIR/release.yaml" "$OUTPUT_BUCKET_LATEST_DIR/release.yaml"
+        cp "$OUTPUT_BUCKET_RELEASE_DIR/release.notags.yaml" "$OUTPUT_BUCKET_LATEST_DIR/release.notags.yaml"
       fi
 
   - name: tag-images


### PR DESCRIPTION
The Triggers release images are pushed to a global registry
(gcr.io/tekton-releases/) as well as regional registries (us.gcr.io,
asia.gcr.io, eu.gcr.io). The regional images were tagged with the
release version while the global one was not.

This commit ensure that the global image is tagged with the release
version as well. In addition, this also adds a `release.notags.yaml`
(just like Pipelines) to support container runtimes that do no support
the `tag@digest` notation.

Fixes #534
/kind bug

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
All triggers release images are now tagged with the release version.
```
