### PR TITLE
Expose the incoming request URL to CEL expressions.

### DIFF
--- a/docs/cel_expressions.md
+++ b/docs/cel_expressions.md
@@ -139,6 +139,20 @@ headers are also available.
       <pre>header['X-Test'][0] == 'test-value'</pre>
     </td>
   </tr>
+  <tr>
+    <th>
+      requestURL
+    </th>
+    <td>
+      string
+    </td>
+    <td>
+      This is the URL for the incoming HTTP request.
+    </td>
+    <td>
+      <pre>requestURL.parseURL().path</pre>
+    </td>
+  </tr>
 </table>
 
 NOTE: The header value is a Go `http.Header`, which is

--- a/pkg/interceptors/cel/cel.go
+++ b/pkg/interceptors/cel/cel.go
@@ -160,7 +160,9 @@ func makeCelEnv(request *http.Request, ns string, k kubernetes.Interface) (*cel.
 		celext.Strings(),
 		cel.Declarations(
 			decls.NewIdent("body", mapStrDyn, nil),
-			decls.NewIdent("header", mapStrDyn, nil)))
+			decls.NewIdent("header", mapStrDyn, nil),
+			decls.NewIdent("requestURL", decls.String, nil),
+		))
 }
 
 func makeEvalContext(body []byte, r *http.Request) (map[string]interface{}, error) {
@@ -169,5 +171,9 @@ func makeEvalContext(body []byte, r *http.Request) (map[string]interface{}, erro
 	if err != nil {
 		return nil, err
 	}
-	return map[string]interface{}{"body": jsonMap, "header": r.Header}, nil
+	return map[string]interface{}{
+		"body":       jsonMap,
+		"header":     r.Header,
+		"requestURL": r.URL.String(),
+	}, nil
 }


### PR DESCRIPTION
# Changes

This adds a `requestURL` key to the CEL expression context.

For example, `requestURL.parseURL().path` would get the path of the incoming request URL.

Fixes: #640 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
This adds a `requestURL` key to the CEL expression context.

For example, `requestURL.parseURL().path` would get the path of the incoming request URL.
```
