### PR TITLE
Remove vendor-specific cluster setup instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -14,26 +14,20 @@ Use this page to add the component to an existing Kubernetes cluster.
 
 ## Pre-requisites
 
-1.  A Kubernetes cluster version 1.15 or later (_if you don't have an existing
-    cluster_):
+1.  A Kubernetes cluster version 1.15 or later
 
-    ```bash
-    # Example cluster creation command on GKE
-    gcloud container clusters create $CLUSTER_NAME \
-      --zone=$CLUSTER_ZONE
-    ```
+    If you don't already have a cluster, you can create one for testing with
+    `kind`.  [Install
+    `kind`](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) and
+    create a cluster by running [`kind create
+    cluster`](https://kind.sigs.k8s.io/docs/user/quick-start/#creating-a-cluster).
+    This will create a cluster running locally, with RBAC enabled.
 
-1.  Grant cluster-admin permissions to the current user:
-
-    ```bash
-    kubectl create clusterrolebinding cluster-admin-binding \
-    --clusterrole=cluster-admin \
-    --user=$(gcloud config get-value core/account)
-    ```
+1.  Grant current user `cluster-admin` privileges.
 
     _See
     [Role-based access control](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#prerequisites_for_using_role-based_access_control)
-    for more information_.
+    for more information._
 
 1.  Install Tekton Pipelines. You can install the latest version using the
     command below or follow the
@@ -42,6 +36,7 @@ Use this page to add the component to an existing Kubernetes cluster.
     ```bash
     kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
     ```
+
 
 ## Versions
 


### PR DESCRIPTION
Instead, assume a cluster already exists, or briefly document using
`kind` to set up a local cluster for testing.

Rationale for this change is outlined in this doc (shared with tekton-dev@): https://docs.google.com/document/d/1sMt06g40Jt0Pr5g0Rgfe02az1A9FAFme8mf962UuSEQ/edit

See also https://github.com/tektoncd/website/pull/167

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [y] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
