### PR TITLE
Fix Incorrect number of response for Forbidden err

### DIFF
--- a/pkg/sink/sink.go
+++ b/pkg/sink/sink.go
@@ -98,6 +98,7 @@ func (r Sink) HandleEvent(response http.ResponseWriter, request *http.Request) {
 				}
 				if kerrors.IsForbidden(err) {
 					result <- http.StatusForbidden
+					return
 				}
 				result <- http.StatusAccepted
 				return


### PR DESCRIPTION
When forbidden error happens, number of response are more than number
of trigger in EL Spec. This patch returns immediately from goroutine
when Forbidden err happens.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```

```
