### PR TITLE
Add TriggerCRD object Ref to ELSpec Trigger

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -70,7 +70,7 @@ metadata:
 rules:
 # Permissions for every EventListener deployment to function
 - apiGroups: ["triggers.tekton.dev"]
-  resources: ["eventlisteners", "triggerbindings", "triggertemplates"]
+  resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers"]
   verbs: ["get"]
 - apiGroups: [""]
   # secrets are only needed for Github/Gitlab interceptors
@@ -99,8 +99,11 @@ The `triggers` field is required. Each EventListener can consist of one or more
 - `name` - (Optional) a valid
   [Kubernetes name](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set)
 - [`interceptors`](#interceptors) - (Optional) list of interceptors to use
-- `bindings` - A list of `TriggerBindings` reference to use or embedded TriggerBindingsSpecs to use.
-- `template` - The name of `TriggerTemplate` to use
+- `bindings` - (Optional) A list of `TriggerBindings` reference to use or embedded TriggerBindingsSpecs to use.
+- `template` - (Optional) The name of `TriggerTemplate` to use
+- `triggerRef` - (Optional) Reference to the [`Trigger`](./triggers.md).
+
+A `trigger` field must have `template` (along with needed `bindings` and `interceptors`) or `triggerRef`.
 
 ```yaml
 triggers:
@@ -117,6 +120,12 @@ triggers:
                 value: Hello from the Triggers EventListener!
     template:
       name: pipeline-template
+```
+
+Or with only `triggerRef`:
+```yaml
+triggers:
+    - triggerRef: trigger
 ```
 
 Also, to support multi-tenant styled scenarios, where an administrator may not want all triggers to have

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -1,0 +1,54 @@
+<!--
+---
+linkTitle: "Trigger"
+weight: 9
+---
+-->
+# Triggers
+
+A `Trigger` is resource that combines `TriggerTemplate`, `TriggerBindings` and `interceptors`. The `Trigger` is processed by EventListener which referenced it when it receives an incoming.
+
+- [Syntax](#syntax)
+
+## Syntax
+
+To define a configuration file for an `Trigger` resource, you can specify
+the following fields:
+
+- Required:
+  - [`apiVersion`][kubernetes-overview] - Specifies the API version, for example
+    `triggers.tekton.dev/v1alpha1`.
+  - [`kind`][kubernetes-overview] - Specifies the `Trigger` resource
+    object.
+  - [`metadata`][kubernetes-overview] - Specifies data to uniquely identify the
+    `Trigger` resource object, for example a `name`.
+  - [`spec`][kubernetes-overview] - Specifies the configuration information for
+    your Trigger resource object. The spec include:
+    - [`bindings`] -  A list of `TriggerBindings` reference to use or embedded TriggerBindingsSpecs to use
+    - [`template`] -  The name of `TriggerTemplate` to use
+    - [`interceptors`](./eventlisteners.md#interceptors) - (Optional) list of interceptors to use
+    - [`serviceAccountName`] - (Optional) Specifies the ServiceAccount provided to EventListener by Trigger to create resources
+
+
+<!-- FILE: examples/triggers/trigger.yaml -->
+```YAML
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: Trigger
+metadata:
+  name: trigger
+spec:
+  interceptors:
+    - cel:
+        filter: "header.match('X-GitHub-Event', 'pull_request')"
+        overlays:
+        - key: extensions.truncated_sha
+          expression: "body.pull_request.head.sha.truncate(7)"
+  bindings:
+  - ref: pipeline-binding
+  template:
+    name: pipeline-template
+```
+
+[kubernetes-overview]:
+  https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields
+

--- a/examples/role-resources/clustertriggerbinding-roles/clusterrole.yaml
+++ b/examples/role-resources/clustertriggerbinding-roles/clusterrole.yaml
@@ -5,7 +5,7 @@ metadata:
 rules:
 # Permissions for every EventListener deployment to function
 - apiGroups: ["triggers.tekton.dev"]
-  resources: ["clustertriggerbindings", "eventlisteners", "triggerbindings", "triggertemplates"]
+  resources: ["clustertriggerbindings", "eventlisteners", "triggerbindings", "triggertemplates", "triggers"]
   verbs: ["get"]
 - apiGroups: [""]
   # secrets are only needed for Github/Gitlab interceptors

--- a/examples/triggers/eventlistener-triggerref.yaml
+++ b/examples/triggers/eventlistener-triggerref.yaml
@@ -1,0 +1,8 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: EventListener
+metadata:
+  name: listener-triggerref
+spec:
+  serviceAccountName: tekton-triggers-example-sa
+  triggers:
+    - triggerRef: trigger

--- a/examples/triggers/rbac.yaml
+++ b/examples/triggers/rbac.yaml
@@ -1,3 +1,4 @@
+---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -18,3 +19,30 @@ rules:
 - apiGroups: [""]
   resources: ["serviceaccounts"]
   verbs: ["impersonate"]
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tekton-triggers-example-secret
+type: Opaque
+stringData:
+  secretToken: "1234567"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-triggers-example-sa
+secrets:
+  - name: tekton-triggers-example-secret
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-triggers-example-binding
+subjects:
+- kind: ServiceAccount
+  name: tekton-triggers-example-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tekton-triggers-example-minimal

--- a/examples/triggers/trigger.yaml
+++ b/examples/triggers/trigger.yaml
@@ -1,0 +1,15 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: Trigger
+metadata:
+  name: trigger
+spec:
+  interceptors:
+    - cel:
+        filter: "header.match('X-GitHub-Event', 'pull_request')"
+        overlays:
+        - key: extensions.truncated_sha
+          expression: "body.pull_request.head.sha.truncate(7)"
+  bindings:
+  - ref: pipeline-binding
+  template:
+    name: pipeline-template

--- a/examples/triggers/triggerbinding.yaml
+++ b/examples/triggers/triggerbinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: pipeline-binding
+spec:
+  params:
+  - name: gitrevision
+    value: $(body.head_commit.id)
+  - name: gitrepositoryurl
+    value: $(body.repository.url)
+  - name: contenttype
+    value: $(header.Content-Type)

--- a/examples/triggers/triggertemplate.yaml
+++ b/examples/triggers/triggertemplate.yaml
@@ -1,0 +1,38 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: pipeline-template
+spec:
+  params:
+  - name: gitrevision
+    description: The git revision
+    default: master
+  - name: gitrepositoryurl
+    description: The git repository url
+  - name: message
+    description: The message to print
+    default: This is the default message
+  - name: contenttype
+    description: The Content-Type of the event
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      generateName: simple-pipeline-run-
+    spec:
+      pipelineRef:
+        name: simple-pipeline
+      params:
+      - name: message
+        value: $(tt.params.message)
+      - name: contenttype
+        value: $(tt.params.contenttype)
+      resources:
+      - name: git-source
+        resourceSpec:
+          type: git
+          params:
+          - name: revision
+            value: $(tt.params.gitrevision)
+          - name: url
+            value: $(tt.params.gitrepositoryurl)

--- a/pkg/apis/triggers/v1alpha1/event_listener_types.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_types.go
@@ -73,10 +73,12 @@ type PodTemplate struct {
 
 // EventListenerTrigger represents a connection between TriggerBinding, Params,
 // and TriggerTemplate; TriggerBinding provides extracted values for
-// TriggerTemplate to then create resources from.
+// TriggerTemplate to then create resources from. TriggerRef can also be
+// provided instead of TriggerBinding, Interceptors and TriggerTemplate
 type EventListenerTrigger struct {
-	Bindings []*EventListenerBinding `json:"bindings"`
-	Template EventListenerTemplate   `json:"template"`
+	Bindings   []*EventListenerBinding `json:"bindings,omitempty"`
+	Template   *EventListenerTemplate  `json:"template,omitempty"`
+	TriggerRef string                  `json:"triggerRef,omitempty"`
 	// +optional
 	Name         string              `json:"name,omitempty"`
 	Interceptors []*EventInterceptor `json:"interceptors,omitempty"`

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation.go
@@ -49,6 +49,10 @@ func (s *EventListenerSpec) validate(ctx context.Context) *apis.FieldError {
 }
 
 func (t *EventListenerTrigger) validate(ctx context.Context) *apis.FieldError {
+	if t.Template == nil && t.TriggerRef == "" {
+		return apis.ErrMissingOneOf("template", "triggerRef")
+	}
+
 	// Validate optional Bindings
 	for i, b := range t.Bindings {
 		// Either Ref or Spec should be present
@@ -67,14 +71,17 @@ func (t *EventListenerTrigger) validate(ctx context.Context) *apis.FieldError {
 	}
 	// Validate required TriggerTemplate
 	// Optional explicit match
-	if t.Template.APIVersion != "" {
-		if t.Template.APIVersion != "v1alpha1" {
-			return apis.ErrInvalidValue(fmt.Errorf("invalid apiVersion"), "template.apiVersion")
+	if t.Template != nil {
+		if t.Template.APIVersion != "" {
+			if t.Template.APIVersion != "v1alpha1" {
+				return apis.ErrInvalidValue(fmt.Errorf("invalid apiVersion"), "template.apiVersion")
+			}
+		}
+		if t.Template.Name == "" {
+			return apis.ErrMissingField("template.name")
 		}
 	}
-	if t.Template.Name == "" {
-		return apis.ErrMissingField("template.name")
-	}
+
 	for i, interceptor := range t.Interceptors {
 		if err := interceptor.validate(ctx).ViaField(fmt.Sprintf("interceptors[%d]", i)); err != nil {
 			return err

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
@@ -41,6 +41,11 @@ func Test_EventListenerValidate(t *testing.T) {
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1"))),
 	}, {
+		name: "Valid EventListener with TriggerRef",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTriggerRef("tt"))),
+	}, {
 		name: "Valid EventListener with TriggerBinding",
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
@@ -165,9 +170,25 @@ func TestEventListenerValidate_error(t *testing.T) {
 				Namespace: "namespace",
 			},
 			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{{}},
+			},
+		},
+	}, {
+		name: "EventListener with no Trigger ref or Template",
+		el: &v1alpha1.EventListener{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "n",
+				Namespace: "namespace",
+			},
+			Spec: v1alpha1.EventListenerSpec{
 				Triggers: nil,
 			},
 		},
+	}, {
+		name: "Valid EventListener with empty TriggerTemplate name",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("", "v1alpha1"))),
 	}, {
 		name: "TriggerBinding with no ref or spec",
 		el: bldr.EventListener("name", "namespace",
@@ -192,7 +213,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{Name: "", Kind: v1alpha1.NamespacedTriggerBindingKind}},
-					Template: v1alpha1.EventListenerTemplate{Name: "tt"},
+					Template: &v1alpha1.EventListenerTemplate{Name: "tt"},
 				}},
 			},
 		},
@@ -206,7 +227,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{Name: "tb", Kind: ""}},
-					Template: v1alpha1.EventListenerTemplate{Name: "tt"},
+					Template: &v1alpha1.EventListenerTemplate{Name: "tt"},
 				}},
 			},
 		},
@@ -220,7 +241,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
-					Template: v1alpha1.EventListenerTemplate{Name: "tt", APIVersion: "invalid"},
+					Template: &v1alpha1.EventListenerTemplate{Name: "tt", APIVersion: "invalid"},
 				}},
 			},
 		},
@@ -234,7 +255,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
-					Template: v1alpha1.EventListenerTemplate{Name: "", APIVersion: "v1alpha1"},
+					Template: &v1alpha1.EventListenerTemplate{Name: "", APIVersion: "v1alpha1"},
 				}},
 			},
 		},
@@ -256,7 +277,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings:     []*v1alpha1.EventListenerBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
-					Template:     v1alpha1.EventListenerTemplate{Name: "tt"},
+					Template:     &v1alpha1.EventListenerTemplate{Name: "tt"},
 					Interceptors: []*v1alpha1.EventInterceptor{{}},
 				}},
 			},
@@ -271,7 +292,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
-					Template: v1alpha1.EventListenerTemplate{Name: "tt"},
+					Template: &v1alpha1.EventListenerTemplate{Name: "tt"},
 					Interceptors: []*v1alpha1.EventInterceptor{{
 						Webhook: &v1alpha1.WebhookInterceptor{
 							ObjectRef: &corev1.ObjectReference{
@@ -345,7 +366,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
-					Template: v1alpha1.EventListenerTemplate{Name: "tt"},
+					Template: &v1alpha1.EventListenerTemplate{Name: "tt"},
 					Interceptors: []*v1alpha1.EventInterceptor{{
 						GitHub:    &v1alpha1.GitHubInterceptor{},
 						GitLab:    &v1alpha1.GitLabInterceptor{},
@@ -364,7 +385,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
-					Template: v1alpha1.EventListenerTemplate{Name: "tt"},
+					Template: &v1alpha1.EventListenerTemplate{Name: "tt"},
 					Interceptors: []*v1alpha1.EventInterceptor{{
 						CEL: &v1alpha1.CELInterceptor{},
 					}},

--- a/pkg/apis/triggers/v1alpha1/trigger_types_convert_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_types_convert_test.go
@@ -31,7 +31,7 @@ func TestToEventListenerTrigger(t *testing.T) {
 		{
 			name: "Convert Empty Object",
 			in:   TriggerSpec{},
-			out:  EventListenerTrigger{},
+			out:  EventListenerTrigger{Template: &EventListenerTemplate{}},
 		},
 		{
 			name: "Convert Partial Object",
@@ -43,7 +43,7 @@ func TestToEventListenerTrigger(t *testing.T) {
 			},
 			out: EventListenerTrigger{
 				Name: "foo",
-				Template: EventListenerTemplate{
+				Template: &EventListenerTemplate{
 					Name: "baz",
 				},
 			},
@@ -91,7 +91,7 @@ func TestToEventListenerTrigger(t *testing.T) {
 						}},
 					},
 				}},
-				Template: EventListenerTemplate{
+				Template: &EventListenerTemplate{
 					Name:       "a",
 					APIVersion: "b",
 				},

--- a/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
@@ -289,7 +289,11 @@ func (in *EventListenerTrigger) DeepCopyInto(out *EventListenerTrigger) {
 			}
 		}
 	}
-	out.Template = in.Template
+	if in.Template != nil {
+		in, out := &in.Template, &out.Template
+		*out = new(TriggerSpecTemplate)
+		**out = **in
+	}
 	if in.Interceptors != nil {
 		in, out := &in.Interceptors, &out.Interceptors
 		*out = make([]*TriggerInterceptor, len(*in))

--- a/pkg/template/resource_test.go
+++ b/pkg/template/resource_test.go
@@ -327,7 +327,7 @@ func Test_ResolveTrigger(t *testing.T) {
 					Ref:  "my-triggerbinding",
 					Kind: triggersv1.NamespacedTriggerBindingKind,
 				}},
-				Template: triggersv1.EventListenerTemplate{
+				Template: &triggersv1.EventListenerTemplate{
 					Name:       "my-triggertemplate",
 					APIVersion: "v1alpha1",
 				},
@@ -345,7 +345,7 @@ func Test_ResolveTrigger(t *testing.T) {
 					Ref:  "my-clustertriggerbinding",
 					Kind: triggersv1.ClusterTriggerBindingKind,
 				}},
-				Template: triggersv1.EventListenerTemplate{
+				Template: &triggersv1.EventListenerTemplate{
 					Name:       "my-triggertemplate",
 					APIVersion: "v1alpha1",
 				},
@@ -368,7 +368,7 @@ func Test_ResolveTrigger(t *testing.T) {
 						}},
 					},
 				}},
-				Template: triggersv1.EventListenerTemplate{
+				Template: &triggersv1.EventListenerTemplate{
 					Name:       "my-triggertemplate",
 					APIVersion: "v1alpha1",
 				},
@@ -392,7 +392,7 @@ func Test_ResolveTrigger(t *testing.T) {
 		{
 			name: "no binding",
 			trigger: triggersv1.EventListenerTrigger{
-				Template: triggersv1.EventListenerTemplate{
+				Template: &triggersv1.EventListenerTemplate{
 					Name:       "my-triggertemplate",
 					APIVersion: "v1alpha1",
 				},
@@ -428,7 +428,7 @@ func Test_ResolveTrigger(t *testing.T) {
 						APIVersion: "v1alpha1",
 					},
 				},
-				Template: triggersv1.EventListenerTemplate{
+				Template: &triggersv1.EventListenerTemplate{
 					Name:       "my-triggertemplate",
 					APIVersion: "v1alpha1",
 				},
@@ -453,7 +453,7 @@ func Test_ResolveTrigger(t *testing.T) {
 					APIVersion: "v1alpha1",
 					Ref:        "my-triggerbinding",
 				}},
-				Template: triggersv1.EventListenerTemplate{
+				Template: &triggersv1.EventListenerTemplate{
 					Name:       "my-triggertemplate",
 					APIVersion: "v1alpha1",
 				},
@@ -493,7 +493,7 @@ func Test_ResolveTrigger_error(t *testing.T) {
 					Ref:  "invalid-tb-name",
 					Kind: triggersv1.NamespacedTriggerBindingKind,
 				}},
-				Template: triggersv1.EventListenerTemplate{
+				Template: &triggersv1.EventListenerTemplate{
 					Name:       "my-triggertemplate",
 					APIVersion: "v1alpha1",
 				},
@@ -509,7 +509,7 @@ func Test_ResolveTrigger_error(t *testing.T) {
 					Ref:  "invalid-ctb-name",
 					Kind: triggersv1.ClusterTriggerBindingKind,
 				}},
-				Template: triggersv1.EventListenerTemplate{
+				Template: &triggersv1.EventListenerTemplate{
 					Name:       "my-triggertemplate",
 					APIVersion: "v1alpha1",
 				},
@@ -525,7 +525,7 @@ func Test_ResolveTrigger_error(t *testing.T) {
 					Ref:  "my-triggerbinding",
 					Kind: triggersv1.NamespacedTriggerBindingKind,
 				}},
-				Template: triggersv1.EventListenerTemplate{
+				Template: &triggersv1.EventListenerTemplate{
 					Name:       "invalid-tt-name",
 					APIVersion: "v1alpha1",
 				},
@@ -541,7 +541,7 @@ func Test_ResolveTrigger_error(t *testing.T) {
 					Ref:  "invalid-tb-name",
 					Kind: triggersv1.NamespacedTriggerBindingKind,
 				}},
-				Template: triggersv1.EventListenerTemplate{
+				Template: &triggersv1.EventListenerTemplate{
 					Name:       "invalid-tt-name",
 					APIVersion: "v1alpha1",
 				},

--- a/test/builder/eventlistener.go
+++ b/test/builder/eventlistener.go
@@ -136,7 +136,7 @@ func EventListenerPodTemplateNodeSelector(nodeSelector map[string]string) EventL
 func EventListenerTrigger(ttName, apiVersion string, ops ...EventListenerTriggerOp) EventListenerSpecOp {
 	return func(spec *v1alpha1.EventListenerSpec) {
 		t := v1alpha1.EventListenerTrigger{
-			Template: v1alpha1.EventListenerTemplate{
+			Template: &v1alpha1.EventListenerTemplate{
 				Name:       ttName,
 				APIVersion: apiVersion,
 			},
@@ -147,6 +147,15 @@ func EventListenerTrigger(ttName, apiVersion string, ops ...EventListenerTrigger
 		}
 
 		spec.Triggers = append(spec.Triggers, t)
+	}
+}
+
+// EventListenerTriggerRef adds an EventListenerTrigger with TriggerRef
+// to the EventListenerSpec Triggers.
+func EventListenerTriggerRef(trName string) EventListenerSpecOp {
+	return func(spec *v1alpha1.EventListenerSpec) {
+		spec.Triggers = append(spec.Triggers,
+			v1alpha1.EventListenerTrigger{TriggerRef: trName})
 	}
 }
 

--- a/test/builder/eventlistener_test.go
+++ b/test/builder/eventlistener_test.go
@@ -169,7 +169,7 @@ func TestEventListenerBuilder(t *testing.T) {
 						},
 						APIVersion: "v1alpha1",
 					}},
-					Template: v1alpha1.EventListenerTemplate{
+					Template: &v1alpha1.EventListenerTemplate{
 						Name:       "tt1",
 						APIVersion: "v1alpha1",
 					},
@@ -184,6 +184,24 @@ func TestEventListenerBuilder(t *testing.T) {
 				),
 			),
 		),
+	}, {
+		name: "One Trigger with one TriggerRef",
+		normal: &v1alpha1.EventListener{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Spec: v1alpha1.EventListenerSpec{
+				ServiceAccountName: "serviceAccount",
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					TriggerRef: "my-trigger",
+				}},
+			},
+		},
+		builder: EventListener("name", "namespace",
+			EventListenerSpec(
+				EventListenerServiceAccount("serviceAccount"),
+				EventListenerTriggerRef("my-trigger"))),
 	}, {
 		name: "One Trigger with one Binding",
 		normal: &v1alpha1.EventListener{
@@ -200,7 +218,7 @@ func TestEventListenerBuilder(t *testing.T) {
 						Ref:        "tb1",
 						APIVersion: "v1alpha1",
 					}},
-					Template: v1alpha1.EventListenerTemplate{
+					Template: &v1alpha1.EventListenerTemplate{
 						Name:       "tt1",
 						APIVersion: "v1alpha1",
 					},
@@ -231,7 +249,7 @@ func TestEventListenerBuilder(t *testing.T) {
 						Ref:        "tb1",
 						APIVersion: "v1alpha1",
 					}},
-					Template: v1alpha1.EventListenerTemplate{
+					Template: &v1alpha1.EventListenerTemplate{
 						Name:       "tt1",
 						APIVersion: "v1alpha1",
 					},
@@ -262,7 +280,7 @@ func TestEventListenerBuilder(t *testing.T) {
 						Ref:        "tb1",
 						APIVersion: "v1alpha1",
 					}},
-					Template: v1alpha1.EventListenerTemplate{
+					Template: &v1alpha1.EventListenerTemplate{
 						Name:       "tt1",
 						APIVersion: "v1alpha1",
 					},
@@ -302,7 +320,7 @@ func TestEventListenerBuilder(t *testing.T) {
 							APIVersion: "v1alpha1",
 						},
 					},
-					Template: v1alpha1.EventListenerTemplate{
+					Template: &v1alpha1.EventListenerTemplate{
 						Name:       "tt1",
 						APIVersion: "v1alpha1",
 					},
@@ -341,7 +359,7 @@ func TestEventListenerBuilder(t *testing.T) {
 						Ref:        "tb1",
 						APIVersion: "v1alpha1",
 					}},
-					Template: v1alpha1.EventListenerTemplate{
+					Template: &v1alpha1.EventListenerTemplate{
 						Name:       "tt1",
 						APIVersion: "v1alpha1",
 					},
@@ -352,7 +370,7 @@ func TestEventListenerBuilder(t *testing.T) {
 						Ref:        "tb2",
 						APIVersion: "v1alpha1",
 					}},
-					Template: v1alpha1.EventListenerTemplate{
+					Template: &v1alpha1.EventListenerTemplate{
 						Name:       "tt2",
 						APIVersion: "v1alpha1",
 					},
@@ -402,7 +420,7 @@ func TestEventListenerBuilder(t *testing.T) {
 						Ref:        "tb1",
 						APIVersion: "v1alpha1",
 					}},
-					Template: v1alpha1.EventListenerTemplate{
+					Template: &v1alpha1.EventListenerTemplate{
 						Name:       "tt1",
 						APIVersion: "v1alpha1",
 					},
@@ -455,7 +473,7 @@ func TestEventListenerBuilder(t *testing.T) {
 						Ref:        "tb1",
 						APIVersion: "v1alpha1",
 					}},
-					Template: v1alpha1.EventListenerTemplate{
+					Template: &v1alpha1.EventListenerTemplate{
 						Name:       "tt1",
 						APIVersion: "v1alpha1",
 					},
@@ -498,7 +516,7 @@ func TestEventListenerBuilder(t *testing.T) {
 						Ref:        "tb1",
 						APIVersion: "v1alpha1",
 					}},
-					Template: v1alpha1.EventListenerTemplate{
+					Template: &v1alpha1.EventListenerTemplate{
 						Name:       "tt1",
 						APIVersion: "v1alpha1",
 					},

--- a/test/controller_test.go
+++ b/test/controller_test.go
@@ -84,6 +84,18 @@ func TestGetResourcesFromClients(t *testing.T) {
 			Name:      "my-triggerTemplate2",
 		},
 	}
+	trigger1 := &v1alpha1.Trigger{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+			Name:      "my-trigger1",
+		},
+	}
+	trigger2 := &v1alpha1.Trigger{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+			Name:      "my-trigger2",
+		},
+	}
 	deployment1 := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "foo",
@@ -137,6 +149,7 @@ func TestGetResourcesFromClients(t *testing.T) {
 				EventListeners:         []*v1alpha1.EventListener{eventListener1},
 				TriggerBindings:        []*v1alpha1.TriggerBinding{triggerBinding1},
 				TriggerTemplates:       []*v1alpha1.TriggerTemplate{triggerTemplate1},
+				Triggers:               []*v1alpha1.Trigger{trigger1},
 				Deployments:            []*appsv1.Deployment{deployment1},
 				Services:               []*corev1.Service{service1},
 			},
@@ -149,6 +162,7 @@ func TestGetResourcesFromClients(t *testing.T) {
 				EventListeners:         []*v1alpha1.EventListener{eventListener1, eventListener2},
 				TriggerBindings:        []*v1alpha1.TriggerBinding{triggerBinding1, triggerBinding2},
 				TriggerTemplates:       []*v1alpha1.TriggerTemplate{triggerTemplate1, triggerTemplate2},
+				Triggers:               []*v1alpha1.Trigger{trigger1, trigger2},
 				Deployments:            []*appsv1.Deployment{deployment1, deployment2},
 				Services:               []*corev1.Service{service1, service2},
 			},

--- a/test/eventlistener_scale_test.go
+++ b/test/eventlistener_scale_test.go
@@ -72,7 +72,7 @@ func TestEventListenerScale(t *testing.T) {
 				Ref:        "tb1",
 				APIVersion: "v1alpha1",
 			}},
-			Template: triggersv1.EventListenerTemplate{
+			Template: &triggersv1.EventListenerTemplate{
 				Name:       "my-triggertemplate",
 				APIVersion: "v1alpha1",
 			},


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Support for adding Trigger CR Object as Ref to EventListenerSpec

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Now, Trigger CRD object can be used to just specify trigger inside the EventListener using `triggerRef`

```
