### PR TITLE
Add validation for replicas

### DIFF
--- a/pkg/apis/triggers/v1alpha1/event_listener_types.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_types.go
@@ -55,7 +55,7 @@ type EventListenerSpec struct {
 	ServiceAccountName string                 `json:"serviceAccountName"`
 	Triggers           []EventListenerTrigger `json:"triggers"`
 	ServiceType        corev1.ServiceType     `json:"serviceType,omitempty"`
-	Replicas           int32                  `json:"replicas"`
+	Replicas           *int32                 `json:"replicas,omitempty"`
 	PodTemplate        PodTemplate            `json:"podTemplate,omitempty"`
 }
 

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation.go
@@ -28,10 +28,15 @@ import (
 
 // Validate EventListener.
 func (e *EventListener) Validate(ctx context.Context) *apis.FieldError {
-	return e.Spec.validate(ctx, e)
+	return e.Spec.validate(ctx)
 }
 
-func (s *EventListenerSpec) validate(ctx context.Context, el *EventListener) *apis.FieldError {
+func (s *EventListenerSpec) validate(ctx context.Context) *apis.FieldError {
+	if s.Replicas != nil {
+		if *s.Replicas <= 0 {
+			return apis.ErrInvalidValue(*s.Replicas, "spec.replicas")
+		}
+	}
 	if len(s.Triggers) == 0 {
 		return apis.ErrMissingField("spec.triggers")
 	}

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
@@ -387,12 +387,19 @@ func TestEventListenerValidate_error(t *testing.T) {
 					bldr.EventListenerTriggerBinding("tb", "", "tb", "v1alpha1"),
 					bldr.EventListenerTriggerName("1234567890123456789012345678901234567890123456789012345678901234"),
 				))),
+	}, {
+		name: "user specify invalid replicas which are 0 and negative values",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerReplicas(0),
+				bldr.EventListenerTrigger("tt", "v1alpha1",
+					bldr.EventListenerTriggerBinding("tb", "TriggerBinding", "tb", "v1alpha1"),
+				))),
 	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.el.Validate(context.Background())
-			if err == nil {
+			if err := test.el.Validate(context.Background()); err == nil {
 				t.Errorf("EventListener.Validate() expected error, but get none, EventListener: %v", test.el)
 			}
 		})

--- a/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
@@ -258,6 +258,11 @@ func (in *EventListenerSpec) DeepCopyInto(out *EventListenerSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Replicas != nil {
+		in, out := &in.Replicas, &out.Replicas
+		*out = new(int32)
+		**out = **in
+	}
 	in.PodTemplate.DeepCopyInto(&out.PodTemplate)
 	return
 }

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"knative.dev/pkg/controller"
+	"knative.dev/pkg/ptr"
 )
 
 const (
@@ -259,8 +260,8 @@ func (c *Reconciler) reconcileDeployment(el *v1alpha1.EventListener) error {
 	}
 
 	labels := mergeLabels(el.Labels, GenerateResourceLabels(el.Name))
-	var replicas int32 = 1
-	if el.Spec.Replicas != 0 {
+	var replicas = ptr.Int32(1)
+	if el.Spec.Replicas != nil {
 		replicas = el.Spec.Replicas
 	}
 	container := corev1.Container{
@@ -313,7 +314,7 @@ func (c *Reconciler) reconcileDeployment(el *v1alpha1.EventListener) error {
 	deployment := &appsv1.Deployment{
 		ObjectMeta: generateObjectMeta(el),
 		Spec: appsv1.DeploymentSpec{
-			Replicas: &replicas,
+			Replicas: replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: GenerateResourceLabels(el.Name),
 			},
@@ -348,7 +349,7 @@ func (c *Reconciler) reconcileDeployment(el *v1alpha1.EventListener) error {
 		// Determine if reconciliation has to occur
 		updated := reconcileObjectMeta(&existingDeployment.ObjectMeta, deployment.ObjectMeta)
 		if existingDeployment.Spec.Replicas == nil || *existingDeployment.Spec.Replicas == 0 {
-			existingDeployment.Spec.Replicas = &replicas
+			existingDeployment.Spec.Replicas = replicas
 			updated = true
 		}
 		if existingDeployment.Spec.Selector != deployment.Spec.Selector {

--- a/test/builder/eventlistener.go
+++ b/test/builder/eventlistener.go
@@ -95,7 +95,7 @@ func EventListenerServiceAccount(saName string) EventListenerSpecOp {
 // EventListenerReplicas sets the specified Replicas of the EventListener.
 func EventListenerReplicas(replicas int32) EventListenerSpecOp {
 	return func(spec *v1alpha1.EventListenerSpec) {
-		spec.Replicas = replicas
+		spec.Replicas = &replicas
 	}
 }
 


### PR DESCRIPTION
# Changes

1. Add changes to validate invalid replicas specified by user as part of eventlistener spec.
2. Modified in order not to show replicas field after EL creation when replicas are not specified as part of EL spec.

Fix: https://github.com/tektoncd/triggers/issues/716

Signed-off-by: Savita Ashture sashture@redhat.com

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

EventListener spec validation ensures proper validation when user specifies `spec.replicas` values as `negative or zero`
ex:

```
cat <<EOF | kubectl create -f -
apiVersion: triggers.tekton.dev/v1alpha1
kind: EventListener
metadata:
  name: bitbucket-listener
spec:
  serviceAccountName: tekton-triggers-bitbucket-sa
  replicas: 0
  triggers:
    - name: bitbucket-triggers
      bindings:
        - ref: bitbucket-binding
      template:
        name: bitbucket-template
EOF
```
Gives response like below
```
Error from server (BadRequest): error when creating "STDIN": admission webhook "validation.webhook.triggers.tekton.dev" denied the request: validation failed: invalid value: 0: spec.replicas
```