### PR TITLE
Allow secure connection to eventlistener pod

### DIFF
--- a/cmd/eventlistenersink/main.go
+++ b/cmd/eventlistenersink/main.go
@@ -136,7 +136,13 @@ func main() {
 			sinkArgs.ELTimeOutHandler*time.Second, "EventListener Timeout!\n"),
 	}
 
-	if err := srv.ListenAndServe(); err != nil {
-		logger.Fatalf("failed to start eventlistener sink: %v", err)
+	if sinkArgs.Cert == "" && sinkArgs.Key == "" {
+		if err := srv.ListenAndServe(); err != nil {
+			logger.Fatalf("failed to start eventlistener sink: %v", err)
+		}
+	} else {
+		if err := srv.ListenAndServeTLS(sinkArgs.Cert, sinkArgs.Key); err != nil {
+			logger.Fatalf("failed to start eventlistener sink: %v", err)
+		}
 	}
 }

--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -42,6 +42,8 @@ using [Event Interceptors](#Interceptors).
     - [Multiple EventListeners (One EventListener Per Namespace)](#multiple-eventlisteners-one-eventlistener-per-namespace)
     - [Multiple EventListeners (Multiple EventListeners per Namespace)](#multiple-eventlisteners-multiple-eventlisteners-per-namespace)
     - [ServiceAccount per EventListenerTrigger](#serviceaccount-per-eventlistenertrigger)
+  - [EventListener Secure Connection](#eventlistener-secure-connection)
+    - [Prerequisites](#prerequisites)
 
 ## Syntax
 
@@ -277,8 +279,11 @@ Right now the allowed values as part of `podSpec` are
 ServiceAccountName
 NodeSelector
 Tolerations
+Volumes
 Containers
 - Resources
+- VolumeMounts
+- Env
 ```
 
 ### Logging
@@ -821,3 +826,12 @@ Except as otherwise noted, the content of this page is licensed under the
 [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/),
 and code samples are licensed under the
 [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).
+
+## EventListener Secure Connection
+
+Triggers now support both `HTTP` and `HTTPS` connection by adding few configuration to eventlistener.
+
+To setup TLS connection add two set of reserved environment variables `TLS_CERT` and `TLS_KEY` using `secretKeyRef` env type 
+where we need to specify the `secret` which contains `cert` and `key` files. See the full [example]((../examples/eventlistener-tls-connection/README.md)) for more details.
+
+Refer [TEP-0027](https://github.com/tektoncd/community/blob/master/teps/0027-https-connection-to-triggers-eventlistener.md) for more information on design and user stories.

--- a/examples/eventlistener-tls-connection/README.md
+++ b/examples/eventlistener-tls-connection/README.md
@@ -1,0 +1,78 @@
+## EventListener Secure Connection
+
+Triggers now support both `HTTP` and `HTTPS` connection by adding some configurations to eventlistener.
+
+### Prerequisites
+* Certificates with Key and Cert
+* Secret which includes those certificates
+
+### Try it out locally:
+
+#### Creating Prerequisites
+
+* #### Certificates with Key and Cert.
+
+##### 1. Steps to generate root key, cert
+1. Create Root Key
+   ```text
+   openssl genrsa -des3 -out rootCA.key 4096
+   ```
+2. Create and self sign the Root Certificate
+   ```text
+   openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 1024 -out rootCA.crt
+   ```
+##### 2. Steps to generate certificate (for each server)
+1. Create the certificate key
+   ```text
+   openssl genrsa -out tls.key 2048
+   ```
+2. Create the signing (csr)
+
+* The CSR is where you specify the details for the certificate you want to generate. 
+This request will be processed by the owner of the root key to generate the certificate.
+
+* **Important:** While creating the csr it is important to specify the `Common Name` providing the IP address or domain name for the service, otherwise the certificate cannot be verified.
+   ```text
+   openssl req -new -key tls.key -out tls.csr
+   ```
+3. Generate the certificate using the tls csr and key along with the CA Root key
+   ```text
+   openssl x509 -req -in tls.csr -CA rootCA.crt -CAkey rootCA.key -CAcreateserial -out tls.crt -days 500 -sha256
+   ```
+##### 3. Follow same steps from 2 to generate certificates for client also
+
+* #### Create secret which includes those certificates
+   ```text
+   kubectl create secret generic tls-secret-key --from-file=tls.crt --from-file=tls.key
+   ```
+
+#### Configuring EventListener for TLS connection
+1. To create the TLS connection for EventListener and all related resources, run:
+
+   ```bash
+   kubectl apply -f examples/eventlistener-tls-connection/
+   ```
+
+1. Test by sending the sample payload.
+
+   ```bash
+   curl -v \
+   -H 'X-GitHub-Event: pull_request' \
+   -H 'X-Hub-Signature: sha1=ba0cdc263b3492a74b601d240c27efe81c4720cb' \
+   -H 'Content-Type: application/json' \
+   -d '{"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git"}}' \
+   https://<el-address> --cacert rootCA.crt --key client.key --cert client.crt
+   ```
+
+   The response status code should be `201 Created`
+   
+   [`HMAC`](https://www.freeformatter.com/hmac-generator.html) tool used to create X-Hub-Signature.
+   
+   In [`HMAC`](https://www.freeformatter.com/hmac-generator.html) `string` is the *body payload ex:* `{"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git"}}`
+   and `secretKey` is the *given secretToken ex:* `1234567`.
+
+1. You should see a new TaskRun that got created:
+
+   ```bash
+   kubectl get taskruns | grep tls-run-
+   ```

--- a/examples/eventlistener-tls-connection/role.yaml
+++ b/examples/eventlistener-tls-connection/role.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-triggers-tls-sa
+secrets:
+  - name: github-secret
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-triggers-tls-binding
+subjects:
+  - kind: ServiceAccount
+    name: tekton-triggers-tls-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tekton-triggers-tls-minimal
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-triggers-tls-minimal
+rules:
+  # Permissions for every EventListener deployment to function
+  - apiGroups: ["triggers.tekton.dev"]
+    resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    # secrets are only needed for GitHub/GitLab interceptors, serviceaccounts only for per trigger authorization
+    resources: ["configmaps", "secrets", "serviceaccounts"]
+    verbs: ["get", "list", "watch"]
+  # Permissions to create resources in associated TriggerTemplates
+  - apiGroups: ["tekton.dev"]
+    resources: ["pipelineruns", "pipelineresources", "taskruns"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-triggers-tls-binding
+subjects:
+  - kind: ServiceAccount
+    name: tekton-triggers-tls-sa
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-triggers-tls-minimal
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-triggers-tls-minimal
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers
+rules:
+  # Permissions for every EventListener deployment to function
+  - apiGroups: ["triggers.tekton.dev"]
+    resources: ["clustertriggerbindings"]
+    verbs: ["get", "list", "watch"]

--- a/examples/eventlistener-tls-connection/secret.yaml
+++ b/examples/eventlistener-tls-connection/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-secret
+type: Opaque
+stringData:
+  secretToken: "1234567"

--- a/examples/eventlistener-tls-connection/tls-eventlistener-interceptor.yaml
+++ b/examples/eventlistener-tls-connection/tls-eventlistener-interceptor.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: EventListener
+metadata:
+  name: tls-listener-interceptor
+spec:
+  triggers:
+    - name: tls-listener
+      interceptors:
+        - github:
+            secretRef:
+              secretName: github-secret
+              secretKey: secretToken
+            eventTypes:
+              - pull_request
+        - cel:
+            filter: "body.action in ['opened', 'synchronize', 'reopened']"
+      bindings:
+        - ref: tls-pr-binding
+      template:
+        ref: tls-template
+  resources:
+    kubernetesResource:
+      spec:
+        template:
+          spec:
+            serviceAccountName: tekton-triggers-tls-sa
+            containers:
+            - env:
+              - name: TLS_CERT
+                valueFrom:
+                  secretKeyRef:
+                    name: tls-key-secret
+                    key: tls.crt
+              - name: TLS_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: tls-key-secret
+                    key: tls.key
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: tls-pr-binding
+spec:
+  params:
+    - name: gitrevision
+      value: $(body.pull_request.head.sha)
+    - name: gitrepositoryurl
+      value: $(body.repository.clone_url)
+
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: tls-template
+spec:
+  params:
+    - name: gitrevision
+    - name: gitrepositoryurl
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1alpha1
+      kind: TaskRun
+      metadata:
+        generateName: tls-run-
+      spec:
+        taskSpec:
+          inputs:
+            resources:
+              - name: source
+                type: git
+          steps:
+            - image: ubuntu
+              script: |
+                #! /bin/bash
+                ls -al $(inputs.resources.source.path)
+        inputs:
+          resources:
+            - name: source
+              resourceSpec:
+                type: git
+                params:
+                  - name: revision
+                    value: $(tt.params.gitrevision)
+                  - name: url
+                    value: $(tt.params.gitrepositoryurl)

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation.go
@@ -21,8 +21,16 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"knative.dev/pkg/apis"
+)
+
+var (
+	reservedEnvVars = sets.NewString(
+		"TLS_CERT",
+		"TLS_KEY",
+	)
 )
 
 // Validate EventListener.
@@ -40,7 +48,7 @@ func (s *EventListenerSpec) validate(ctx context.Context) (errs *apis.FieldError
 		errs = errs.Also(trigger.validate(ctx).ViaField(fmt.Sprintf("spec.triggers[%d]", i)))
 	}
 	if s.Resources.KubernetesResource != nil {
-		errs = errs.Also(validateKubernetesObject(s.Resources.KubernetesResource))
+		errs = errs.Also(validateKubernetesObject(s.Resources.KubernetesResource).ViaField("spec.resources.kubernetesResource"))
 	}
 	return errs
 }
@@ -56,14 +64,86 @@ func validateKubernetesObject(orig *KubernetesResource) (errs *apis.FieldError) 
 	if len(orig.Template.Spec.Containers) == 1 {
 		errs = errs.Also(apis.CheckDisallowedFields(orig.Template.Spec.Containers[0],
 			*containerFieldMask(&orig.Template.Spec.Containers[0])).ViaField("spec.template.spec.containers[0]"))
+		// validate env
+		errs = errs.Also(validateEnv(orig.Template.Spec.Containers[0].Env).ViaField("spec.template.spec.containers[0].env"))
 	}
 
 	return errs
 }
 
+func validateEnv(envVars []corev1.EnvVar) (errs *apis.FieldError) {
+	var (
+		count    = 0
+		envValue string
+	)
+	for i, env := range envVars {
+		errs = errs.Also(validateEnvVar(env).ViaIndex(i))
+		if reservedEnvVars.Has(env.Name) {
+			count++
+			envValue = env.Name
+		}
+	}
+	// This is to make sure both TLS_CERT and TLS_KEY is set for tls connection
+	if count == 1 {
+		errs = errs.Also(&apis.FieldError{
+			Message: fmt.Sprintf("Expected env's are TLS_CERT and TLS_KEY, but got only one env %s", envValue),
+		})
+	}
+	return errs
+}
+
+func validateEnvVar(env corev1.EnvVar) (errs *apis.FieldError) {
+	errs = errs.Also(apis.CheckDisallowedFields(env, *envVarMask(&env)))
+
+	return errs.Also(validateEnvValueFrom(env.ValueFrom).ViaField("valueFrom"))
+}
+
+func validateEnvValueFrom(source *corev1.EnvVarSource) *apis.FieldError {
+	if source == nil {
+		return nil
+	}
+	return apis.CheckDisallowedFields(*source, *envVarSourceMask(source))
+}
+
+// envVarSourceMask performs a _shallow_ copy of the Kubernetes EnvVarSource object to a new
+// Kubernetes EnvVarSource object bringing over only the fields allowed in the Triggers EventListener API.
+func envVarSourceMask(in *corev1.EnvVarSource) *corev1.EnvVarSource {
+	if in == nil {
+		return nil
+	}
+	out := new(corev1.EnvVarSource)
+	// Allowed fields
+	out.SecretKeyRef = in.SecretKeyRef
+
+	// Disallowed fields
+	out.ConfigMapKeyRef = nil
+	out.FieldRef = nil
+	out.ResourceFieldRef = nil
+
+	return out
+}
+
+// envVarMask performs a _shallow_ copy of the Kubernetes EnvVar object to a new
+// Kubernetes EnvVar object bringing over only the fields allowed in the Triggers EventListener API.
+func envVarMask(in *corev1.EnvVar) *corev1.EnvVar {
+	if in == nil {
+		return nil
+	}
+	out := new(corev1.EnvVar)
+	// Allowed fields
+	out.Name = in.Name
+	out.ValueFrom = in.ValueFrom
+
+	// Disallowed fields
+	out.Value = ""
+
+	return out
+}
+
 func containerFieldMask(in *corev1.Container) *corev1.Container {
 	out := new(corev1.Container)
 	out.Resources = in.Resources
+	out.Env = in.Env
 
 	// Disallowed fields
 	// This list clarifies which all container attributes are not allowed.
@@ -87,7 +167,6 @@ func containerFieldMask(in *corev1.Container) *corev1.Container {
 	out.TTY = false
 	out.VolumeDevices = nil
 	out.EnvFrom = nil
-	out.Env = nil
 
 	return out
 }

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
@@ -164,7 +164,7 @@ func Test_EventListenerValidate(t *testing.T) {
 					bldr.EventListenerCELInterceptor("", bldr.EventListenerCELOverlay("body.value", "'testing'")),
 				))),
 	}, {
-		name: "Valid EventListener with kubernetes resource for podspec",
+		name: "Valid EventListener with kubernetes env for podspec",
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1"),
@@ -192,6 +192,41 @@ func Test_EventListenerValidate(t *testing.T) {
 												corev1.ResourceMemory: resource.Quantity{Format: resource.BinarySI},
 											},
 										},
+									}},
+								},
+							},
+						}),
+					)),
+			)),
+	}, {
+		name: "Valid EventListener with env for TLS connection",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tt", "v1alpha1"),
+				bldr.EventListenerResources(
+					bldr.EventListenerKubernetesResources(
+						bldr.EventListenerPodSpec(duckv1.WithPodSpec{
+							Template: duckv1.PodSpecable{
+								Spec: corev1.PodSpec{
+									ServiceAccountName: "k8sresource",
+									Containers: []corev1.Container{{
+										Env: []corev1.EnvVar{{
+											Name: "TLS_CERT",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													LocalObjectReference: corev1.LocalObjectReference{Name: "secret-name"},
+													Key:                  "tls.crt",
+												},
+											},
+										}, {
+											Name: "TLS_KEY",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													LocalObjectReference: corev1.LocalObjectReference{Name: "secret-name"},
+													Key:                  "tls.key",
+												},
+											},
+										}},
 									}},
 								},
 							},
@@ -519,7 +554,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 					)),
 			)),
 	}, {
-		name: "user specifies an unsupported container field",
+		name: "user specifies an unsupported container fields",
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(
 				bldr.EventListenerTrigger("tt", "v1alpha1",
@@ -532,6 +567,47 @@ func TestEventListenerValidate_error(t *testing.T) {
 								Spec: corev1.PodSpec{
 									Containers: []corev1.Container{{
 										Name: "containername",
+										Env: []corev1.EnvVar{{
+											Name:  "key",
+											Value: "value",
+										}, {
+											Name: "key1",
+											ValueFrom: &corev1.EnvVarSource{
+												ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+													Key: "key",
+												},
+											},
+										}},
+									}},
+								},
+							},
+						}),
+					)),
+			)),
+	}, {
+		name: "user specifies an invalid env for TLS connection",
+		el: bldr.EventListener("name", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tt", "v1alpha1",
+					bldr.EventListenerTriggerBinding("tb", "TriggerBinding", "v1alpha1"),
+				),
+				bldr.EventListenerResources(
+					bldr.EventListenerKubernetesResources(
+						bldr.EventListenerPodSpec(duckv1.WithPodSpec{
+							Template: duckv1.PodSpecable{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{
+										Env: []corev1.EnvVar{{
+											Name: "TLS_CERT",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: "secret-name",
+													},
+													Key: "tls.key",
+												},
+											},
+										}},
 									}},
 								},
 							},

--- a/pkg/sink/initialization.go
+++ b/pkg/sink/initialization.go
@@ -53,6 +53,10 @@ var (
 		"The timeout for Timeout Handler of EventListener Server.")
 	isMultiNSFlag = flag.Bool("is-multi-ns", false,
 		"Whether EventListener serve Multiple NS.")
+	tlsCertFlag = flag.String("tls-cert", "",
+		"The filename for the TLS certificate.")
+	tlsKeyFlag = flag.String("tls-key", "",
+		"The filename for the TLS key.")
 )
 
 // Args define the arguments for Sink.
@@ -73,6 +77,10 @@ type Args struct {
 	ELTimeOutHandler time.Duration
 	// IsMultiNS determines whether el functions as namespaced or clustered
 	IsMultiNS bool
+	// Key defines the filename for tls Key.
+	Key string
+	// Cert defines the filename for tls Cert.
+	Cert string
 }
 
 // Clients define the set of client dependencies Sink requires.
@@ -104,6 +112,8 @@ func GetArgs() (Args, error) {
 		ELWriteTimeOut:   time.Duration(*elWriteTimeOut),
 		ELIdleTimeOut:    time.Duration(*elIdleTimeOut),
 		ELTimeOutHandler: time.Duration(*elTimeOutHandler),
+		Cert:             *tlsCertFlag,
+		Key:              *tlsKeyFlag,
 	}, nil
 }
 


### PR DESCRIPTION
# Changes

Issue: https://github.com/tektoncd/triggers/issues/650

As part of this PR Triggers eventlistener now support end to end secure connection to eventlistener pod.
For more info about the feature refer [TEP-0027](https://github.com/tektoncd/community/blob/master/teps/0027-https-connection-to-triggers-eventlistener.md) .
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
`HTTPS` connection to eventlistener can be configured by tweaking eventlistener configuration
```
   apiVersion: triggers.tekton.dev/v1alpha1
   kind: EventListener
   metadata:
     name: github-listener-interceptor
   spec:
     ...
     resources:
       kubernetesResource:
         spec:
           template:
             spec:
               serviceAccountName: tekton-triggers-github-sa
               containers:
               - env:
                 - name: TLS_CERT
                   valueFrom:
                     secretKeyRef:
                       name: tls-key-secret
                       key: tls.crt
                 - name: TLS_KEY
                   valueFrom:
                     secretKeyRef:
                       name: tls-key-secret
                       key: tls.key
``` 
**Note:**
`TLS_CERT`, `TLS_KEY` are **RESERVED** env