### PR TITLE
Use Kaniko instead of img in tutorial to fix permission issue

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -59,6 +59,17 @@ Our Pipeline will do a few things.
 - Push the image to the specified repository
 - Run the image locally
 
+If your cluster doesn't have access to your docker registry you may
+need to add the secret to your Kubernetes cluster and `pipeline.yaml`.
+For that please follow the instructions [here](https://github.com/tektoncd/pipeline/blob/master/docs/tutorial.md#configuring-task-execution-credentials) and also add
+```
+  env:
+    - name: "DOCKER_CONFIG"
+      value: "/tekton/home/.docker/"
+```
+to the `pipeline.yaml` tasks similar to [this](https://github.com/tektoncd/pipeline/blob/master/docs/tutorial.md#specifying-task-inputs-and-outputs) and re-apply
+the yaml file.
+
 #### What does it do?
 
 The Pipeline will build a Docker image with

--- a/docs/getting-started/pipeline.yaml
+++ b/docs/getting-started/pipeline.yaml
@@ -85,6 +85,10 @@ spec:
     description:
       The build directory used by img
     default: /workspace/source-repo
+  - name: pathToDockerFile
+    type: string
+    description: The path to the dockerfile to build
+    default: $(resources.inputs.source-repo.path)/Dockerfile
   resources:
     inputs:
       - name: source-repo
@@ -94,15 +98,13 @@ spec:
         type: image
   steps:
     - name: build-and-push
-      image: r.j3ss.co/img
+      image: gcr.io/kaniko-project/executor:v0.16.0
       command:
-        - /usr/bin/img
+        - /kaniko/executor
       args:
-        - build
-        - -t
-        - "$(resources.outputs.builtImage.url)"
-        - --no-cache
-        - "$(params.pathToContext)"
+        - --dockerfile=$(params.pathToDockerFile)
+        - --destination=$(resources.outputs.builtImage.url)
+        - --context=$(params.pathToContext)
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: Condition
@@ -116,7 +118,8 @@ spec:
   check:
     image: golang
     command: ["go"]
-    args: ['test', "$(resources.source-repo.path)/..."]
+    workingDir: "$(resources.source-repo.path)"
+    args: ['test', "./..."]
 ---
 # Finally, we need something to receive our cloudevent announcing success!
 # That is this services only purpose


### PR DESCRIPTION
Use Kaniko instead of img in tutorial to fix permission issue

Fixes #615 