### PR TITLE
Fix EventListener Error Response during Parsing

### DIFF
--- a/pkg/sink/sink.go
+++ b/pkg/sink/sink.go
@@ -99,6 +99,9 @@ func (r Sink) HandleEvent(response http.ResponseWriter, request *http.Request) {
 				if kerrors.IsForbidden(err) {
 					result <- http.StatusForbidden
 				}
+				if template.IsParseErr(err) {
+					result <- http.StatusBadRequest
+				}
 				result <- http.StatusAccepted
 				return
 			}


### PR DESCRIPTION
This fixes EventListener Error Response during Parsing to return
500 when marshaling error occurs or JsonPath error is encountered.
Fixes: https://github.com/tektoncd/triggers/issues/656

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
