### PR TITLE
Fix Binding builder to only use ref

### DIFF
--- a/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
@@ -51,37 +51,37 @@ func Test_EventListenerValidate(t *testing.T) {
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "TriggerBinding", "", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "TriggerBinding", "v1alpha1"),
 				))),
 	}, {
 		name: "Valid EventListener with ClusterTriggerBinding",
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "ClusterTriggerBinding", "", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "ClusterTriggerBinding", "v1alpha1"),
 				))),
 	}, {
 		name: "Valid EventListener with multiple TriggerBindings",
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb1", "ClusterTriggerBinding", "", "v1alpha1"),
-					bldr.EventListenerTriggerBinding("tb2", "TriggerBinding", "", "v1alpha1"),
-					bldr.EventListenerTriggerBinding("tb3", "", "", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb1", "ClusterTriggerBinding", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb2", "TriggerBinding", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb3", "", "v1alpha1"),
 				))),
 	}, {
 		name: "Valid EventListener No Interceptor",
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "v1alpha1"),
 				))),
 	}, {
 		name: "Valid EventListener Interceptor",
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "v1alpha1"),
 					bldr.EventListenerTriggerInterceptor("svc", "v1", "Service", "namespace"),
 				))),
 	}, {
@@ -89,7 +89,7 @@ func Test_EventListenerValidate(t *testing.T) {
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "v1alpha1"),
 					bldr.EventListenerTriggerInterceptor("svc", "v1", "Service", "namespace",
 						bldr.EventInterceptorParam("Valid-Header-Key", "valid value"),
 					),
@@ -99,7 +99,7 @@ func Test_EventListenerValidate(t *testing.T) {
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "v1alpha1"),
 					bldr.EventListenerTriggerInterceptor("svc", "v1", "Service", "namespace",
 						bldr.EventInterceptorParam("Valid-Header-Key1", "valid value1"),
 						bldr.EventInterceptorParam("Valid-Header-Key1", "valid value2"),
@@ -111,18 +111,18 @@ func Test_EventListenerValidate(t *testing.T) {
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "v1alpha1"),
 					bldr.EventListenerTriggerInterceptor("svc", "v1", "Service", "namespace"),
 				),
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "v1alpha1"),
 				))),
 	}, {
 		name: "Valid EventListener with CEL interceptor",
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "v1alpha1"),
 					bldr.EventListenerCELInterceptor("body.value == 'test'"),
 				))),
 	}, {
@@ -130,30 +130,43 @@ func Test_EventListenerValidate(t *testing.T) {
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "v1alpha1"),
 				))),
 	}, {
 		name: "Valid EventListener with embedded bindings",
-		el: bldr.EventListener("name", "namespace",
-			bldr.EventListenerSpec(
-				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("", "", "", "v1alpha1", bldr.TriggerBindingParam("key", "value")),
-				))),
+		el: &v1alpha1.EventListener{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "ns",
+			},
+			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					Template: &v1alpha1.EventListenerTemplate{Name: "tt"},
+					Bindings: []*v1alpha1.EventListenerBinding{{
+						Name: "bname",
+						Spec: &v1alpha1.TriggerBindingSpec{
+							Params: []v1alpha1.Param{{
+								Name:  "key",
+								Value: "value",
+							}},
+						},
+					}},
+				}},
+			},
+		},
 	}, {
 		name: "Valid EventListener with CEL overlays",
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "v1alpha1"),
 					bldr.EventListenerCELInterceptor("", bldr.EventListenerCELOverlay("body.value", "'testing'")),
 				))),
 	}, {
 		name: "Valid EventListener with kubernetes resource for podspec",
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
-				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "TriggerBinding", "tb", "v1alpha1"),
-				),
+				bldr.EventListenerTrigger("tt", "v1alpha1"),
 				bldr.EventListenerResources(
 					bldr.EventListenerKubernetesResources(
 						bldr.EventListenerPodSpec(duckv1.WithPodSpec{
@@ -220,17 +233,10 @@ func TestEventListenerValidate_error(t *testing.T) {
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("", "", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("", "", "v1alpha1"),
 				))),
 	}, {
 		name: "TriggerBinding with both ref and spec",
-		el: bldr.EventListener("name", "namespace",
-			bldr.EventListenerSpec(
-				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "tb", "v1alpha1", bldr.TriggerBindingParam("key", "value")),
-				))),
-	}, {
-		name: "Bindings missing name",
 		el: &v1alpha1.EventListener{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "name",
@@ -238,7 +244,30 @@ func TestEventListenerValidate_error(t *testing.T) {
 			},
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
-					Bindings: []*v1alpha1.EventListenerBinding{{Name: "", Kind: v1alpha1.NamespacedTriggerBindingKind}},
+					Template: &v1alpha1.EventListenerTemplate{Name: "tt"},
+					Bindings: []*v1alpha1.EventListenerBinding{{
+						Ref:  "tb",
+						Name: "",
+						Spec: &v1alpha1.TriggerBindingSpec{
+							Params: []v1alpha1.Param{{
+								Name:  "key",
+								Value: "value",
+							}},
+						},
+					}},
+				}},
+			},
+		},
+	}, {
+		name: "Bindings invalid ref",
+		el: &v1alpha1.EventListener{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					Bindings: []*v1alpha1.EventListenerBinding{{Ref: "", Kind: v1alpha1.NamespacedTriggerBindingKind}},
 					Template: &v1alpha1.EventListenerTemplate{Name: "tt"},
 				}},
 			},
@@ -252,7 +281,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			},
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
-					Bindings: []*v1alpha1.EventListenerBinding{{Name: "tb", Kind: ""}},
+					Bindings: []*v1alpha1.EventListenerBinding{{Ref: "tb", Kind: ""}},
 					Template: &v1alpha1.EventListenerTemplate{Name: "tt"},
 				}},
 			},
@@ -266,7 +295,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			},
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
-					Bindings: []*v1alpha1.EventListenerBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
+					Bindings: []*v1alpha1.EventListenerBinding{{Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
 					Template: &v1alpha1.EventListenerTemplate{Name: "tt", APIVersion: "invalid"},
 				}},
 			},
@@ -280,7 +309,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			},
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
-					Bindings: []*v1alpha1.EventListenerBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
+					Bindings: []*v1alpha1.EventListenerBinding{{Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
 					Template: &v1alpha1.EventListenerTemplate{Name: "", APIVersion: "v1alpha1"},
 				}},
 			},
@@ -290,7 +319,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "v1alpha1"),
 					bldr.EventListenerTriggerInterceptor("svc", "", "", ""),
 				))),
 	}, {
@@ -302,7 +331,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			},
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
-					Bindings:     []*v1alpha1.EventListenerBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
+					Bindings:     []*v1alpha1.EventListenerBinding{{Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
 					Template:     &v1alpha1.EventListenerTemplate{Name: "tt"},
 					Interceptors: []*v1alpha1.EventInterceptor{{}},
 				}},
@@ -317,7 +346,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			},
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
-					Bindings: []*v1alpha1.EventListenerBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
+					Bindings: []*v1alpha1.EventListenerBinding{{Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
 					Template: &v1alpha1.EventListenerTemplate{Name: "tt"},
 					Interceptors: []*v1alpha1.EventInterceptor{{
 						Webhook: &v1alpha1.WebhookInterceptor{
@@ -334,14 +363,14 @@ func TestEventListenerValidate_error(t *testing.T) {
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "NamespaceTriggerBinding", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "NamespaceTriggerBinding", "v1alpha1"),
 				))),
 	}, {
 		name: "Interceptor Wrong APIVersion",
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "v1alpha1"),
 					bldr.EventListenerTriggerInterceptor("foo", "v3", "Service", ""),
 				))),
 	}, {
@@ -349,7 +378,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "v1alpha1"),
 					bldr.EventListenerTriggerInterceptor("foo", "v1", "Deployment", ""),
 				))),
 	}, {
@@ -357,7 +386,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "v1alpha1"),
 					bldr.EventListenerTriggerInterceptor("foo", "v1", "Deployment", "",
 						bldr.EventInterceptorParam("non-canonical-header-key", "valid value"),
 					),
@@ -367,7 +396,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "v1alpha1"),
 					bldr.EventListenerTriggerInterceptor("foo", "v1", "Deployment", "",
 						bldr.EventInterceptorParam("", "valid value"),
 					),
@@ -377,7 +406,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "v1alpha1"),
 					bldr.EventListenerTriggerInterceptor("foo", "v1", "Deployment", "",
 						bldr.EventInterceptorParam("Valid-Header-Key", ""),
 					),
@@ -391,7 +420,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			},
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
-					Bindings: []*v1alpha1.EventListenerBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
+					Bindings: []*v1alpha1.EventListenerBinding{{Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
 					Template: &v1alpha1.EventListenerTemplate{Name: "tt"},
 					Interceptors: []*v1alpha1.EventInterceptor{{
 						GitHub:    &v1alpha1.GitHubInterceptor{},
@@ -410,7 +439,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			},
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
-					Bindings: []*v1alpha1.EventListenerBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
+					Bindings: []*v1alpha1.EventListenerBinding{{Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
 					Template: &v1alpha1.EventListenerTemplate{Name: "tt"},
 					Interceptors: []*v1alpha1.EventInterceptor{{
 						CEL: &v1alpha1.CELInterceptor{},
@@ -423,7 +452,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "v1alpha1"),
 					bldr.EventListenerCELInterceptor("body.value == 'test')"),
 				))),
 	}, {
@@ -431,7 +460,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "v1alpha1"),
 					bldr.EventListenerCELInterceptor("", bldr.EventListenerCELOverlay("body.value", "'testing')")),
 				))),
 	}, {
@@ -439,7 +468,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "v1alpha1"),
 					bldr.EventListenerTriggerName("github.com/tektoncd/triggers"),
 				))),
 	}, {
@@ -447,7 +476,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "", "v1alpha1"),
 					bldr.EventListenerTriggerName("1234567890123456789012345678901234567890123456789012345678901234"),
 				))),
 	}, {
@@ -456,14 +485,14 @@ func TestEventListenerValidate_error(t *testing.T) {
 			bldr.EventListenerSpec(
 				bldr.EventListenerReplicas(-1),
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "TriggerBinding", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "TriggerBinding", "v1alpha1"),
 				))),
 	}, {
 		name: "user specify multiple containers",
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "TriggerBinding", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "TriggerBinding", "v1alpha1"),
 				),
 				bldr.EventListenerResources(
 					bldr.EventListenerKubernetesResources(
@@ -471,13 +500,9 @@ func TestEventListenerValidate_error(t *testing.T) {
 							Template: duckv1.PodSpecable{
 								Spec: corev1.PodSpec{
 									Containers: []corev1.Container{{
-										Env: []corev1.EnvVar{{
-											Name: "HTTP",
-										}},
+										Env: []corev1.EnvVar{{Name: "HTTP"}},
 									}, {
-										Env: []corev1.EnvVar{{
-											Name: "TCP",
-										}},
+										Env: []corev1.EnvVar{{Name: "TCP"}},
 									}},
 								},
 							},
@@ -489,7 +514,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "TriggerBinding", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "TriggerBinding", "v1alpha1"),
 				),
 				bldr.EventListenerResources(
 					bldr.EventListenerKubernetesResources(
@@ -507,7 +532,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
-					bldr.EventListenerTriggerBinding("tb", "TriggerBinding", "tb", "v1alpha1"),
+					bldr.EventListenerTriggerBinding("tb", "TriggerBinding", "v1alpha1"),
 				),
 				bldr.EventListenerResources(
 					bldr.EventListenerKubernetesResources(

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -198,7 +198,7 @@ func TestHandleEvent(t *testing.T) {
 		tbs = append(tbs, tb)
 		// Add TriggerBinding to trigger in EventListener
 		trigger := bldr.EventListenerTrigger("my-triggertemplate", "v1alpha1",
-			bldr.EventListenerTriggerBinding(tbName, "", tbName, "v1alpha1"),
+			bldr.EventListenerTriggerBinding(tbName, "", "v1alpha1"),
 		)
 		triggers = append(triggers, trigger)
 	}

--- a/test/builder/eventlistener.go
+++ b/test/builder/eventlistener.go
@@ -226,10 +226,9 @@ func EventListenerTriggerServiceAccount(saName, namespace string) EventListenerT
 }
 
 // EventListenerTriggerBinding adds a Binding to the Trigger in EventListenerSpec Triggers.
-func EventListenerTriggerBinding(ref, kind, name, apiVersion string, ops ...TriggerBindingSpecOp) EventListenerTriggerOp {
+func EventListenerTriggerBinding(ref, kind, apiVersion string, ops ...TriggerBindingSpecOp) EventListenerTriggerOp {
 	return func(trigger *v1alpha1.EventListenerTrigger) {
 		binding := &v1alpha1.EventListenerBinding{
-			Name:       name,
 			APIVersion: apiVersion,
 		}
 

--- a/test/builder/eventlistener_test.go
+++ b/test/builder/eventlistener_test.go
@@ -149,43 +149,6 @@ func TestEventListenerBuilder(t *testing.T) {
 			),
 		),
 	}, {
-		name: "One Trigger with one embedded Binding",
-		normal: &v1alpha1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
-			Spec: v1alpha1.EventListenerSpec{
-				ServiceAccountName: "serviceAccount",
-				Triggers: []v1alpha1.EventListenerTrigger{{
-					Bindings: []*v1alpha1.EventListenerBinding{{
-						Name: "tb1",
-						Spec: &v1alpha1.TriggerBindingSpec{
-							Params: []v1alpha1.Param{
-								{
-									Name:  "key",
-									Value: "value",
-								},
-							},
-						},
-						APIVersion: "v1alpha1",
-					}},
-					Template: &v1alpha1.EventListenerTemplate{
-						Name:       "tt1",
-						APIVersion: "v1alpha1",
-					},
-				}},
-			},
-		},
-		builder: EventListener("name", "namespace",
-			EventListenerSpec(
-				EventListenerServiceAccount("serviceAccount"),
-				EventListenerTrigger("tt1", "v1alpha1",
-					EventListenerTriggerBinding("", "", "tb1", "v1alpha1", TriggerBindingParam("key", "value")),
-				),
-			),
-		),
-	}, {
 		name: "One Trigger with one TriggerRef",
 		normal: &v1alpha1.EventListener{
 			ObjectMeta: metav1.ObjectMeta{
@@ -214,7 +177,6 @@ func TestEventListenerBuilder(t *testing.T) {
 				ServiceAccountName: "serviceAccount",
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{
-						Name:       "tb1",
 						Kind:       v1alpha1.NamespacedTriggerBindingKind,
 						Ref:        "tb1",
 						APIVersion: "v1alpha1",
@@ -230,7 +192,7 @@ func TestEventListenerBuilder(t *testing.T) {
 			EventListenerSpec(
 				EventListenerServiceAccount("serviceAccount"),
 				EventListenerTrigger("tt1", "v1alpha1",
-					EventListenerTriggerBinding("tb1", "", "tb1", "v1alpha1"),
+					EventListenerTriggerBinding("tb1", "", "v1alpha1"),
 				),
 			),
 		),
@@ -245,7 +207,6 @@ func TestEventListenerBuilder(t *testing.T) {
 				ServiceAccountName: "serviceAccount",
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{
-						Name:       "tb1",
 						Kind:       v1alpha1.NamespacedTriggerBindingKind,
 						Ref:        "tb1",
 						APIVersion: "v1alpha1",
@@ -261,7 +222,7 @@ func TestEventListenerBuilder(t *testing.T) {
 			EventListenerSpec(
 				EventListenerServiceAccount("serviceAccount"),
 				EventListenerTrigger("tt1", "v1alpha1",
-					EventListenerTriggerBinding("tb1", "TriggerBinding", "tb1", "v1alpha1"),
+					EventListenerTriggerBinding("tb1", "TriggerBinding", "v1alpha1"),
 				),
 			),
 		),
@@ -276,7 +237,6 @@ func TestEventListenerBuilder(t *testing.T) {
 				ServiceAccountName: "serviceAccount",
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{
-						Name:       "tb1",
 						Kind:       v1alpha1.ClusterTriggerBindingKind,
 						Ref:        "tb1",
 						APIVersion: "v1alpha1",
@@ -292,7 +252,7 @@ func TestEventListenerBuilder(t *testing.T) {
 			EventListenerSpec(
 				EventListenerServiceAccount("serviceAccount"),
 				EventListenerTrigger("tt1", "v1alpha1",
-					EventListenerTriggerBinding("tb1", "ClusterTriggerBinding", "tb1", "v1alpha1"),
+					EventListenerTriggerBinding("tb1", "ClusterTriggerBinding", "v1alpha1"),
 				),
 			),
 		),
@@ -308,14 +268,11 @@ func TestEventListenerBuilder(t *testing.T) {
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{
 						{
-							Name: "tb1",
-							Kind: v1alpha1.NamespacedTriggerBindingKind,
-							Ref:  "tb1",
-
+							Kind:       v1alpha1.NamespacedTriggerBindingKind,
+							Ref:        "tb1",
 							APIVersion: "v1alpha1",
 						},
 						{
-							Name:       "ctb1",
 							Kind:       v1alpha1.ClusterTriggerBindingKind,
 							Ref:        "ctb1",
 							APIVersion: "v1alpha1",
@@ -332,8 +289,8 @@ func TestEventListenerBuilder(t *testing.T) {
 			EventListenerSpec(
 				EventListenerServiceAccount("serviceAccount"),
 				EventListenerTrigger("tt1", "v1alpha1",
-					EventListenerTriggerBinding("tb1", "", "tb1", "v1alpha1"),
-					EventListenerTriggerBinding("ctb1", "ClusterTriggerBinding", "ctb1", "v1alpha1"),
+					EventListenerTriggerBinding("tb1", "", "v1alpha1"),
+					EventListenerTriggerBinding("ctb1", "ClusterTriggerBinding", "v1alpha1"),
 				),
 			),
 		),
@@ -355,7 +312,6 @@ func TestEventListenerBuilder(t *testing.T) {
 				ServiceAccountName: "serviceAccount",
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{
-						Name:       "tb1",
 						Kind:       v1alpha1.NamespacedTriggerBindingKind,
 						Ref:        "tb1",
 						APIVersion: "v1alpha1",
@@ -366,7 +322,6 @@ func TestEventListenerBuilder(t *testing.T) {
 					},
 				}, {
 					Bindings: []*v1alpha1.EventListenerBinding{{
-						Name:       "tb2",
 						Kind:       v1alpha1.NamespacedTriggerBindingKind,
 						Ref:        "tb2",
 						APIVersion: "v1alpha1",
@@ -387,10 +342,10 @@ func TestEventListenerBuilder(t *testing.T) {
 			EventListenerSpec(
 				EventListenerServiceAccount("serviceAccount"),
 				EventListenerTrigger("tt1", "v1alpha1",
-					EventListenerTriggerBinding("tb1", "", "tb1", "v1alpha1"),
+					EventListenerTriggerBinding("tb1", "", "v1alpha1"),
 				),
 				EventListenerTrigger("tt2", "v1alpha1",
-					EventListenerTriggerBinding("tb2", "", "tb2", "v1alpha1"),
+					EventListenerTriggerBinding("tb2", "", "v1alpha1"),
 				),
 			),
 		),
@@ -416,7 +371,6 @@ func TestEventListenerBuilder(t *testing.T) {
 						},
 					}},
 					Bindings: []*v1alpha1.EventListenerBinding{{
-						Name:       "tb1",
 						Kind:       v1alpha1.NamespacedTriggerBindingKind,
 						Ref:        "tb1",
 						APIVersion: "v1alpha1",
@@ -432,7 +386,7 @@ func TestEventListenerBuilder(t *testing.T) {
 			EventListenerSpec(
 				EventListenerServiceAccount("serviceAccount"),
 				EventListenerTrigger("tt1", "v1alpha1",
-					EventListenerTriggerBinding("tb1", "", "tb1", "v1alpha1"),
+					EventListenerTriggerBinding("tb1", "", "v1alpha1"),
 					EventListenerTriggerName("foo-trig"),
 					EventListenerTriggerInterceptor("foo", "v1", "Service", "namespace"),
 				),
@@ -469,7 +423,6 @@ func TestEventListenerBuilder(t *testing.T) {
 						},
 					}},
 					Bindings: []*v1alpha1.EventListenerBinding{{
-						Name:       "tb1",
 						Kind:       v1alpha1.NamespacedTriggerBindingKind,
 						Ref:        "tb1",
 						APIVersion: "v1alpha1",
@@ -484,7 +437,7 @@ func TestEventListenerBuilder(t *testing.T) {
 			EventListenerSpec(
 				EventListenerServiceAccount("serviceAccount"),
 				EventListenerTrigger("tt1", "v1alpha1",
-					EventListenerTriggerBinding("tb1", "", "tb1", "v1alpha1"),
+					EventListenerTriggerBinding("tb1", "", "v1alpha1"),
 					EventListenerTriggerName("foo-trig"),
 					EventListenerTriggerInterceptor("foo", "v1", "Service", "namespace",
 						EventInterceptorParam("header1", "value1"),
@@ -512,7 +465,6 @@ func TestEventListenerBuilder(t *testing.T) {
 						},
 					}},
 					Bindings: []*v1alpha1.EventListenerBinding{{
-						Name:       "tb1",
 						Kind:       v1alpha1.NamespacedTriggerBindingKind,
 						Ref:        "tb1",
 						APIVersion: "v1alpha1",
@@ -528,7 +480,7 @@ func TestEventListenerBuilder(t *testing.T) {
 			EventListenerSpec(
 				EventListenerServiceAccount("serviceAccount"),
 				EventListenerTrigger("tt1", "v1alpha1",
-					EventListenerTriggerBinding("tb1", "", "tb1", "v1alpha1"),
+					EventListenerTriggerBinding("tb1", "", "v1alpha1"),
 					EventListenerTriggerName("foo-trig"),
 					EventListenerCELInterceptor("body.value == 'test'", EventListenerCELOverlay("value", "'testing'")),
 				),
@@ -545,7 +497,6 @@ func TestEventListenerBuilder(t *testing.T) {
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Name: "foo-trig",
 					Bindings: []*v1alpha1.EventListenerBinding{{
-						Name:       "tb1",
 						Kind:       v1alpha1.NamespacedTriggerBindingKind,
 						Ref:        "tb1",
 						APIVersion: "v1alpha1",
@@ -615,7 +566,7 @@ func TestEventListenerBuilder(t *testing.T) {
 					),
 				),
 				EventListenerTrigger("tt1", "v1alpha1",
-					EventListenerTriggerBinding("tb1", "", "tb1", "v1alpha1"),
+					EventListenerTriggerBinding("tb1", "", "v1alpha1"),
 					EventListenerTriggerName("foo-trig"),
 				),
 			),

--- a/test/eventlistener_test.go
+++ b/test/eventlistener_test.go
@@ -304,8 +304,8 @@ func TestEventListenerCreate(t *testing.T) {
 				),
 				bldr.EventListenerReplicas(3),
 				bldr.EventListenerTrigger(tt.Name, "",
-					bldr.EventListenerTriggerBinding(tb.Name, "", tb.Name, "v1alpha1"),
-					bldr.EventListenerTriggerBinding(ctb.Name, "ClusterTriggerBinding", ctb.Name, "v1alpha1"),
+					bldr.EventListenerTriggerBinding(tb.Name, "", "v1alpha1"),
+					bldr.EventListenerTriggerBinding(ctb.Name, "ClusterTriggerBinding", "v1alpha1"),
 				),
 			),
 		))


### PR DESCRIPTION

# Changes

The testbuilder `EventListenerTriggerBinding` allows users to specify both
`name` and `ref` fields. With #617, specifying both `name` and `ref` is no
longer allowed.

We fixed the builder usage for all the happy path tests to use `name` as an
empty string but did not do it for tests that are verifying error paths (such
as validation errors). So, these tests will now all fail at the same validation
check making most of these tests useless (causing the drop in coverage in

To fix, I changed the builder to only accept `ref` so that one cannot create
invalid structs. Later, we can migrate our tests to not use builders at all and
have our error tests verify the actual error string.

Signed-off-by: Dibyo Mukherjee <dibyo@google.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
NONE
```
/kind bug

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
