### PR TITLE
Set runAsUser uid for nonroot distroless image

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -71,3 +71,7 @@ spec:
           value: config-observability-triggers
         - name: METRICS_DOMAIN
           value: tekton.dev/triggers
+        securityContext:
+          allowPrivilegeEscalation: false
+          # User 65532 is the distroless nonroot user ID
+          runAsUser: 65532

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -74,3 +74,7 @@ spec:
           containerPort: 8008
         - name: https-webhook
           containerPort: 8443
+        securityContext:
+          allowPrivilegeEscalation: false
+          # User 65532 is the distroless nonroot user ID
+          runAsUser: 65532


### PR DESCRIPTION

# Changes

Port of tektoncd/pipeline#3342:

The distroless nonroot image define a user with the uid 65532 and not 1001. The
deployment should use that uid to make sure it works anywhere.

Fixes #781

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes
```release-note
Fix inconsistent uid for the controller and webhook deployment, resulting in failure of installing tekton pipeline on minikube (and other platforms.)
```