### PR TITLE
Handle validation, defaults and working behavior for Replicas 

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -175,9 +175,9 @@ check out the guide on [exposing EventListeners](./exposing-eventlisteners.md).
 ### Replicas
 
 The `replicas` field is optional. By default, the number of replicas of EventListener is 1.
-If you want to deploy more than one pod, you can specify the number to this field. 
+If you want to deploy more than one pod, you can specify the number to `replicas` field.
 
-**Note:** If user sets `replicas` field while creating eventlistener yaml then it won't respects replicas values edited by user manually or through any other mechanism (ex: HPA).
+**Note:** If user sets `replicas` field while creating/updating eventlistener yaml then it won't respects replicas values edited by user manually on deployment or through any other mechanism (ex: HPA).
 
 ### PodTemplate
 

--- a/pkg/apis/triggers/v1alpha1/event_listener_defaults.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_defaults.go
@@ -24,6 +24,9 @@ import (
 func (el *EventListener) SetDefaults(ctx context.Context) {
 	if IsUpgradeViaDefaulting(ctx) {
 		// set defaults
+		if el.Spec.Replicas != nil && *el.Spec.Replicas == 0 {
+			*el.Spec.Replicas = 1
+		}
 		for i := range el.Spec.Triggers {
 			triggerSpecBindingArray(el.Spec.Triggers[i].Bindings).
 				defaultBindings()

--- a/pkg/apis/triggers/v1alpha1/event_listener_defaults_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_defaults_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	"knative.dev/pkg/ptr"
 )
 
 func TestEventListenerSetDefaults(t *testing.T) {
@@ -70,6 +71,32 @@ func TestEventListenerSetDefaults(t *testing.T) {
 						},
 					},
 				}},
+			},
+		},
+	}, {
+		name: "set replicas to 1 if provided replicas is 0 as part of eventlistener spec",
+		in: &v1alpha1.EventListener{
+			Spec: v1alpha1.EventListenerSpec{
+				Replicas: ptr.Int32(0),
+			},
+		},
+		wc: v1alpha1.WithUpgradeViaDefaulting,
+		want: &v1alpha1.EventListener{
+			Spec: v1alpha1.EventListenerSpec{
+				Replicas: ptr.Int32(1),
+			},
+		},
+	}, {
+		name: "different value for replicas other than 0",
+		in: &v1alpha1.EventListener{
+			Spec: v1alpha1.EventListenerSpec{
+				Replicas: ptr.Int32(2),
+			},
+		},
+		wc: v1alpha1.WithUpgradeViaDefaulting,
+		want: &v1alpha1.EventListener{
+			Spec: v1alpha1.EventListenerSpec{
+				Replicas: ptr.Int32(2),
 			},
 		},
 	}}

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation.go
@@ -31,7 +31,7 @@ func (e *EventListener) Validate(ctx context.Context) *apis.FieldError {
 
 func (s *EventListenerSpec) validate(ctx context.Context) *apis.FieldError {
 	if s.Replicas != nil {
-		if *s.Replicas <= 0 {
+		if *s.Replicas < 0 {
 			return apis.ErrInvalidValue(*s.Replicas, "spec.replicas")
 		}
 	}

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
@@ -425,10 +425,10 @@ func TestEventListenerValidate_error(t *testing.T) {
 					bldr.EventListenerTriggerName("1234567890123456789012345678901234567890123456789012345678901234"),
 				))),
 	}, {
-		name: "user specify invalid replicas which are 0 and negative values",
+		name: "user specify invalid replicas",
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
-				bldr.EventListenerReplicas(0),
+				bldr.EventListenerReplicas(-1),
 				bldr.EventListenerTrigger("tt", "v1alpha1",
 					bldr.EventListenerTriggerBinding("tb", "TriggerBinding", "tb", "v1alpha1"),
 				))),

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
@@ -343,9 +343,12 @@ func (r *Reconciler) reconcileDeployment(logger *zap.SugaredLogger, el *v1alpha1
 
 		// Determine if reconciliation has to occur
 		updated := reconcileObjectMeta(&existingDeployment.ObjectMeta, deployment.ObjectMeta)
-		if existingDeployment.Spec.Replicas != deployment.Spec.Replicas {
-			existingDeployment.Spec.Replicas = replicas
-			updated = true
+		if *existingDeployment.Spec.Replicas != *deployment.Spec.Replicas {
+			if el.Spec.Replicas != nil {
+				existingDeployment.Spec.Replicas = replicas
+				updated = true
+			}
+			// if no replicas found as part of el.Spec then replicas from existingDeployment will be considered
 		}
 		if existingDeployment.Spec.Selector != deployment.Spec.Selector {
 			existingDeployment.Spec.Selector = deployment.Spec.Selector


### PR DESCRIPTION
# Changes

1. PR fixes https://github.com/tektoncd/triggers/issues/750
2. Edit operation for `replicas` on deployment was not working eventhough `replicas` not provided as part of `el.spec`.

That means if user don't specify `replicas` as part of `el.spec` then the edit operation on deployment should be success(edit operation on deployments can be done manually or any other mechanism ex: HPA).
as per the discussion from this PR https://github.com/tektoncd/triggers/pull/715#discussion_r472392787

Signed-off-by: Savita Ashture sashture@redhat.com

/cc @dibyom 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

1. End user have a flexibility to set `replicas` as part of eventlistener spec
2. If no `replicas` set on eventlistener  spec then user can do edit operation on deployment manually or by any other mechanism (ex: HPA)
3. If user provide negative value to `replicas` validation will fail and provide below error
```  
Error from server (BadRequest): error when creating "STDIN": admission webhook "validation.webhook.triggers.tekton.dev" denied the request: validation failed: invalid value: -1: spec.replicas
```
4. If user provide replicas value as `0` then a default value `1` will be set by webhook
 
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

    ```release-note
    Your release note here
    ```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->
