### PR TITLE
Use sets.NewString instead of map[string]struct{}

### DIFF
--- a/pkg/apis/triggers/v1alpha1/trigger_binding_validation.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_binding_validation.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/apis"
 )
 
@@ -37,12 +38,12 @@ func (s *TriggerBindingSpec) Validate(ctx context.Context) *apis.FieldError {
 
 func validateParams(params []Param) *apis.FieldError {
 	// Ensure there aren't multiple params with the same name.
-	seen := map[string]struct{}{}
+	seen := sets.NewString()
 	for _, param := range params {
-		if _, ok := seen[param.Name]; ok {
+		if seen.Has(param.Name) {
 			return apis.ErrMultipleOneOf("spec.params")
 		}
-		seen[param.Name] = struct{}{}
+		seen.Insert(param.Name)
 	}
 	return nil
 }


### PR DESCRIPTION
# Changes

Motivated by PR https://github.com/tektoncd/pipeline/pull/2909 .
This pull request replaces the use of map[string]struct{} with sets.String from K8s apimachinery.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

/kind cleanup