### PR TITLE
Fix GitHub and GitLab capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ continuous integration and delivery (CI/CD) framework that enables you to create
 containerized, composable, and configurable workloads declaratively through
 CRDs. Naturally, CI/CD events contain information that should:
 
-- Identify the kind of event (GitHub Push, Gitlab Issue, Docker Hub Webhook,
+- Identify the kind of event (GitHub Push, GitLab Issue, Docker Hub Webhook,
   etc.)
 - Be accessible from and map to particular pipelines (Take SHA from payload to
   use it in pipeline X)

--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -89,7 +89,7 @@ rules:
   resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers"]
   verbs: ["get"]
 - apiGroups: [""]
-  # secrets are only needed for Github/Gitlab interceptors
+  # secrets are only needed for GitHub/GitLab interceptors
   resources: ["configmaps", "secrets"]
   verbs: ["get", "list", "watch"]
 # Permissions to create resources in associated TriggerTemplates

--- a/examples/bitbucket/role.yaml
+++ b/examples/bitbucket/role.yaml
@@ -15,7 +15,7 @@ rules:
     resources: ["eventlisteners", "triggerbindings", "triggertemplates"]
     verbs: ["get"]
   - apiGroups: [""]
-    # secrets are only needed for Github/Gitlab interceptors, serviceaccounts only for per trigger authorization
+    # secrets are only needed for GitHub/GitLab interceptors, serviceaccounts only for per trigger authorization
     resources: ["configmaps", "secrets", "serviceaccounts"]
     verbs: ["get", "list", "watch"]
   # Permissions to create resources in associated TriggerTemplates

--- a/examples/cron/role.yaml
+++ b/examples/cron/role.yaml
@@ -8,7 +8,7 @@ rules:
     resources: ["eventlisteners", "triggerbindings", "triggertemplates"]
     verbs: ["get"]
   - apiGroups: [""]
-    # secrets are only needed for Github/Gitlab interceptors, serviceaccounts only for per trigger authorization
+    # secrets are only needed for GitHub/GitLab interceptors, serviceaccounts only for per trigger authorization
     resources: ["configmaps", "secrets", "serviceaccounts"]
     verbs: ["get", "list", "watch"]
   # Permissions to create resources in associated TriggerTemplates

--- a/examples/event-interceptors/main.go
+++ b/examples/event-interceptors/main.go
@@ -41,13 +41,13 @@ func main() {
 		payload, err := github.ValidatePayload(request, []byte(secretToken))
 		id := github.DeliveryID(request)
 		if err != nil {
-			log.Printf("Error handling Github Event with delivery ID %s : %q", id, err)
+			log.Printf("Error handling GitHub Event with delivery ID %s : %q", id, err)
 			http.Error(writer, fmt.Sprint(err), http.StatusBadRequest)
 		}
-		log.Printf("Handling Github Event with delivery ID: %s; Payload: %s", id, payload)
+		log.Printf("Handling GitHub Event with delivery ID: %s; Payload: %s", id, payload)
 		n, err := writer.Write(payload)
 		if err != nil {
-			log.Printf("Failed to write response for Github event ID: %s. Bytes writted: %d. Error: %q", id, n, err)
+			log.Printf("Failed to write response for GitHub event ID: %s. Bytes writted: %d. Error: %q", id, n, err)
 		}
 	})
 

--- a/examples/github/role.yaml
+++ b/examples/github/role.yaml
@@ -27,7 +27,7 @@ rules:
     resources: ["eventlisteners", "triggerbindings", "triggertemplates"]
     verbs: ["get"]
   - apiGroups: [""]
-    # secrets are only needed for Github/Gitlab interceptors, serviceaccounts only for per trigger authorization
+    # secrets are only needed for GitHub/GitLab interceptors, serviceaccounts only for per trigger authorization
     resources: ["configmaps", "secrets", "serviceaccounts"]
     verbs: ["get", "list", "watch"]
   # Permissions to create resources in associated TriggerTemplates

--- a/examples/gitlab/README.md
+++ b/examples/gitlab/README.md
@@ -1,6 +1,6 @@
 ## GitLab Push EventListener
 
-Creates an EventListener that listens for Gitlab webhook events.
+Creates an EventListener that listens for GitLab webhook events.
 
 ### Try it out locally:
 

--- a/examples/gitlab/role.yaml
+++ b/examples/gitlab/role.yaml
@@ -8,7 +8,7 @@ rules:
     resources: ["eventlisteners", "triggerbindings", "triggertemplates"]
     verbs: ["get"]
   - apiGroups: [""]
-    # secrets are only needed for Github/Gitlab interceptors, serviceaccounts only for per trigger authorization
+    # secrets are only needed for GitHub/GitLab interceptors, serviceaccounts only for per trigger authorization
     resources: ["configmaps", "secrets", "serviceaccounts"]
     verbs: ["get", "list", "watch"]
   # Permissions to create resources in associated TriggerTemplates

--- a/examples/role-resources/clustertriggerbinding-roles/clusterrole.yaml
+++ b/examples/role-resources/clustertriggerbinding-roles/clusterrole.yaml
@@ -8,7 +8,7 @@ rules:
   resources: ["clustertriggerbindings", "eventlisteners", "triggerbindings", "triggertemplates", "triggers"]
   verbs: ["get"]
 - apiGroups: [""]
-  # secrets are only needed for Github/Gitlab interceptors
+  # secrets are only needed for GitHub/GitLab interceptors
   resources: ["configmaps", "secrets"]
   verbs: ["get", "list", "watch"]
 # Permissions to create resources in associated TriggerTemplates

--- a/examples/role-resources/triggerbinding-roles/role.yaml
+++ b/examples/role-resources/triggerbinding-roles/role.yaml
@@ -8,7 +8,7 @@ rules:
   resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers"]
   verbs: ["get"]
 - apiGroups: [""]
-  # secrets are only needed for Github/Gitlab interceptors
+  # secrets are only needed for GitHub/GitLab interceptors
   resources: ["configmaps", "secrets"]
   verbs: ["get", "list", "watch"]
 # Permissions to create resources in associated TriggerTemplates

--- a/examples/triggers/rbac.yaml
+++ b/examples/triggers/rbac.yaml
@@ -9,7 +9,7 @@ rules:
   resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers"]
   verbs: ["get"]
 - apiGroups: [""]
-  # secrets are only needed for Github/Gitlab interceptors
+  # secrets are only needed for GitHub/GitLab interceptors
   resources: ["configmaps", "secrets"]
   verbs: ["get", "list", "watch"]
 # Permissions to create resources in associated TriggerTemplates

--- a/pkg/interceptors/interceptors.go
+++ b/pkg/interceptors/interceptors.go
@@ -55,7 +55,7 @@ func getCache(req *http.Request) map[string]interface{} {
 }
 
 // GetSecretToken queries Kubernetes for the given secret reference. We use this function
-// to resolve secret material like Github webhook secrets, and call it once for every
+// to resolve secret material like GitHub webhook secrets, and call it once for every
 // trigger that references it.
 //
 // As we may have many triggers that all use the same secret, we cache the secret values


### PR DESCRIPTION
# Changes

Fix the capitalization of "GitHub" and "GitLab" in documentation and in comments.

