### PR TITLE
Fix TestTrigger_Error using deterministic inputs

### DIFF
--- a/cmd/triggerrun/cmd/root.go
+++ b/cmd/triggerrun/cmd/root.go
@@ -68,7 +68,7 @@ func init() {
 }
 
 func rootRun(cmd *cobra.Command, args []string) error {
-	err := trigger(triggerFile, httpPath, action, os.Stdout)
+	err := trigger(triggerFile, httpPath, action, kubeconfig, os.Stdout)
 	if err != nil {
 		return fmt.Errorf("fail to call trigger: %v", err)
 	}
@@ -76,7 +76,7 @@ func rootRun(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func trigger(triggerFile, httpPath, action string, writer io.Writer) error {
+func trigger(triggerFile, httpPath, action, kubeconfig string, writer io.Writer) error {
 	// Read HTTP request.
 	request, body, err := readHTTP(httpPath)
 	if err != nil {

--- a/cmd/triggerrun/cmd/root_test.go
+++ b/cmd/triggerrun/cmd/root_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -42,18 +43,12 @@ import (
 func TestTrigger_Error(t *testing.T) {
 	//error case for show feature
 	buf := new(bytes.Buffer)
-	err := trigger("../testdata/trigger.yaml", "../testdata/http.txt", "show", buf)
+	err := trigger("../testdata/trigger.yaml", "../testdata/http.txt", "show", "BAD_KUBECONFIG", buf)
 
-	wantError := "fail to get clients: Failed to build config from the flags: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable"
+	wantError := "fail to get clients: Failed to build config from the flags:"
 
-	if err.Error() != wantError {
-		t.Errorf("Error actual = %v, and Expected = %v.", err, wantError)
-	}
-
-	gotValue := buf.Bytes()
-	wantValue := []uint8(nil)
-	if diff := cmp.Diff(wantValue, gotValue); diff != "" {
-		t.Errorf("Trigger mismatch -want +got: %s", diff)
+	if !strings.Contains(err.Error(), wantError) {
+		t.Errorf("Expected actual error to contain %s but got: %s", wantError, err.Error())
 	}
 }
 


### PR DESCRIPTION
TestTrigger_Error had an error test case that was expecting failure due to a
bad kubeconfig input. The kubeconfig was passed in via a flag/global variable
which means in the test its value is "". This is a problem since if the
kubeconfig is an empty string, one of the underlying functions will try to
authenticate using inClusterConfig which means that the test behaves
differently depending on whether in runs in a k8s pod with access to the
apiserver or not. In local and CI runs, the test passes since its either out of
a k8s cluster or running in a pod which cannot talk to the apiserver directly.
But in our nightly tests running in a tekton cluster, it fails.

The test was also using a golden input to exactly match errors. I modified it
to only match the part of errors which we return from our code.

Fixes #795

/kind bug

Verified this fix by running the golang-test task with Triggers on master (fails), and with this patch(pass)!

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
