### PR TITLE
Prevent double-logging of interceptor errors.

### DIFF
--- a/pkg/sink/sink.go
+++ b/pkg/sink/sink.go
@@ -213,7 +213,6 @@ func (r Sink) executeInterceptors(t *triggersv1.EventListenerTrigger, in *http.R
 		var err error
 		resp, err = interceptor.ExecuteTrigger(request)
 		if err != nil {
-			log.Error(err)
 			return nil, nil, err
 		}
 


### PR DESCRIPTION
# Changes

This reduces the double logging of errors when executing interceptors.

This drops the log when executing the interceptor, but this is logged out by `processTrigger`.

https://github.com/bigkevmcd/triggers/blob/4b3ecb4c7260ceeb12a65d32290d4925b74b2348/pkg/sink/sink.go#L144-L148

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Prevent double-logging of errors from interceptors.
```
