### PR TITLE
Update README.md

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -45,7 +45,8 @@ your cluster, you will need this for your Webhook in later steps.
 you will need to export it, and reimport it to the _getting-started_ namespace.
 The following is a general example of what you'd need to do.
   - ```bash
-	kubectl get secret <name> --namespace=<namespace> --export -o yaml |\
+	kubectl get secret <name> --namespace=<namespace> -o yaml |\
+	   grep -v '^\s*namespace:\s' |\
 	   kubectl apply --namespace=<new namespace> -f -
 	```
 - [Create the create-webhook user, role and rolebinding](./rbac/webhook-role.yaml)


### PR DESCRIPTION
# Changes
remove kubectl --export flag as it has been deprecated since v1.14 and should be removed in v1.18 currently implemented using grep, but this would work using yq too:
```
kubectl get secret <name> --namespace=<namespace> |\
yq d - 'metadata.namespace' |\
kubectl apply --namespace=getting-started -f -
```

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
