### PR TITLE
Improve the error from the context evaluation.

### DIFF
--- a/pkg/interceptors/cel/cel_test.go
+++ b/pkg/interceptors/cel/cel_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"regexp"
 	"strings"
@@ -287,7 +288,7 @@ func TestInterceptor_ExecuteTrigger_Errors(t *testing.T) {
 				},
 			},
 			payload: []byte(`{"value":"test"}`),
-			want:    "failed to evaluate overlay expression 'test.value'",
+			want:    `expression "test.value" check failed: ERROR:.*undeclared reference to 'test'`,
 		},
 	}
 	for _, tt := range tests {
@@ -502,12 +503,12 @@ func TestExpressionEvaluation_Error(t *testing.T) {
 		{
 			name: "unknown value",
 			expr: "body.val",
-			want: "no such key: val",
+			want: `expression "body.val" failed to evaluate: no such key: val`,
 		},
 		{
 			name: "invalid syntax",
 			expr: "body.value = 'testing'",
-			want: "Syntax error: token recognition error",
+			want: `failed to parse expression "body.value = 'testing'"`,
 		},
 		{
 			name: "unknown function",
@@ -617,6 +618,17 @@ func TestURLToMap(t *testing.T) {
 
 	if diff := cmp.Diff(want, m); diff != "" {
 		t.Fatalf("urlToMap failed:\n%s", diff)
+	}
+}
+
+func TestMakeEvalContextWithError(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	payload := []byte(`{"tes`)
+
+	_, err := makeEvalContext(payload, req)
+
+	if !matchError(t, "failed to parse the body as JSON: unexpected end of JSON input", err) {
+		t.Fatalf("failed to match the error: %s", err)
 	}
 }
 


### PR DESCRIPTION
# Changes
Improve the error messages around parsing CEL expressions.

This improves the granularity of the error messages that are returned by evaluating expressions.

It also improves the error message when parsing the hook body when creating the evaluation environment.

This should go some way to solving  #641

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Better error messages when parsing CEL expressions, and parsing the hook body.
```
