### PR TITLE
Ensure that decodeB64 returns a String rather than Bytes.

### DIFF
--- a/pkg/interceptors/cel/triggers.go
+++ b/pkg/interceptors/cel/triggers.go
@@ -261,7 +261,7 @@ func decodeB64String(val ref.Val) ref.Val {
 	if err != nil {
 		return types.NewErr("failed to decode '%v' in decodeB64: %w", str, err)
 	}
-	return types.Bytes(dec)
+	return types.String(dec)
 }
 
 // makeCompareSecret creates and returns a functions.FunctionOp that wraps the


### PR DESCRIPTION
# Changes

This changes the return value of the decodeB64 overload to ensure that it returns a string.

Fixes #608 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Changes the output of decodeB64 to return a string, rather than bytes.
```
