### PR TITLE
Propagate annotations from EL to svc and deployment

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -22,6 +22,7 @@ using [Event Interceptors](#Interceptors).
     - [Interceptors](#interceptors)
 - [Logging](#logging)
 - [Labels](#labels)
+- [Annotations](#annotations)
 - [EventListener Response](#eventlistener-response)
 - [Examples](#examples)
 - [Multi-Tenant Concerns](#multi-tenant-concerns)
@@ -219,6 +220,27 @@ Since the EventListener name and Trigger name are used as label values, they
 must adhere to the
 [Kubernetes syntax and character set requirements](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set)
 for label values.
+
+## Annotations
+
+All the annotations provided in Eventlistener will be further propagated to the service
+and deployment created by that Eventlistener.
+
+Example: You may need to add some annotation to the service like you need to annotation
+for TLS support to a LoadBalancer service on AWS, you can specify that annotation in 
+Eventlistener and it will be available to the service created by EventListener.
+
+```
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: EventListener
+metadata:
+  name: eventlistener
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: https
+```
+
+**Note**: If there are any annotations attached to the service or the deployment, they will get overwritten 
+by the annotations available in the eventlistener.
 
 ## Interceptors
 

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
@@ -166,6 +166,10 @@ func reconcileObjectMeta(oldMeta *metav1.ObjectMeta, newMeta metav1.ObjectMeta) 
 		updated = true
 		oldMeta.Labels = newMeta.Labels
 	}
+	if !reflect.DeepEqual(oldMeta.Annotations, newMeta.Annotations) {
+		updated = true
+		oldMeta.Annotations = newMeta.Annotations
+	}
 	if !reflect.DeepEqual(oldMeta.OwnerReferences, newMeta.OwnerReferences) {
 		updated = true
 		oldMeta.OwnerReferences = newMeta.OwnerReferences
@@ -448,6 +452,7 @@ func generateObjectMeta(el *v1alpha1.EventListener) metav1.ObjectMeta {
 		Name:            el.Status.Configuration.GeneratedResourceName,
 		OwnerReferences: []metav1.OwnerReference{*el.GetOwnerReference()},
 		Labels:          mergeLabels(el.Labels, GenerateResourceLabels(el.Name)),
+		Annotations:     el.Annotations,
 	}
 }
 

--- a/test/builder/meta.go
+++ b/test/builder/meta.go
@@ -40,6 +40,16 @@ func Label(key, value string) ObjectMetaOp {
 	}
 }
 
+// Annotation adds a single annotation to the ObjectMeta.
+func Annotation(key, value string) ObjectMetaOp {
+	return func(m *metav1.ObjectMeta) {
+		if m.Annotations == nil {
+			m.Annotations = make(map[string]string)
+		}
+		m.Annotations[key] = value
+	}
+}
+
 // TypeMeta sets the TypeMeta struct with default values.
 func TypeMeta(kind, apiVersion string) TypeMetaOp {
 	return func(m *metav1.TypeMeta) {

--- a/test/builder/meta_test.go
+++ b/test/builder/meta_test.go
@@ -53,6 +53,30 @@ func TestObjectMeta(t *testing.T) {
 				Label("key2", "value2"),
 			},
 		},
+		{
+			name: "One Annotation",
+			normal: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"key1": "value1",
+				},
+			},
+			builderFuncs: []ObjectMetaOp{
+				Annotation("key1", "value1"),
+			},
+		},
+		{
+			name: "Two Annotations",
+			normal: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+			builderFuncs: []ObjectMetaOp{
+				Annotation("key1", "value1"),
+				Annotation("key2", "value2"),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This will add the feature of propagating annotations
of an eventlistener to the service, deployment and
further pods created by the eventlistener

Add docs and tests

Fix #700

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Now annotations of the eventlistener will be propagated to deployment and services. If you have any custom annotation on your services/deployment, please add them to annotations otherwise they will be overwritten.
```
