### PR TITLE
Add cel filter for pull request actions in github example

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -327,6 +327,8 @@ spec:
               secretKey: secretToken
             eventTypes:
               - pull_request
+        - cel:
+            filter: "body.action in ['opened', 'synchronize', 'reopened']"
       bindings:
         - ref: github-binding
       template:

--- a/examples/github/README.md
+++ b/examples/github/README.md
@@ -29,7 +29,7 @@ Creates an EventListener that listens for GitHub webhook events.
    -H 'X-GitHub-Event: pull_request' \
    -H 'X-Hub-Signature: sha1=0835c8c5dc317870c4e48659df5f3c53213cd348' \
    -H 'Content-Type: application/json' \
-   -d '{"head_commit":{"id":"master"},"repository":{"url": "https://github.com/tektoncd/triggers"}}' \
+   -d '{"action": "opened", "head_commit":{"id":"master"},"repository":{"url": "https://github.com/tektoncd/triggers"}}' \
    http://localhost:8080
    ```
 

--- a/examples/github/github-eventlistener-interceptor.yaml
+++ b/examples/github/github-eventlistener-interceptor.yaml
@@ -14,6 +14,8 @@ spec:
               secretKey: secretToken
             eventTypes:
               - pull_request
+        - cel:
+            filter: "body.action in ['opened', 'synchronize', 'reopened']"
       bindings:
         - ref: github-binding
       template:


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

The GitHub interceptor doesn't filter the actions for the `pull_request` event type, which means it will trigger when editing a pull requests' description and other similar actions.

This commit adds a CEL interceptor in order to filter the pull request actions and only trigger when a pull request is opened, synchronized, or reopened.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._