### PR TITLE
Support for marshaling other types.

### DIFF
--- a/pkg/interceptors/cel/cel.go
+++ b/pkg/interceptors/cel/cel.go
@@ -54,6 +54,7 @@ type Interceptor struct {
 var (
 	structType = reflect.TypeOf(&structpb.Value{})
 	listType   = reflect.TypeOf(&structpb.ListValue{})
+	mapType    = reflect.TypeOf(&structpb.Struct{})
 )
 
 // NewInterceptor creates a prepopulated Interceptor.
@@ -125,6 +126,19 @@ func (w *Interceptor) ExecuteTrigger(request *http.Request) (*http.Response, err
 				if err == nil {
 					b = []byte(s)
 				}
+			}
+		case traits.Mapper:
+			raw, err = val.ConvertToNative(mapType)
+			if err == nil {
+				s, err := protojson.Marshal(raw.(proto.Message))
+				if err == nil {
+					b = []byte(s)
+				}
+			}
+		case types.Bool:
+			raw, err = val.ConvertToNative(structType)
+			if err == nil {
+				b, err = json.Marshal(raw.(*structpb.Value).GetBoolValue())
 			}
 		default:
 			raw, err = val.ConvertToNative(reflect.TypeOf([]byte{}))


### PR DESCRIPTION
# Changes

This adds support for marshaling bool values, and maps if they're used as the
values of expressions in a CEL overlay.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Marshaling of maps and boolean values in CEL expressions for the overlay mechanism should now work.
```
