### PR TITLE
Remove explicit pinning of golang version 📌

### DIFF
--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -32,8 +32,6 @@ spec:
       params:
         - name: package
           value: $(params.package)
-        - name: version
-          value: "1.13"
       resources:
         inputs:
           - name: source
@@ -44,8 +42,6 @@ spec:
       params:
         - name: package
           value: $(params.package)
-        - name: version
-          value: "1.13"
       resources:
         inputs:
           - name: source


### PR DESCRIPTION
# Changes

The nightly triggers unit tests were failing to build b/c they are now using
tests that require golang 1.14 features (specifically Cleanup) and the
version was explicitly pinned to 1.13. The tektoncd/pipeline release
pipelines do not explicitly pin the version and looking at the
golang-test task in the catalog the default version is "latest".
(https://github.com/tektoncd/catalog/blob/972bca5c5642a056c28ff1976c30c7367e6a9c3a/task/golang-test/0.1/golang-test.yaml#L23)
We could pin it to something explicit if we want; if so we should do it
for all of our pipelines. In the meantime removing the explicit pin so
we can use the default and the unit tests can pass.

Fixes #793

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```

