### PR TITLE
Add Error Msg and BadRequest for Parsing error

### DIFF
--- a/pkg/template/event.go
+++ b/pkg/template/event.go
@@ -25,6 +25,11 @@ import (
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 )
 
+const (
+	jsonPathErr = "failed to replace JSONPath value for param"
+	marshalErr  = "failed to marshal event"
+)
+
 // ResolveParams takes given triggerbindings and produces the resulting
 // resource params.
 func ResolveParams(rt ResolvedTrigger, body []byte, header http.Header) ([]triggersv1.Param, error) {
@@ -87,7 +92,7 @@ func newEvent(body []byte, headers http.Header) (*event, error) {
 func applyEventValuesToParams(params []triggersv1.Param, body []byte, header http.Header) ([]triggersv1.Param, error) {
 	event, err := newEvent(body, header)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal event: %w", err)
+		return nil, fmt.Errorf("%s: %w", marshalErr, err)
 	}
 
 	for idx, p := range params {
@@ -97,11 +102,22 @@ func applyEventValuesToParams(params []triggersv1.Param, body []byte, header htt
 		for i, expr := range expressions {
 			val, err := ParseJSONPath(event, expr)
 			if err != nil {
-				return nil, fmt.Errorf("failed to replace JSONPath value for param %s: %s: %w", p.Name, p.Value, err)
+				return nil, fmt.Errorf("%s %s: %s: %w", jsonPathErr, p.Name, p.Value, err)
 			}
 			pValue = strings.ReplaceAll(pValue, originals[i], val)
 		}
 		params[idx].Value = pValue
 	}
 	return params, nil
+}
+
+// IsParseErr determines if err is an error which indicates that parsing event failed
+func IsParseErr(err error) bool {
+	if strings.Contains(err.Error(), jsonPathErr) {
+		return true
+	}
+	if strings.Contains(err.Error(), marshalErr) {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
This fixes EventListener Error Response during Parsing to return
400 when marshaling error occurs or JsonPath error is encountered.
Fixes: #656

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

    ```release-note
    Your release note here
    ```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->
