### PR TITLE
Add CEL function to parse YAML

### DIFF
--- a/docs/cel_expressions.md
+++ b/docs/cel_expressions.md
@@ -278,6 +278,20 @@ interceptor.
   </tr>
   <tr>
     <th>
+     parseYAML()
+    </th>
+    <td>
+     <pre>&lt;string&gt;.parseYAML() -> map&lt;string, dyn&gt;</pre>
+    </td>
+    <td>
+     This parses a string that contains a YAML body into a map which which can be subsequently used in other expressions.
+    </td>
+    <td>
+     <pre>'key1: value1\nkey2: value2\n'.parseYAML().key1 == "value"</pre>
+    </td>
+  </tr>
+  <tr>
+    <th>
      parseURL()
     </th>
     <td>

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89 // indirect
 	knative.dev/caching v0.0.0-20200228235451-13d271455c74
 	knative.dev/pkg v0.0.0-20200207155214-fef852970f43
-	sigs.k8s.io/yaml v1.2.0 // indirect
+	sigs.k8s.io/yaml v1.2.0
 )
 
 // Knative deps (release-0.12)


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
This PR will add a CEL function named `parseYAML` that can parse a YAML string into a map of strings to dynamic values

Syntax: <string>.parseYAML() -> map<string, dyn>

Fixes: #622 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
 'parseYAML' is a CEL function that can parse YAML body in string to a map.
```