### PR TITLE
Add ToEventListenerTrigger conversion func.

### DIFF
--- a/pkg/apis/triggers/v1alpha1/trigger_types_convert.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_types_convert.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"encoding/json"
+)
+
+// ToEventListenerTrigger converts a TriggerSpec into an EventListenerTrigger.
+// This is primarily for compatibility between CRD and non-CRD types so that
+// underlying libraries can reuse existing code.
+func ToEventListenerTrigger(in TriggerSpec) (EventListenerTrigger, error) {
+	var out EventListenerTrigger
+
+	// Use json Marshalling in order to be field agnostic. Since TriggerSpec
+	// is a subset of the existing EventListenerTrigger type, and should always
+	// contain the same field labels, this should be safe to do.
+	b, err := json.Marshal(in)
+	if err != nil {
+		return out, err
+	}
+
+	if err := json.Unmarshal(b, &out); err != nil {
+		return out, err
+	}
+	return out, nil
+}

--- a/pkg/apis/triggers/v1alpha1/trigger_types_convert_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_types_convert_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestToEventListenerTrigger(t *testing.T) {
+	tt := []struct {
+		name string
+		in   TriggerSpec
+		out  EventListenerTrigger
+	}{
+		{
+			name: "Convert Empty Object",
+			in:   TriggerSpec{},
+			out:  EventListenerTrigger{},
+		},
+		{
+			name: "Convert Partial Object",
+			in: TriggerSpec{
+				Name: "foo",
+				Template: TriggerSpecTemplate{
+					Name: "baz",
+				},
+			},
+			out: EventListenerTrigger{
+				Name: "foo",
+				Template: EventListenerTemplate{
+					Name: "baz",
+				},
+			},
+		},
+		{
+			name: "Convert Full Object",
+			in: TriggerSpec{
+				Name: "a",
+				ServiceAccount: &v1.ObjectReference{
+					Name: "a",
+				},
+				Interceptors: []*TriggerInterceptor{{
+					Webhook: &WebhookInterceptor{},
+				}},
+				Bindings: []*TriggerSpecBinding{{
+					Name:       "a",
+					APIVersion: "b",
+					Kind:       "c",
+					Ref:        "d",
+					Spec: &TriggerBindingSpec{
+						Params: []Param{{
+							Name:  "a",
+							Value: "b",
+						}},
+					},
+				}},
+				Template: TriggerSpecTemplate{
+					Name:       "a",
+					APIVersion: "b",
+				},
+			},
+			out: EventListenerTrigger{
+				Name: "a",
+				ServiceAccount: &v1.ObjectReference{
+					Name: "a",
+				},
+				Interceptors: []*TriggerInterceptor{{
+					Webhook: &WebhookInterceptor{},
+				}},
+				Bindings: []*EventListenerBinding{{
+					Name:       "a",
+					APIVersion: "b",
+					Kind:       "c",
+					Ref:        "d",
+					Spec: &TriggerBindingSpec{
+						Params: []Param{{
+							Name:  "a",
+							Value: "b",
+						}},
+					},
+				}},
+				Template: EventListenerTemplate{
+					Name:       "a",
+					APIVersion: "b",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ToEventListenerTrigger(tc.in)
+			if err != nil {
+				t.Fatalf("ToEventListenerTrigger: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.out, got); diff != "" {
+				t.Errorf("(-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Changes

The existing `resolveTrigger` and related Trigger processing functions
currently assume an `EventListenerTrigger` input. With the introduction of
Trigger CRDs, we need a mechanism to handle triggers consisently,
regardless of their originating type.

As a first step, this allows for `TriggerSpec` to be converted to
`EventListenerTrigger` in order to reuse existing libraries.

Part of the work required for
https://github.com/tektoncd/triggers/issues/624.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._