### PR TITLE
Enhance validation code for triggers

### DIFF
--- a/pkg/apis/triggers/v1alpha1/trigger_binding_validation.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_binding_validation.go
@@ -30,10 +30,7 @@ func (tb *TriggerBinding) Validate(ctx context.Context) *apis.FieldError {
 
 // Validate TriggerBindingSpec.
 func (s *TriggerBindingSpec) Validate(ctx context.Context) *apis.FieldError {
-	if err := validateParams(s.Params); err != nil {
-		return err
-	}
-	return nil
+	return validateParams(s.Params)
 }
 
 func validateParams(params []Param) *apis.FieldError {

--- a/pkg/apis/triggers/v1alpha1/trigger_template_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_template_validation_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	b "github.com/tektoncd/triggers/test/builder"
 
@@ -155,13 +154,13 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 		}, {
 			name:     "no spec to triggertemplate",
 			template: b.TriggerTemplate("tt", "foo", b.TriggerTemplateSpec()),
-			want:     apis.ErrMissingField("spec"),
+			want:     apis.ErrMissingField("spec", "spec.resourcetemplates"),
 		}}
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			got := tc.template.Validate(context.Background())
-			if d := cmp.Diff(got, tc.want, cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
+			if d := cmp.Diff(got.Error(), tc.want.Error()); d != "" {
 				t.Errorf("TriggerTemplate Validation failed: %s", d)
 			}
 		})

--- a/pkg/apis/triggers/v1alpha1/trigger_validation.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_validation.go
@@ -29,70 +29,62 @@ import (
 
 // Validate validates a Trigger
 func (t *Trigger) Validate(ctx context.Context) *apis.FieldError {
-	if err := validate.ObjectMetadata(t.GetObjectMeta()); err != nil {
-		return err.ViaField("metadata")
-	}
-	return t.Spec.validate(ctx).ViaField("spec")
+	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
+	return errs.Also(t.Spec.validate(ctx).ViaField("spec"))
 }
 
 func (t *TriggerSpec) validate(ctx context.Context) *apis.FieldError {
 	// Validate optional Bindings
-	if err := triggerSpecBindingArray(t.Bindings).validate(ctx); err != nil {
-		return err
-	}
+	errs := triggerSpecBindingArray(t.Bindings).validate(ctx)
 	// Validate required TriggerTemplate
-	if err := t.Template.validate(ctx); err != nil {
-		return err
-	}
+	errs = errs.Also(t.Template.validate(ctx))
 
 	// Validate optional Interceptors
 	for i, interceptor := range t.Interceptors {
-		if err := interceptor.validate(ctx).ViaField(fmt.Sprintf("interceptors[%d]", i)); err != nil {
-			return err
-		}
+		errs = errs.Also(interceptor.validate(ctx).ViaField(fmt.Sprintf("interceptors[%d]", i)))
 	}
 
-	return nil
+	return errs
 }
 
-func (t TriggerSpecTemplate) validate(ctx context.Context) *apis.FieldError {
+func (t TriggerSpecTemplate) validate(ctx context.Context) (errs *apis.FieldError) {
 	// Optional explicit match
 	if t.APIVersion != "" {
 		if t.APIVersion != "v1alpha1" {
-			return apis.ErrInvalidValue(fmt.Errorf("invalid apiVersion"), "template.apiVersion")
+			errs = errs.Also(apis.ErrInvalidValue(fmt.Errorf("invalid apiVersion"), "template.apiVersion"))
 		}
 	}
 	if t.Name == "" {
-		return apis.ErrMissingField("template.name")
+		errs = errs.Also(apis.ErrMissingField("template.name"))
 	}
-	return nil
+	return errs
 
 }
 
-func (t triggerSpecBindingArray) validate(ctx context.Context) *apis.FieldError {
+func (t triggerSpecBindingArray) validate(ctx context.Context) (errs *apis.FieldError) {
 	if len(t) > 0 {
 		for i, b := range t {
 			// Either Ref or Spec should be present
 			if b.Ref == "" && b.Spec == nil {
-				return apis.ErrMissingOneOf(fmt.Sprintf("bindings[%d].Ref", i), fmt.Sprintf("bindings[%d].Spec", i))
+				errs = errs.Also(apis.ErrMissingOneOf(fmt.Sprintf("bindings[%d].Ref", i), fmt.Sprintf("bindings[%d].Spec", i)))
 			}
 
 			// Both Ref and Spec can't be present at the same time
 			if b.Ref != "" && b.Spec != nil {
-				return apis.ErrMultipleOneOf(fmt.Sprintf("bindings[%d].Ref", i), fmt.Sprintf("bindings[%d].Spec", i))
+				errs = errs.Also(apis.ErrMultipleOneOf(fmt.Sprintf("bindings[%d].Ref", i), fmt.Sprintf("bindings[%d].Spec", i)))
 			}
 
 			if b.Ref != "" && b.Kind != NamespacedTriggerBindingKind && b.Kind != ClusterTriggerBindingKind {
-				return apis.ErrInvalidValue(fmt.Errorf("invalid kind"), fmt.Sprintf("bindings[%d].kind", i))
+				errs = errs.Also(apis.ErrInvalidValue(fmt.Errorf("invalid kind"), fmt.Sprintf("bindings[%d].kind", i)))
 			}
 		}
 	}
-	return nil
+	return errs
 }
 
-func (i *TriggerInterceptor) validate(ctx context.Context) *apis.FieldError {
+func (i *TriggerInterceptor) validate(ctx context.Context) (errs *apis.FieldError) {
 	if i.Webhook == nil && i.GitHub == nil && i.GitLab == nil && i.CEL == nil && i.Bitbucket == nil {
-		return apis.ErrMissingField("interceptor")
+		errs = errs.Also(apis.ErrMissingField("interceptor"))
 	}
 
 	// Enforce oneof
@@ -111,35 +103,35 @@ func (i *TriggerInterceptor) validate(ctx context.Context) *apis.FieldError {
 	}
 
 	if numSet > 1 {
-		return apis.ErrMultipleOneOf("interceptor.webhook", "interceptor.github", "interceptor.gitlab")
+		errs = errs.Also(apis.ErrMultipleOneOf("interceptor.webhook", "interceptor.github", "interceptor.gitlab"))
 	}
 
 	if i.Webhook != nil {
 		if i.Webhook.ObjectRef == nil || i.Webhook.ObjectRef.Name == "" {
-			return apis.ErrMissingField("interceptor.webhook.objectRef")
+			errs = errs.Also(apis.ErrMissingField("interceptor.webhook.objectRef"))
 		}
 		w := i.Webhook
 		if w.ObjectRef.Kind != "Service" {
-			return apis.ErrInvalidValue(fmt.Errorf("invalid kind"), "interceptor.webhook.objectRef.kind")
+			errs = errs.Also(apis.ErrInvalidValue(fmt.Errorf("invalid kind"), "interceptor.webhook.objectRef.kind"))
 		}
 
 		// Optional explicit match
 		if w.ObjectRef.APIVersion != "v1" {
-			return apis.ErrInvalidValue(fmt.Errorf("invalid apiVersion"), "interceptor.webhook.objectRef.apiVersion")
+			errs = errs.Also(apis.ErrInvalidValue(fmt.Errorf("invalid apiVersion"), "interceptor.webhook.objectRef.apiVersion"))
 		}
 
 		for i, header := range w.Header {
 			// Enforce non-empty canonical header keys
 			if len(header.Name) == 0 || http.CanonicalHeaderKey(header.Name) != header.Name {
-				return apis.ErrInvalidValue(fmt.Errorf("invalid header name"), fmt.Sprintf("interceptor.webhook.header[%d].name", i))
+				errs = errs.Also(apis.ErrInvalidValue(fmt.Errorf("invalid header name"), fmt.Sprintf("interceptor.webhook.header[%d].name", i)))
 			}
 			// Enforce non-empty header values
 			if header.Value.Type == pipelinev1.ParamTypeString {
 				if len(header.Value.StringVal) == 0 {
-					return apis.ErrInvalidValue(fmt.Errorf("invalid header value"), fmt.Sprintf("interceptor.webhook.header[%d].value", i))
+					errs = errs.Also(apis.ErrInvalidValue(fmt.Errorf("invalid header value"), fmt.Sprintf("interceptor.webhook.header[%d].value", i)))
 				}
 			} else if len(header.Value.ArrayVal) == 0 {
-				return apis.ErrInvalidValue(fmt.Errorf("invalid header value"), fmt.Sprintf("interceptor.webhook.header[%d].value", i))
+				errs = errs.Also(apis.ErrInvalidValue(fmt.Errorf("invalid header value"), fmt.Sprintf("interceptor.webhook.header[%d].value", i)))
 			}
 		}
 	}
@@ -156,22 +148,22 @@ func (i *TriggerInterceptor) validate(ctx context.Context) *apis.FieldError {
 
 	if i.CEL != nil {
 		if i.CEL.Filter == "" && len(i.CEL.Overlays) == 0 {
-			return apis.ErrMultipleOneOf("cel.filter", "cel.overlays")
+			errs = errs.Also(apis.ErrMultipleOneOf("cel.filter", "cel.overlays"))
 		}
 		env, err := cel.NewEnv()
 		if err != nil {
-			return apis.ErrInvalidValue(fmt.Errorf("failed to create a CEL env: %s", err), "cel.filter")
+			errs = errs.Also(apis.ErrInvalidValue(fmt.Errorf("failed to create a CEL env: %s", err), "cel.filter"))
 		}
 		if i.CEL.Filter != "" {
 			if _, issues := env.Parse(i.CEL.Filter); issues != nil && issues.Err() != nil {
-				return apis.ErrInvalidValue(fmt.Errorf("failed to parse the CEL filter: %s", issues.Err()), "cel.filter")
+				errs = errs.Also(apis.ErrInvalidValue(fmt.Errorf("failed to parse the CEL filter: %s", issues.Err()), "cel.filter"))
 			}
 		}
 		for _, v := range i.CEL.Overlays {
 			if _, issues := env.Parse(v.Expression); issues != nil && issues.Err() != nil {
-				return apis.ErrInvalidValue(fmt.Errorf("failed to parse the CEL overlay: %s", issues.Err()), "cel.overlay")
+				errs = errs.Also(apis.ErrInvalidValue(fmt.Errorf("failed to parse the CEL overlay: %s", issues.Err()), "cel.overlay"))
 			}
 		}
 	}
-	return nil
+	return errs
 }


### PR DESCRIPTION
# Changes

The PR make use of `knative.dev/pkg` apis errs pacakge to report better error message and multiple validation error at once which intern helps to user to know the error at once.

Signed-off-by: Savita Ashture sashture@redhat.com

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Triggers validation now reports all the error at once with more detailed information.
```
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
