### PR TITLE
Improve the error message when URL form encoding is received.

### DIFF
--- a/pkg/interceptors/github/github.go
+++ b/pkg/interceptors/github/github.go
@@ -30,6 +30,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// ErrInvalidContentType is returned when the content-type is not a JSON body.
+var ErrInvalidContentType = errors.New("form parameter encoding not supported, please change the hook to send JSON payloads")
+
 type Interceptor struct {
 	KubeClientSet          kubernetes.Interface
 	Logger                 *zap.SugaredLogger
@@ -49,6 +52,9 @@ func NewInterceptor(gh *triggersv1.GitHubInterceptor, k kubernetes.Interface, ns
 func (w *Interceptor) ExecuteTrigger(request *http.Request) (*http.Response, error) {
 	payload := []byte{}
 	var err error
+	if v := request.Header.Get("Content-Type"); v == "application/x-www-form-urlencoded" {
+		return nil, ErrInvalidContentType
+	}
 
 	if request.Body != nil {
 		defer request.Body.Close()


### PR DESCRIPTION
# Changes

Improve the error message when URL form encoding is received.
    
It's a common mistake to use the default form-encoding hook format when setting
up a GitHub hook, this detects this case with an explicit error message.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
The GitHub interceptor now detects form-encoded hook requests and returns an explicit error for this case rather than the generic JSON parsing error.
```
