### PR TITLE
Add basic syntactical parsing of CEL filters and expressions.

### DIFF
--- a/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
@@ -372,6 +372,22 @@ func TestEventListenerValidate_error(t *testing.T) {
 			},
 		},
 	}, {
+		name: "CEL interceptor with bad filter expression",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tt", "v1alpha1",
+					bldr.EventListenerTriggerBinding("tb", "", "tb", "v1alpha1"),
+					bldr.EventListenerCELInterceptor("body.value == 'test')"),
+				))),
+	}, {
+		name: "CEL interceptor with bad overlay expression",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tt", "v1alpha1",
+					bldr.EventListenerTriggerBinding("tb", "", "tb", "v1alpha1"),
+					bldr.EventListenerCELInterceptor("", bldr.EventListenerCELOverlay("body.value", "'testing')")),
+				))),
+	}, {
 		name: "Triggers name has invalid label characters",
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(


### PR DESCRIPTION
# Changes

This does basic syntax checking of CEL interceptor Filters and Overlays.

This would fix this https://tektoncd.slack.com/archives/CKUSJ2A5D/p1599486079009700

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Perform simple syntax checking of CEL filter and overlays in the Webhook validator.

This performs perfunctory syntax validation of the expressions in the interceptor, it won't detect logical errors (expressions that rely on JSON bodies).
```