### PR TITLE
Fix the Data Race in portforward e2e test of EventListener

### DIFF
--- a/test/buffer.go
+++ b/test/buffer.go
@@ -1,0 +1,45 @@
+// +build e2e
+
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"bytes"
+	"sync"
+)
+
+// Buffer is the thread safe Buffer implementation
+type Buffer struct {
+	b bytes.Buffer
+	m sync.Mutex
+}
+
+// Write to the Buffer in a thread safe manner
+func (b *Buffer) Write(p []byte) (n int, err error) {
+	b.m.Lock()
+	defer b.m.Unlock()
+	return b.b.Write(p)
+}
+
+// String returns the contents of the unread portion of the buffer
+// as a string in a thread safe manner.
+func (b *Buffer) String() string {
+	b.m.Lock()
+	defer b.m.Unlock()
+	return b.b.String()
+}

--- a/test/eventlistener_test.go
+++ b/test/eventlistener_test.go
@@ -338,7 +338,7 @@ func TestEventListenerCreate(t *testing.T) {
 		hostIP := strings.TrimPrefix(config.Host, "https://")
 		serverURL := url.URL{Scheme: "https", Path: path, Host: hostIP}
 		dialer := spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper}, http.MethodPost, &serverURL)
-		out, errOut := new(bytes.Buffer), new(bytes.Buffer)
+		out, errOut := new(Buffer), new(Buffer)
 		readyChan := make(chan struct{}, 1)
 		forwarder, err := portforward.New(dialer, []string{portString}, stopChan, readyChan, out, errOut)
 		if err != nil {


### PR DESCRIPTION
bytes.Buffer isn't thread safe. Added custom implementation with sync.
Fixes #629 

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

