### PR TITLE
Mark some command tests as end-to-end

### DIFF
--- a/cmd/binding-eval/cmd/root_test.go
+++ b/cmd/binding-eval/cmd/root_test.go
@@ -1,3 +1,5 @@
+// +build e2e
+
 /*
 Copyright 2020 The Tekton Authors
 

--- a/cmd/triggerrun/cmd/root_test.go
+++ b/cmd/triggerrun/cmd/root_test.go
@@ -1,3 +1,5 @@
+// +build e2e
+
 /*
 Copyright 2020 The Tekton Authors
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -36,6 +36,7 @@ $(dirname $0)/e2e-tests-ingress.sh || failed=1
 # Run the integration tests
 header "Running Go e2e tests"
 go_test_e2e -timeout=20m ./test || failed=1
+go_test_e2e -timeout=20m ./cmd/... || failed=1
 
 (( failed )) && fail_test
 success


### PR DESCRIPTION


# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Those tests require a living cluster (with tekton installed), this
means they are end-to-end tests. Adding the `e2e` build tag on them so
they don't get executed while doing unit tests.

Also, run those as part of the e2e script.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>

/cc @dibyom @savitaashture @khrm @wlynch 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
