### PR TITLE
Fix the declarations for compareSecret.

### DIFF
--- a/pkg/interceptors/cel/cel_test.go
+++ b/pkg/interceptors/cel/cel_test.go
@@ -190,9 +190,17 @@ func TestInterceptor_ExecuteTrigger(t *testing.T) {
 			want:    []byte(`{"count":1,"measure":1.7}`),
 		},
 		{
+			name: "validating a secret",
+			CEL: &triggersv1.CELInterceptor{
+				Filter: "header.canonical('X-Secret-Token').compareSecret('token', 'test-secret', 'testing-ns') && body.count == 1.0",
+			},
+			payload: ioutil.NopCloser(bytes.NewBufferString(`{"count":1,"measure":1.7}`)),
+			want:    []byte(`{"count":1,"measure":1.7}`),
+		},
+		{
 			name: "validating a secret in the default namespace",
 			CEL: &triggersv1.CELInterceptor{
-				Filter: "header.canonical('X-Secret-Token').compareSecret('token', 'test-secret')",
+				Filter: "header.canonical('X-Secret-Token').compareSecret('token', 'test-secret') && body.count == 1.0",
 			},
 			payload: ioutil.NopCloser(bytes.NewBufferString(`{"count":1,"measure":1.7}`)),
 			want:    []byte(`{"count":1,"measure":1.7}`),

--- a/pkg/interceptors/cel/triggers.go
+++ b/pkg/interceptors/cel/triggers.go
@@ -178,7 +178,7 @@ func (triggersLib) CompileOptions() []cel.EnvOption {
 					[]*exprpb.Type{decls.String, decls.Int}, decls.String)),
 			decls.NewFunction("compareSecret",
 				decls.NewInstanceOverload("compareSecret_string_string_string",
-					[]*exprpb.Type{decls.String, decls.String, decls.String, decls.String}, decls.String)),
+					[]*exprpb.Type{decls.String, decls.String, decls.String, decls.String}, decls.Bool)),
 			decls.NewFunction("parseJSON",
 				decls.NewInstanceOverload("parseJSON_string",
 					[]*exprpb.Type{decls.String}, mapStrDyn)),
@@ -190,7 +190,7 @@ func (triggersLib) CompileOptions() []cel.EnvOption {
 					[]*exprpb.Type{decls.String}, mapStrDyn)),
 			decls.NewFunction("compareSecret",
 				decls.NewInstanceOverload("compareSecret_string_string",
-					[]*exprpb.Type{decls.String, decls.String, decls.String}, decls.String)))}
+					[]*exprpb.Type{decls.String, decls.String, decls.String}, decls.Bool)))}
 }
 
 func (t triggersLib) ProgramOptions() []cel.ProgramOption {


### PR DESCRIPTION
# Changes

compareSecret in both its forms was declared as returning a String not a
Bool.

This fixes both of these.

Fixes: #644

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
The CEL function compareSecret now returns a boolean value, which makes it work in multiple logical comparisons in a filter.
```
