### PR TITLE
Use another NodeSelector value in EventListener tests

### DIFF
--- a/test/eventlistener_scale_test.go
+++ b/test/eventlistener_scale_test.go
@@ -51,7 +51,7 @@ func TestEventListenerScale(t *testing.T) {
 		bldr.EventListenerReplicas(3),
 		bldr.EventListenerPodTemplate(
 			bldr.EventListenerPodTemplateSpec(
-				bldr.EventListenerPodTemplateNodeSelector(map[string]string{"beta.kubernetes.io/arch": "amd64"}),
+				bldr.EventListenerPodTemplateNodeSelector(map[string]string{"beta.kubernetes.io/os": "linux"}),
 				bldr.EventListenerPodTemplateTolerations([]corev1.Toleration{
 					{
 						Key:      "key",

--- a/test/eventlistener_test.go
+++ b/test/eventlistener_test.go
@@ -287,7 +287,7 @@ func TestEventListenerCreate(t *testing.T) {
 				bldr.EventListenerReplicas(3),
 				bldr.EventListenerPodTemplate(
 					bldr.EventListenerPodTemplateSpec(
-						bldr.EventListenerPodTemplateNodeSelector(map[string]string{"beta.kubernetes.io/arch": "amd64"}),
+						bldr.EventListenerPodTemplateNodeSelector(map[string]string{"beta.kubernetes.io/os": "linux"}),
 						bldr.EventListenerPodTemplateTolerations([]corev1.Toleration{
 							{
 								Key:      "key",


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

NodeSelector values are changed for 2 tests from beta.kubernetes.io/arch=amd64
to beta.kubernetes.io/os=linux to let e2e tests pass on non amd64
architecture (s390x, ppc64le, etc)

Fix: https://github.com/tektoncd/triggers/issues/718

Signed-off-by: Yulia Gaponenko <yulia.gaponenko1@de.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
None
```
