### PR TITLE
Change tekton.dev to triggers.tekton.dev for e2e Tests

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -55,8 +55,8 @@ function install_triggers_crd() {
   ko apply -f config/ || fail_test "Tekton Triggers installation failed"
 
   # Make sure that eveything is cleaned up in the current namespace.
-  for res in eventlistener triggertemplate triggerbinding; do
-    kubectl delete --ignore-not-found=true ${res}.tekton.dev --all
+  for res in eventlistener triggertemplate triggerbinding clustertriggerbinding; do
+    kubectl delete --ignore-not-found=true ${res}.triggers.tekton.dev --all
   done
 
   # Wait for pods to be running in the namespaces we are deploying to


### PR DESCRIPTION
# Changes

Noticed this when adding triggers component to e2e clusters for the cli that the resource name format should be `${res}.triggers.tekton.dev` for the check. Also adding ClusterTriggerBinding to the check.

# Submitter Checklist

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

N/A
