### PR TITLE
Remove deprecated $(params) to avoid confusion between resourcetemplates and triggertemplate params

### DIFF
--- a/cmd/triggerRun/cmd/root_test.go
+++ b/cmd/triggerRun/cmd/root_test.go
@@ -115,7 +115,7 @@ func Test_processTriggerSpec(t *testing.T) {
 			Name:      "my-taskrun",
 			Namespace: "default",
 			Labels: map[string]string{
-				"someLabel": "$(params.foo)",
+				"someLabel": "$(tt.params.foo)",
 			},
 		},
 		Spec: pipelinev1alpha1.TaskRunSpec{

--- a/docs/getting-started/triggers.yaml
+++ b/docs/getting-started/triggers.yaml
@@ -17,7 +17,7 @@ spec:
       kind: PipelineRun
       metadata:
         name: getting-started-pipeline-run-$(uid)
-        namespace: $(params.namespace)
+        namespace: $(tt.params.namespace)
       spec:
         serviceAccountName: tekton-triggers-admin
         pipelineRef:
@@ -28,9 +28,9 @@ spec:
               type: git
               params:
               - name: revision
-                value: $(params.gitrevision)
+                value: $(tt.params.gitrevision)
               - name: url
-                value: $(params.gitrepositoryurl)
+                value: $(tt.params.gitrepositoryurl)
           - name: image-source
             resourceSpec:
               type: image

--- a/examples/github/triggertemplate.yaml
+++ b/examples/github/triggertemplate.yaml
@@ -30,6 +30,6 @@ spec:
                 type: git
                 params:
                   - name: revision
-                    value: $(params.gitrevision)
+                    value: $(tt.params.gitrevision)
                   - name: url
                     value: $(tt.params.gitrepositoryurl)

--- a/pkg/apis/triggers/v1alpha1/trigger_template_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_template_validation_test.go
@@ -38,14 +38,8 @@ var v1beta1ResourceTemplate = runtime.RawExtension{
 var paramResourceTemplate = runtime.RawExtension{
 	Raw: []byte(`{"kind":"PipelineRun","apiVersion":"tekton.dev/v1alpha1","metadata":{"creationTimestamp":null},"spec": "$(tt.params.foo)","status":{}}`),
 }
-var deprecatedParamResourceTemplate = runtime.RawExtension{
-	Raw: []byte(`{"kind":"PipelineRun","apiVersion":"tekton.dev/v1alpha1","metadata":{"creationTimestamp":null},"spec": "$(params.foo)","status":{}}`),
-}
 var invalidParamResourceTemplate = runtime.RawExtension{
 	Raw: []byte(`{"kind":"PipelineRun","apiVersion":"tekton.dev/v1alpha1","metadata":{"creationTimestamp":null},"spec": "$(.foo)","status":{}}`),
-}
-var bothParamResourceTemplate = runtime.RawExtension{
-	Raw: []byte(`{"kind":"PipelineRun","apiVersion":"tekton.dev/v1alpha1","metadata":{"creationTimestamp":null},"spec": {"$(params1.foo)", "$(params.bar)", "$(tt.params.baz)"},"status":{}}`),
 }
 
 func TestTriggerTemplate_Validate(t *testing.T) {
@@ -133,7 +127,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 				Paths:   []string{"spec.resourcetemplates[0]"},
 			},
 		}, {
-			name: "params used in resource template are declared",
+			name: "tt.params used in resource template are declared",
 			template: b.TriggerTemplate("tt", "foo", b.TriggerTemplateSpec(
 				b.TriggerTemplateParam("foo", "desc", "val"),
 				b.TriggerResourceTemplate(paramResourceTemplate))),
@@ -146,24 +140,6 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 				Message: "invalid value: undeclared param '$(tt.params.foo)'",
 				Paths:   []string{"spec.resourcetemplates[0]"},
 				Details: "'$(tt.params.foo)' must be declared in spec.params",
-			},
-		}, {
-			name: "params used in resource template are not declared",
-			template: b.TriggerTemplate("tt", "foo", b.TriggerTemplateSpec(
-				b.TriggerResourceTemplate(deprecatedParamResourceTemplate))),
-			want: &apis.FieldError{
-				Message: "invalid value: undeclared param '$(params.foo)'",
-				Paths:   []string{"spec.resourcetemplates[0]"},
-				Details: "'$(params.foo)' must be declared in spec.params",
-			},
-		}, {
-			name: "both params and tt.params used in resource template are not declared",
-			template: b.TriggerTemplate("tt", "foo", b.TriggerTemplateSpec(
-				b.TriggerResourceTemplate(bothParamResourceTemplate))),
-			want: &apis.FieldError{
-				Message: "invalid value: undeclared param '$(params.bar)'",
-				Paths:   []string{"spec.resourcetemplates[0]"},
-				Details: "'$(params.bar)' must be declared in spec.params",
 			},
 		}, {
 			name: "invalid params used in resource template are not declared",

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -156,15 +156,15 @@ func TestHandleEvent(t *testing.T) {
 			Name:      "$(tt.params.name)",
 			Namespace: namespace,
 			Labels: map[string]string{
-				"app":  "$(params.foo)",
-				"type": "$(params.type)",
+				"app":  "$(tt.params.foo)",
+				"type": "$(tt.params.type)",
 			},
 		},
 		Spec: pipelinev1alpha1.PipelineResourceSpec{
 			Type: pipelinev1alpha1.PipelineResourceTypeGit,
 			Params: []pipelinev1alpha1.ResourceParam{
-				{Name: "url", Value: "$(params.url)"},
-				{Name: "revision", Value: "$(params.revision)"},
+				{Name: "url", Value: "$(tt.params.url)"},
+				{Name: "revision", Value: "$(tt.params.revision)"},
 			},
 		},
 	}

--- a/pkg/template/resource.go
+++ b/pkg/template/resource.go
@@ -110,16 +110,12 @@ func ApplyParamsToResourceTemplate(params []triggersv1.Param, rt json.RawMessage
 // applyParamToResourceTemplate returns the TriggerResourceTemplate with the
 // param value substituted for all matching param variables in the template
 func applyParamToResourceTemplate(param triggersv1.Param, rt json.RawMessage) json.RawMessage {
-	// The changes are for backward compatibility with both $(params) and $(tt.params)
-	// TODO(#606)
-	for _, tag := range []string{"params", "tt.params"} {
-		// Assume the param is valid
-		paramVariable := fmt.Sprintf("$(%s.%s)", tag, param.Name)
-		// Escape quotes so that that JSON strings can be appended to regular strings.
-		// See #257 for discussion on this behavior.
-		paramValue := strings.Replace(param.Value, `"`, `\"`, -1)
-		rt = bytes.Replace(rt, []byte(paramVariable), []byte(paramValue), -1)
-	}
+	// Assume the param is valid
+	paramVariable := fmt.Sprintf("$(tt.params.%s)", param.Name)
+	// Escape quotes so that that JSON strings can be appended to regular strings.
+	// See #257 for discussion on this behavior.
+	paramValue := strings.Replace(param.Value, `"`, `\"`, -1)
+	rt = bytes.Replace(rt, []byte(paramVariable), []byte(paramValue), -1)
 	return rt
 }
 

--- a/pkg/template/resource_test.go
+++ b/pkg/template/resource_test.go
@@ -183,16 +183,6 @@ func Test_applyParamToResourceTemplate(t *testing.T) {
 				rt: json.RawMessage(`{"foo": "$(tt.params.p1)"}`),
 			},
 			want: json.RawMessage(`{"foo": "{\"a\":\"b\"}"}`),
-		}, {
-			name: "deprecated params in resourcetemplate",
-			args: args{
-				param: triggersv1.Param{
-					Name:  "p1",
-					Value: `{"a":"b"}`,
-				},
-				rt: json.RawMessage(`{"p1": "$(params.p1)"}`),
-			},
-			want: json.RawMessage(`{"p1": "{\"a\":\"b\"}"}`),
 		},
 	}
 	for _, tt := range tests {
@@ -207,8 +197,6 @@ func Test_applyParamToResourceTemplate(t *testing.T) {
 
 func Test_ApplyParamsToResourceTemplate(t *testing.T) {
 	rt := json.RawMessage(`{"oneparam": "$(tt.params.oneid)", "twoparam": "$(tt.params.twoid)", "threeparam": "$(tt.params.threeid)"`)
-	rt1 := json.RawMessage(`{"deprecatedParam": "$(params.oneid)"`)
-	rt2 := json.RawMessage(`{"actualParam": "$(tt.params.oneid)", "deprecatedParam": "$(params.twoid)"`)
 	rt3 := json.RawMessage(`{"actualParam": "$(tt.params.oneid)", "invalidParam": "$(tt.params1.invalidid)", "deprecatedParam": "$(params.twoid)"`)
 	type args struct {
 		params []triggersv1.Param
@@ -250,27 +238,6 @@ func Test_ApplyParamsToResourceTemplate(t *testing.T) {
 			want: json.RawMessage(`{"oneparam": "onevalue", "twoparam": "twovalue", "threeparam": "threevalue"`),
 		},
 		{
-			name: "deprecated params",
-			args: args{
-				params: []triggersv1.Param{
-					{Name: "oneid", Value: "deprecatedParamValue"},
-				},
-				rt: rt1,
-			},
-			want: json.RawMessage(`{"deprecatedParam": "deprecatedParamValue"`),
-		},
-		{
-			name: "both params and tt.params together",
-			args: args{
-				params: []triggersv1.Param{
-					{Name: "oneid", Value: "actualValue"},
-					{Name: "twoid", Value: "deprecatedParamValue"},
-				},
-				rt: rt2,
-			},
-			want: json.RawMessage(`{"actualParam": "actualValue", "deprecatedParam": "deprecatedParamValue"`),
-		},
-		{
 			name: "valid and invalid params together",
 			args: args{
 				params: []triggersv1.Param{
@@ -280,7 +247,7 @@ func Test_ApplyParamsToResourceTemplate(t *testing.T) {
 				},
 				rt: rt3,
 			},
-			want: json.RawMessage(`{"actualParam": "actualValue", "invalidParam": "$(tt.params1.invalidid)", "deprecatedParam": "deprecatedParamValue"`),
+			want: json.RawMessage(`{"actualParam": "actualValue", "invalidParam": "$(tt.params1.invalidid)", "deprecatedParam": "$(params.twoid)"`),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
# Changes

Closes: https://github.com/tektoncd/triggers/issues/606

Removed deprecated `params` which was deprecated as part of this [PR](https://github.com/tektoncd/triggers/pull/589) 

Signed-off-by: Savita Ashture sashture@redhat.com
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

This is a breaking change as this PR remove complete support of $(params) and moved to $(tt.params) in order to avoid confusion between resourcetemplates and triggertemplate params

And the example

```
apiVersion: triggers.tekton.dev/v1alpha1
kind: TriggerTemplate
metadata:
  name: github-template
spec:
  params:
    - name: gitrevision
    - name: gitrepositoryurl
  resourcetemplates:
    - apiVersion: tekton.dev/v1alpha1
      kind: TaskRun
      metadata:
        generateName: github-run-
      spec:
        taskSpec:
          inputs:
            resources:
              - name: source
                type: git
          steps:
            - image: ubuntu
              script: |
                #! /bin/bash
                ls -al $(inputs.resources.source.path)
        inputs:
          resources:
            - name: source
              resourceSpec:
                type: git
                params:
                  - name: revision
                    value: $(tt.params.gitrevision)
                  - name: url
                    value: $(tt.params.gitrepositoryurl)
```