### PR TITLE
Fix update deployment when there is a change in replicas

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -166,6 +166,8 @@ check out the guide on [exposing EventListeners](./exposing-eventlisteners.md).
 The `replicas` field is optional. By default, the number of replicas of EventListener is 1.
 If you want to deploy more than one pod, you can specify the number to this field. 
 
+**Note:** If user sets `replicas` field while creating eventlistener yaml then it won't respects replicas values edited by user manually or through any other mechanism (ex: HPA).
+
 ### PodTemplate
 
 The `podTemplate` field is optional. A PodTemplate is specifications for 

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
@@ -348,7 +348,7 @@ func (c *Reconciler) reconcileDeployment(el *v1alpha1.EventListener) error {
 		el.Status.SetDeploymentConditions(existingDeployment.Status.Conditions)
 		// Determine if reconciliation has to occur
 		updated := reconcileObjectMeta(&existingDeployment.ObjectMeta, deployment.ObjectMeta)
-		if existingDeployment.Spec.Replicas == nil || *existingDeployment.Spec.Replicas == 0 {
+		if existingDeployment.Spec.Replicas != deployment.Spec.Replicas {
 			existingDeployment.Spec.Replicas = replicas
 			updated = true
 		}

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
@@ -546,7 +546,7 @@ func TestReconcile(t *testing.T) {
 		endResources: test.Resources{
 			Namespaces:     []*corev1.Namespace{namespaceResource},
 			EventListeners: []*v1alpha1.EventListener{elWithStatus},
-			Deployments:    []*appsv1.Deployment{deploymentWithUpdatedReplicas},
+			Deployments:    []*appsv1.Deployment{elDeployment},
 			Services:       []*corev1.Service{elService},
 			ConfigMaps:     []*corev1.ConfigMap{loggingConfigMap},
 		},


### PR DESCRIPTION
# Changes
The changes fix update deployment operation when there is a change in replicas number.
With current code whenever user updates `replicas` as part of eventlistener update success but no change in behavior.

Fix: https://github.com/tektoncd/triggers/issues/714

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
None
```
