### PR TITLE
Remove unused Ref from EventListenerTrigger

### DIFF
--- a/pkg/apis/triggers/v1alpha1/event_listener_types.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_types.go
@@ -79,7 +79,6 @@ type EventListenerTrigger struct {
 	Template EventListenerTemplate   `json:"template"`
 	// +optional
 	Name         string              `json:"name,omitempty"`
-	Ref          string              `json:"ref,omitempty"`
 	Interceptors []*EventInterceptor `json:"interceptors,omitempty"`
 	// ServiceAccount optionally associates credentials with each trigger;
 	// more granular authorization for


### PR DESCRIPTION
# Changes

Remove unused `Ref` field from  EventListenerTrigger which was introduced as part of this PR https://github.com/tektoncd/triggers/pull/603 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
None

```
