### PR TITLE
Allow users to set resources as part of podtemplate

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -273,6 +273,8 @@ Right now the allowed values as part of `podSpec` are
 ServiceAccountName
 NodeSelector
 Tolerations
+Containers
+- Resources
 ```
 
 ### Logging
@@ -470,6 +472,14 @@ spec:
         template:
           spec:
             serviceAccountName: tekton-triggers-github-sa
+            containers:
+              - resources:
+                  requests:
+                    memory: "64Mi"
+                    cpu: "250m"
+                  limits:
+                    memory: "128Mi"
+                    cpu: "500m"
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding

--- a/examples/github/github-eventlistener-interceptor.yaml
+++ b/examples/github/github-eventlistener-interceptor.yaml
@@ -25,6 +25,14 @@ spec:
         template:
           spec:
             serviceAccountName: tekton-triggers-github-sa
+            containers:
+              - resources:
+                  requests:
+                    memory: "64Mi"
+                    cpu: "250m"
+                  limits:
+                    memory: "128Mi"
+                    cpu: "500m"
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation.go
@@ -66,6 +66,7 @@ func validateKubernetesObject(orig *KubernetesResource) (errs *apis.FieldError) 
 
 func containerFieldMask(in *corev1.Container) *corev1.Container {
 	out := new(corev1.Container)
+	out.Resources = in.Resources
 
 	// Disallowed fields
 	// This list clarifies which all container attributes are not allowed.
@@ -89,7 +90,6 @@ func containerFieldMask(in *corev1.Container) *corev1.Container {
 	out.TTY = false
 	out.VolumeDevices = nil
 	out.EnvFrom = nil
-	out.Resources = corev1.ResourceRequirements{}
 	out.Env = nil
 
 	return out

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	bldr "github.com/tektoncd/triggers/test/builder"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
@@ -180,6 +181,18 @@ func Test_EventListenerValidate(t *testing.T) {
 										Effect:   "NoSchedule",
 									}},
 									NodeSelector: map[string]string{"beta.kubernetes.io/os": "linux"},
+									Containers: []corev1.Container{{
+										Resources: corev1.ResourceRequirements{
+											Limits: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.Quantity{Format: resource.DecimalSI},
+												corev1.ResourceMemory: resource.Quantity{Format: resource.BinarySI},
+											},
+											Requests: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.Quantity{Format: resource.DecimalSI},
+												corev1.ResourceMemory: resource.Quantity{Format: resource.BinarySI},
+											},
+										},
+									}},
 								},
 							},
 						}),

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
@@ -32,6 +32,7 @@ import (
 	bldr "github.com/tektoncd/triggers/test/builder"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -377,6 +378,18 @@ func TestReconcile(t *testing.T) {
 					Spec: corev1.PodSpec{
 						NodeSelector:       map[string]string{"key": "value"},
 						ServiceAccountName: "k8sresource",
+						Containers: []corev1.Container{{
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.Quantity{Format: resource.DecimalSI},
+									corev1.ResourceMemory: resource.Quantity{Format: resource.BinarySI},
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.Quantity{Format: resource.DecimalSI},
+									corev1.ResourceMemory: resource.Quantity{Format: resource.BinarySI},
+								},
+							},
+						}},
 					},
 				},
 			},
@@ -435,6 +448,16 @@ func TestReconcile(t *testing.T) {
 	deploymentForKubernetesResource := makeDeployment(func(d *appsv1.Deployment) {
 		d.Spec.Template.Spec.ServiceAccountName = "k8sresource"
 		d.Spec.Template.Spec.NodeSelector = map[string]string{"key": "value"}
+		d.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.Quantity{Format: resource.DecimalSI},
+				corev1.ResourceMemory: resource.Quantity{Format: resource.BinarySI},
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.Quantity{Format: resource.DecimalSI},
+				corev1.ResourceMemory: resource.Quantity{Format: resource.BinarySI},
+			},
+		}
 	})
 
 	deploymentForKubernetesResourceObjectMeta := makeDeployment(func(d *appsv1.Deployment) {


### PR DESCRIPTION
# Changes

Issue: https://github.com/tektoncd/triggers/issues/762

Added changes to allow resource information as part of eventlistener.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

Now trigger allow users to specify their resource information in eventlistener
```
apiVersion: triggers.tekton.dev/v1alpha1
kind: EventListener
metadata:
  name: github-listener-interceptor
spec:
  ...
  resources:
    kubernetesResource:
      spec:
        template:
          spec:
            serviceAccountName: tekton-triggers-github-sa
            containers:
              - resources:
                  requests:
                    memory: "64Mi"
                    cpu: "250m"
                  limits:
                    memory: "128Mi"
                    cpu: "500m"
```
