### PR TITLE
Provide the incoming EventListener URL to the Webhook Interceptor.

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -229,6 +229,9 @@ headers before being sent;
 [canonical](https://golang.org/pkg/net/textproto/#CanonicalMIMEHeaderKey) names
 must be specified.
 
+The incoming request URL (received by the EventListener) is provided in the
+`Eventlistener-Request-URL` header provided to the Webhook interceptor.
+
 When multiple Interceptors are specified, requests are piped through each
 Interceptor sequentially for processing - e.g. the headers/body of the first
 Interceptor's response will be sent as the request to the second Interceptor. It

--- a/pkg/interceptors/webhook/webhook.go
+++ b/pkg/interceptors/webhook/webhook.go
@@ -33,8 +33,12 @@ import (
 	"go.uber.org/zap"
 )
 
-// Timeout for outgoing requests to interceptor services
-const interceptorTimeout = 5 * time.Second
+const (
+	// Timeout for outgoing requests to interceptor services
+	interceptorTimeout = 5 * time.Second
+	// the incoming request URL is passed through to the webhook in this header.
+	webhookURLHeader = "EventListener-Request-URL"
+)
 
 type Interceptor struct {
 	HTTPClient             *http.Client
@@ -61,6 +65,7 @@ func (w *Interceptor) ExecuteTrigger(request *http.Request) (*http.Response, err
 	if err != nil {
 		return nil, err
 	}
+	request.Header.Set(webhookURLHeader, request.URL.String())
 	request.URL = u
 	request.Host = u.Host
 	addInterceptorHeaders(request.Header, w.Webhook.Header)

--- a/pkg/interceptors/webhook/webhook_test.go
+++ b/pkg/interceptors/webhook/webhook_test.go
@@ -50,6 +50,10 @@ func TestWebHookInterceptor(t *testing.T) {
 			http.Error(w, "Expected header does not match", http.StatusBadRequest)
 			return
 		}
+		if r.Header.Get(webhookURLHeader) != "http://doesnotmatter.example.com" {
+			http.Error(w, "Expected webhookURLHeader does not match", http.StatusBadRequest)
+			return
+		}
 		// Return new values back in the response. It is expected for interceptors
 		// to be able to mutate the request.
 		w.Header().Set("Foo", "bar")


### PR DESCRIPTION
# Changes

Webhook Interceptors can parse the `EventListener-Request-URL` if they want to
extract parameters from the original request URL being handled by the
EventListener.

Fixes: #667 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Webhook Interceptors can parse the `EventListener-Request-URL` if they want to
extract parameters from the original request URL being handled by the
EventListener.
```
