### PR TITLE
Use refs instead of name to refer to Bindings

### DIFF
--- a/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
@@ -50,37 +50,37 @@ func Test_EventListenerValidate(t *testing.T) {
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "TriggerBinding", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "TriggerBinding", "", "v1alpha1"),
 				))),
 	}, {
 		name: "Valid EventListener with ClusterTriggerBinding",
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "ClusterTriggerBinding", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "ClusterTriggerBinding", "", "v1alpha1"),
 				))),
 	}, {
 		name: "Valid EventListener with multiple TriggerBindings",
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb1", "ClusterTriggerBinding", "tb1", "v1alpha1"),
-					bldr.EventListenerTriggerBinding("tb2", "TriggerBinding", "tb2", "v1alpha1"),
-					bldr.EventListenerTriggerBinding("tb3", "", "tb3", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb1", "ClusterTriggerBinding", "", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb2", "TriggerBinding", "", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb3", "", "", "v1alpha1"),
 				))),
 	}, {
 		name: "Valid EventListener No Interceptor",
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "", "v1alpha1"),
 				))),
 	}, {
 		name: "Valid EventListener Interceptor",
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "", "v1alpha1"),
 					bldr.EventListenerTriggerInterceptor("svc", "v1", "Service", "namespace"),
 				))),
 	}, {
@@ -88,7 +88,7 @@ func Test_EventListenerValidate(t *testing.T) {
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "", "v1alpha1"),
 					bldr.EventListenerTriggerInterceptor("svc", "v1", "Service", "namespace",
 						bldr.EventInterceptorParam("Valid-Header-Key", "valid value"),
 					),
@@ -98,7 +98,7 @@ func Test_EventListenerValidate(t *testing.T) {
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "", "v1alpha1"),
 					bldr.EventListenerTriggerInterceptor("svc", "v1", "Service", "namespace",
 						bldr.EventInterceptorParam("Valid-Header-Key1", "valid value1"),
 						bldr.EventInterceptorParam("Valid-Header-Key1", "valid value2"),
@@ -110,18 +110,18 @@ func Test_EventListenerValidate(t *testing.T) {
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "", "v1alpha1"),
 					bldr.EventListenerTriggerInterceptor("svc", "v1", "Service", "namespace"),
 				),
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "", "v1alpha1"),
 				))),
 	}, {
 		name: "Valid EventListener with CEL interceptor",
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "", "v1alpha1"),
 					bldr.EventListenerCELInterceptor("body.value == 'test'"),
 				))),
 	}, {
@@ -129,7 +129,7 @@ func Test_EventListenerValidate(t *testing.T) {
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "", "v1alpha1"),
 				))),
 	}, {
 		name: "Valid EventListener with embedded bindings",
@@ -143,7 +143,7 @@ func Test_EventListenerValidate(t *testing.T) {
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "", "v1alpha1"),
 					bldr.EventListenerCELInterceptor("", bldr.EventListenerCELOverlay("body.value", "'testing'")),
 				))),
 	}}

--- a/pkg/apis/triggers/v1alpha1/trigger_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_validation_test.go
@@ -40,30 +40,30 @@ func Test_TriggerValidate(t *testing.T) {
 		tr: bldr.Trigger("name", "namespace",
 			bldr.TriggerSpec(
 				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "TriggerBinding", "tb", "v1alpha1"),
+				bldr.TriggerSpecBinding("tb", "TriggerBinding", "", "v1alpha1"),
 			)),
 	}, {
 		name: "Valid Trigger with ClusterTriggerBinding",
 		tr: bldr.Trigger("name", "namespace",
 			bldr.TriggerSpec(
 				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "ClusterTriggerBinding", "tb", "v1alpha1"),
+				bldr.TriggerSpecBinding("tb", "ClusterTriggerBinding", "", "v1alpha1"),
 			)),
 	}, {
 		name: "Valid Trigger with multiple TriggerBindings",
 		tr: bldr.Trigger("name", "namespace",
 			bldr.TriggerSpec(
 				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "ClusterTriggerBinding", "tb", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "TriggerBinding", "tb", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb3", "", "tb3", "v1alpha1"),
+				bldr.TriggerSpecBinding("tb", "ClusterTriggerBinding", "", "v1alpha1"),
+				bldr.TriggerSpecBinding("tb", "TriggerBinding", "", "v1alpha1"),
+				bldr.TriggerSpecBinding("tb3", "", "", "v1alpha1"),
 			)),
 	}, {
 		name: "Valid Trigger Interceptor",
 		tr: bldr.Trigger("name", "namespace",
 			bldr.TriggerSpec(
 				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "", "tb", "v1alpha1"),
+				bldr.TriggerSpecBinding("tb", "", "", "v1alpha1"),
 				bldr.TriggerSpecInterceptor("svc", "v1", "Service", "namespace"),
 			)),
 	}, {
@@ -71,7 +71,7 @@ func Test_TriggerValidate(t *testing.T) {
 		tr: bldr.Trigger("name", "namespace",
 			bldr.TriggerSpec(
 				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "", "tb", "v1alpha1"),
+				bldr.TriggerSpecBinding("tb", "", "", "v1alpha1"),
 				bldr.TriggerSpecInterceptor("svc", "v1", "Service", "namespace",
 					bldr.TriggerSpecInterceptorParam("Valid-Header-Key", "valid value"),
 				),
@@ -81,7 +81,7 @@ func Test_TriggerValidate(t *testing.T) {
 		tr: bldr.Trigger("name", "namespace",
 			bldr.TriggerSpec(
 				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "", "tb", "v1alpha1"),
+				bldr.TriggerSpecBinding("tb", "", "", "v1alpha1"),
 				bldr.TriggerSpecInterceptor("svc", "v1", "Service", "namespace",
 					bldr.TriggerSpecInterceptorParam("Valid-Header-Key1", "valid value1"),
 					bldr.TriggerSpecInterceptorParam("Valid-Header-Key1", "valid value2"),
@@ -89,11 +89,11 @@ func Test_TriggerValidate(t *testing.T) {
 				),
 			)),
 	}, {
-		name: "Valid Trigger with CTR interceptor",
+		name: "Valid Trigger with CEL interceptor",
 		tr: bldr.Trigger("name", "namespace",
 			bldr.TriggerSpec(
 				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "", "tb", "v1alpha1"),
+				bldr.TriggerSpecBinding("tb", "", "", "v1alpha1"),
 				bldr.TriggerSpecCELInterceptor("body.value == 'test'"),
 			)),
 	}, {
@@ -101,10 +101,10 @@ func Test_TriggerValidate(t *testing.T) {
 		tr: bldr.Trigger("name", "namespace",
 			bldr.TriggerSpec(
 				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "", "tb", "v1alpha1"),
+				bldr.TriggerSpecBinding("tb", "", "", "v1alpha1"),
 			)),
 	}, {
-		name: "Valid Trigger with embedded bindings",
+		name: "Valid Trigger with old embedded bindings",
 		tr: bldr.Trigger("name", "namespace",
 			bldr.TriggerSpec(
 				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
@@ -115,7 +115,7 @@ func Test_TriggerValidate(t *testing.T) {
 		tr: bldr.Trigger("name", "namespace",
 			bldr.TriggerSpec(
 				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "", "tb", "v1alpha1"),
+				bldr.TriggerSpecBinding("tb", "", "", "v1alpha1"),
 				bldr.TriggerSpecCELInterceptor("", bldr.TriggerSpecCELOverlay("body.value", "'testing'")),
 			)),
 	}}

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -406,7 +406,7 @@ func TestHandleEventWithInterceptors(t *testing.T) {
 		},
 		Spec: triggersv1.EventListenerSpec{
 			Triggers: []triggersv1.EventListenerTrigger{{
-				Bindings: []*triggersv1.EventListenerBinding{{Name: "tb", Kind: "TriggerBinding"}},
+				Bindings: []*triggersv1.EventListenerBinding{{Ref: "tb", Kind: "TriggerBinding"}},
 				Template: &triggersv1.EventListenerTemplate{Name: "tt"},
 				Interceptors: []*triggersv1.EventInterceptor{{
 					GitHub: &triggersv1.GitHubInterceptor{
@@ -533,7 +533,7 @@ func TestHandleEventPassesURLThrough(t *testing.T) {
 		},
 		Spec: triggersv1.EventListenerSpec{
 			Triggers: []triggersv1.EventListenerTrigger{{
-				Bindings: []*triggersv1.EventListenerBinding{{Name: "tb", Kind: "TriggerBinding"}},
+				Bindings: []*triggersv1.EventListenerBinding{{Ref: "tb", Kind: "TriggerBinding"}},
 				Template: &triggersv1.EventListenerTemplate{Name: "tt"},
 				Interceptors: []*triggersv1.EventInterceptor{{
 					CEL: &triggersv1.CELInterceptor{
@@ -647,7 +647,7 @@ func TestHandleEventWithWebhookInterceptors(t *testing.T) {
 	var triggers []triggersv1.EventListenerTrigger
 	for i := 0; i < numTriggers; i++ {
 		trigger := triggersv1.EventListenerTrigger{
-			Bindings: []*triggersv1.EventListenerBinding{{Name: "tb", Kind: "TriggerBinding"}},
+			Bindings: []*triggersv1.EventListenerBinding{{Ref: "tb", Kind: "TriggerBinding"}},
 			Template: &triggersv1.EventListenerTemplate{Name: "tt"},
 			Interceptors: []*triggersv1.EventInterceptor{{
 				Webhook: &triggersv1.WebhookInterceptor{
@@ -990,7 +990,7 @@ func TestHandleEventWithInterceptorsAndTriggerAuth(t *testing.T) {
 			Spec: triggersv1.EventListenerSpec{
 				Triggers: []triggersv1.EventListenerTrigger{{
 					ServiceAccountName: testCase.userVal,
-					Bindings:           []*triggersv1.EventListenerBinding{{Name: "tb", Kind: "TriggerBinding"}},
+					Bindings:           []*triggersv1.EventListenerBinding{{Ref: "tb", Kind: "TriggerBinding"}},
 					Template:           &triggersv1.EventListenerTemplate{Name: "tt"},
 					Interceptors: []*triggersv1.EventInterceptor{{
 						GitHub: &triggersv1.GitHubInterceptor{
@@ -1078,7 +1078,7 @@ func TestHandleEventWithBitbucketInterceptors(t *testing.T) {
 		Spec: triggersv1.EventListenerSpec{
 			Triggers: []triggersv1.EventListenerTrigger{{
 				ServiceAccountName: userWithPermissions,
-				Bindings:           []*triggersv1.EventListenerBinding{{Name: "tb", Kind: "TriggerBinding"}},
+				Bindings:           []*triggersv1.EventListenerBinding{{Ref: "tb", Kind: "TriggerBinding"}},
 				Template:           &triggersv1.EventListenerTemplate{Name: "tt"},
 				Interceptors: []*triggersv1.EventInterceptor{{
 					Bitbucket: &triggersv1.BitbucketInterceptor{

--- a/test/eventlistener_scale_test.go
+++ b/test/eventlistener_scale_test.go
@@ -67,7 +67,6 @@ func TestEventListenerScale(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		trigger := triggersv1.EventListenerTrigger{
 			Bindings: []*triggersv1.EventListenerBinding{{
-				Name:       "my-triggerbinding",
 				Kind:       triggersv1.NamespacedTriggerBindingKind,
 				Ref:        "tb1",
 				APIVersion: "v1alpha1",


### PR DESCRIPTION
# Changes

There were still a few tests that were referring to bindings using `name`
instead of `ref`. This PR cleans up those usages.

Signed-off-by: Dibyo Mukherjee <dibyo@google.com>

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
    NONE
```
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

    ```release-note
    Your release note here
    ```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->
