### PR TITLE
Update docs and examples to use ref instead of name for bindings

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -102,8 +102,7 @@ triggers:
       - github:
           eventTypes: ["pull_request"]
     bindings:
-      - name: pipeline-binding
-        ref:  pipeline-binding
+      - ref: pipeline-binding
       - name: message-binding
         spec:
             params:
@@ -127,10 +126,8 @@ triggers:
       - github:
           eventTypes: ["pull_request"]
     bindings:
-      - name: pipeline-binding
-        ref:  pipeline-binding
-      - name: message-binding
-        ref:  message-binding
+      - ref: pipeline-binding
+      - ref: message-binding
     template:
       name: pipeline-template
 ``` 
@@ -374,8 +371,7 @@ spec:
             eventTypes:
               - Push Hook
       bindings:
-        - name: pipeline-binding
-          ref:  pipeline-binding
+        - ref: pipeline-binding
       template:
         name: pipeline-template
 ```
@@ -416,7 +412,7 @@ spec:
             eventTypes:
               - repo:refs_changed
       bindings:
-        - name: bitbucket-binding
+        - ref: bitbucket-binding
       template:
         name: bitbucket-template
 ```

--- a/docs/triggerbindings.md
+++ b/docs/triggerbindings.md
@@ -151,14 +151,14 @@ spec:
   triggers:
     - name: prod-trigger
       bindings:
-        - name: event-binding
-        - name: prod-env
+        - ref: event-binding
+        - ref: prod-env
       template:
         name: pipeline-template
     - name: staging-trigger
       bindings:
-        - name: event-binding
-        - name: staging-env
+        - ref: event-binding
+        - ref: staging-env
       template:
         name: pipeline-template
 ```

--- a/examples/bitbucket/bitbucket-eventlistener-interceptor.yaml
+++ b/examples/bitbucket/bitbucket-eventlistener-interceptor.yaml
@@ -15,6 +15,6 @@ spec:
             eventTypes:
               - repo:refs_changed
       bindings:
-        - name: bitbucket-binding
+        - ref: bitbucket-binding
       template:
         name: bitbucket-template

--- a/examples/cron/eventlistener.yaml
+++ b/examples/cron/eventlistener.yaml
@@ -7,6 +7,6 @@ spec:
   triggers:
     - name: cron-trig
       bindings:
-      - name: cron-binding
+      - ref: cron-binding
       template:
         name: pipeline-template

--- a/examples/github/README.md
+++ b/examples/github/README.md
@@ -27,7 +27,7 @@ Creates an EventListener that listens for GitHub webhook events.
    ```bash
    curl -v \
    -H 'X-GitHub-Event: pull_request' \
-   -H 'X-Hub-Signature: sha1=0835c8c5dc317870c4e48659df5f3c53213cd348' \
+   -H 'X-Hub-Signature: sha1=13eaa0168f8d8efcdf5189ea75b782cf89809de6' \
    -H 'Content-Type: application/json' \
    -d '{"action": "opened", "head_commit":{"id":"master"},"repository":{"url": "https://github.com/tektoncd/triggers"}}' \
    http://localhost:8080

--- a/examples/gitlab/gitlab-push-listener.yaml
+++ b/examples/gitlab/gitlab-push-listener.yaml
@@ -60,6 +60,6 @@ spec:
             eventTypes:
               - Push Hook  # Only push events
       bindings:
-        - name: gitlab-push-binding
+        - ref: gitlab-push-binding
       template:
         name: gitlab-echo-template


### PR DESCRIPTION
# Changes

1. Updated examples and docs to use `ref` instead of `name` for bindings
2. Updated signature value in GH README because  CEL filters are added as part of this PR https://github.com/tektoncd/triggers/pull/637 which resulted signature validation failure.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

