### PR TITLE
Add extra columns for EventListeners

### DIFF
--- a/config/300-eventlistener.yaml
+++ b/config/300-eventlistener.yaml
@@ -42,3 +42,13 @@ spec:
   subresources:
     status: {}
   version: v1alpha1
+  additionalPrinterColumns:
+  - name: Address
+    type: string
+    JSONPath: .status.address.url
+  - name: Available
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Available')].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Available')].reason"


### PR DESCRIPTION
# Changes

Adds the address.url and the `Available` status as additional columns, so users
running `kubectl get` can access them easily.

```
NAME                     ADDRESS                                                           AVAILABLE   REASON
gitlab-listener          http://el-gitlab-listener.default.svc.cluster.local:8080          True        MinimumReplicasAvailable
listener-embed-binding   http://el-listener-embed-binding.default.svc.cluster.local:8080   True        MinimumReplicasAvailable
```

Thanks to @n3wscott for the suggestion!!

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
EventListeners now display the status.address.url  and Available status.Condition as additional fields when listed with kubectl get
```
