### PR TITLE
switch trigger sa ref from global to namespace scoped

### DIFF
--- a/pkg/apis/triggers/v1alpha1/trigger_types.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_types.go
@@ -32,14 +32,10 @@ type TriggerSpec struct {
 	Name         string                `json:"name,omitempty"`
 	Interceptors []*TriggerInterceptor `json:"interceptors,omitempty"`
 	// ServiceAccount optionally associates credentials with each trigger;
-	// more granular authorization for
-	// who is allowed to utilize the associated pipeline
-	// vs. defaulting to whatever permissions are associated
-	// with the entire EventListener and associated sink facilitates
-	// multi-tenant model based scenarios
-	// TODO do we want to restrict this to the event listener namespace and just ask for the service account name here?
+	// Unlike EventListeners, this should be scoped to the same namespace
+	// as the Trigger itself
 	// +optional
-	ServiceAccount *corev1.ObjectReference `json:"serviceAccount,omitempty"`
+	ServiceAccount *corev1.LocalObjectReference `json:"serviceAccount,omitempty"`
 }
 
 type TriggerSpecTemplate struct {

--- a/pkg/apis/triggers/v1alpha1/trigger_types_convert_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_types_convert_test.go
@@ -53,7 +53,7 @@ func TestToEventListenerTrigger(t *testing.T) {
 			name: "Convert Full Object",
 			in: TriggerSpec{
 				Name: "a",
-				ServiceAccount: &v1.ObjectReference{
+				ServiceAccount: &v1.LocalObjectReference{
 					Name: "a",
 				},
 				Interceptors: []*TriggerInterceptor{{

--- a/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
@@ -730,7 +730,7 @@ func (in *TriggerSpec) DeepCopyInto(out *TriggerSpec) {
 	}
 	if in.ServiceAccount != nil {
 		in, out := &in.ServiceAccount, &out.ServiceAccount
-		*out = new(v1.ObjectReference)
+		*out = new(v1.LocalObjectReference)
 		**out = **in
 	}
 	return


### PR DESCRIPTION
# Changes

So in getting caught up on some thing related to the trigger crd tep, I came across this type and https://github.com/tektoncd/triggers/pull/628

It appears to me that to some extent there was a simple copy done in https://github.com/tektoncd/triggers/pull/628 of https://github.com/tektoncd/triggers/blob/master/pkg/apis/triggers/v1alpha1/event_listener_types.go#L77-L92
including my verbose comment and TODO around the `ServiceAccount` field.

Now, as already indicated in https://github.com/tektoncd/community/pull/148 and the use of a string type `serviceAccountName`, as well in the WG discussion, any SA assoicated with a Trigger should be in the same namespace as the trigger

So why make this correction now vs. just waiting until the TEP is implemented?

@dibyom 's comment https://github.com/tektoncd/triggers/pull/628#issuecomment-661103086 is what motivated me to submit this for consideration.

If the "run CLI tool" item noted there drops with sufficient time before the tep does, then we don't want the precedent of triggers using SAs from other namespaces being established.

Thoughts @khrm @dibyom @dorismeixing  ?

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes


