### PR TITLE
Add multi-arch builds for triggers

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -77,12 +77,12 @@ spec:
       OUTPUT_BUCKET_RELEASE_DIR="/workspace/output/bucket/previous/$(inputs.params.versionTag)"
 
       # Publish images and create release.yaml
-      ko resolve --preserve-import-paths -t $(inputs.params.versionTag) -f /workspace/go/src/github.com/tektoncd/triggers/config/ > $OUTPUT_BUCKET_RELEASE_DIR/release.yaml
+      ko resolve --platform=all --preserve-import-paths -t $(inputs.params.versionTag) -f /workspace/go/src/github.com/tektoncd/triggers/config/ > $OUTPUT_BUCKET_RELEASE_DIR/release.yaml
 
       # Publish images and create release.notags.yaml
       # This is useful if your container runtime doesn't support the `image-reference:tag@digest` notation
       # This is currently the case for `cri-o` (and most likely others)
-      ko resolve --preserve-import-paths -f /workspace/go/src/github.com/tektoncd/triggers/config/ > $OUTPUT_BUCKET_RELEASE_DIR/release.notags.yaml
+      ko resolve --platform=all --preserve-import-paths -f /workspace/go/src/github.com/tektoncd/triggers/config/ > $OUTPUT_BUCKET_RELEASE_DIR/release.notags.yaml
     volumeMounts:
       - name: gcp-secret
         mountPath: /secret


### PR DESCRIPTION
# Changes

ko has `platform` parameter which allows to build multi-arch images.
`ko --platform=all` will build images for all architectures, which are
supported by base image (at this moment `amd64`, `arm64`, `s390x`, `ppc64le`)
Multi-arch builds are already accepted by https://github.com/tektoncd/pipeline, see 
- https://github.com/tektoncd/pipeline/pull/3451
- https://github.com/tektoncd/pipeline/pull/3456

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Add multi-arch builds for triggers
```

