### PR TITLE
Fix triggertemplate validation to validate missing spec field 

### DIFF
--- a/pkg/apis/triggers/v1alpha1/trigger_template_validation.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_template_validation.go
@@ -42,7 +42,7 @@ func (t *TriggerTemplate) Validate(ctx context.Context) *apis.FieldError {
 
 // Validate validates a TriggerTemplateSpec.
 func (s *TriggerTemplateSpec) validate(ctx context.Context) *apis.FieldError {
-	if equality.Semantic.DeepEqual(s, TriggerTemplateSpec{}) {
+	if equality.Semantic.DeepEqual(s, &TriggerTemplateSpec{}) {
 		return apis.ErrMissingField(apis.CurrentField)
 	}
 	if len(s.ResourceTemplates) == 0 {

--- a/pkg/apis/triggers/v1alpha1/trigger_template_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_template_validation_test.go
@@ -176,6 +176,10 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 				b.TriggerTemplateParam("foo", "desc", "val"),
 				b.TriggerResourceTemplate(invalidParamResourceTemplate))),
 			want: nil,
+		}, {
+			name:     "no spec to triggertemplate",
+			template: b.TriggerTemplate("tt", "foo", b.TriggerTemplateSpec()),
+			want:     apis.ErrMissingField("spec"),
 		}}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
# Changes

Fixed TriggerTemplate validation to give proper error message when TriggerTemplate miss to specify `spec` 

**Actual Behavior:**
when we specify TriggerTemplate like below
```
apiVersion: triggers.tekton.dev/v1alpha1
kind: TriggerTemplate
metadata:
  name: github-template
```
It returns error like 
```
Error from server (BadRequest): error when creating "examples/github/triggertemplate.yaml": admission webhook "validation.webhook.triggers.tekton.dev" denied the request: validation failed: missing field(s): spec.resourcetemplates
```

**Expected Behavior:**
```
apiVersion: triggers.tekton.dev/v1alpha1
kind: TriggerTemplate
metadata:
  name: github-template
```
It should return error like 
```
Error from server (BadRequest): error when creating "examples/github/triggertemplate.yaml": admission webhook "validation.webhook.triggers.tekton.dev" denied the request: validation failed: missing field(s): spec
```

This has been observed from the [coverage report](https://github.com/tektoncd/triggers/pull/690#issuecomment-665192179) as part of the [PR](https://github.com/tektoncd/triggers/pull/690)
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

/cc @dibyom 
