### PR TITLE
Use Listers to fetch data in the Sink

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -87,7 +87,7 @@ rules:
 # Permissions for every EventListener deployment to function
 - apiGroups: ["triggers.tekton.dev"]
   resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers"]
-  verbs: ["get"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   # secrets are only needed for GitHub/GitLab interceptors
   resources: ["configmaps", "secrets"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,7 @@ messages.
 ```sh
 kubectl apply -f role-resources/secret.yaml
 kubectl apply -f role-resources/serviceaccount.yaml
+kubectl apply -f role-resources/clustertriggerbinding-roles
 kubectl apply -f role-resources/triggerbinding-roles
 kubectl apply -f triggertemplates/triggertemplate.yaml
 kubectl apply -f triggerbindings/triggerbinding.yaml

--- a/examples/bitbucket/role.yaml
+++ b/examples/bitbucket/role.yaml
@@ -12,8 +12,8 @@ metadata:
 rules:
   # Permissions for every EventListener deployment to function
   - apiGroups: ["triggers.tekton.dev"]
-    resources: ["eventlisteners", "triggerbindings", "triggertemplates"]
-    verbs: ["get"]
+    resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     # secrets are only needed for GitHub/GitLab interceptors, serviceaccounts only for per trigger authorization
     resources: ["configmaps", "secrets", "serviceaccounts"]
@@ -34,3 +34,29 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: tekton-triggers-bitbucket-minimal
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-triggers-bitbucket-binding
+subjects:
+  - kind: ServiceAccount
+    name: tekton-triggers-bitbucket-sa
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-triggers-bitbucket-minimal
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-triggers-bitbucket-minimal
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers
+rules:
+  # Permissions for every EventListener deployment to function
+  - apiGroups: ["triggers.tekton.dev"]
+    resources: ["clustertriggerbindings"]
+    verbs: ["get", "list", "watch"]

--- a/examples/cron/binding.yaml
+++ b/examples/cron/binding.yaml
@@ -9,3 +9,16 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: tekton-triggers-cron-minimal
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-triggers-cron-binding
+subjects:
+  - kind: ServiceAccount
+    name: tekton-triggers-cron-sa
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-triggers-cron-minimal

--- a/examples/cron/role.yaml
+++ b/examples/cron/role.yaml
@@ -5,8 +5,8 @@ metadata:
 rules:
   # Permissions for every EventListener deployment to function
   - apiGroups: ["triggers.tekton.dev"]
-    resources: ["eventlisteners", "triggerbindings", "triggertemplates"]
-    verbs: ["get"]
+    resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     # secrets are only needed for GitHub/GitLab interceptors, serviceaccounts only for per trigger authorization
     resources: ["configmaps", "secrets", "serviceaccounts"]
@@ -15,3 +15,16 @@ rules:
   - apiGroups: ["tekton.dev"]
     resources: ["pipelineruns", "pipelineresources", "taskruns"]
     verbs: ["create"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-triggers-cron-minimal
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers
+rules:
+  # Permissions for every EventListener deployment to function
+  - apiGroups: ["triggers.tekton.dev"]
+    resources: ["clustertriggerbindings"]
+    verbs: ["get", "list", "watch"]

--- a/examples/github/role.yaml
+++ b/examples/github/role.yaml
@@ -24,8 +24,8 @@ metadata:
 rules:
   # Permissions for every EventListener deployment to function
   - apiGroups: ["triggers.tekton.dev"]
-    resources: ["eventlisteners", "triggerbindings", "triggertemplates"]
-    verbs: ["get"]
+    resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     # secrets are only needed for GitHub/GitLab interceptors, serviceaccounts only for per trigger authorization
     resources: ["configmaps", "secrets", "serviceaccounts"]
@@ -34,3 +34,29 @@ rules:
   - apiGroups: ["tekton.dev"]
     resources: ["pipelineruns", "pipelineresources", "taskruns"]
     verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-triggers-github-binding
+subjects:
+  - kind: ServiceAccount
+    name: tekton-triggers-github-sa
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-triggers-github-minimal
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-triggers-github-minimal
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers
+rules:
+  # Permissions for every EventListener deployment to function
+  - apiGroups: ["triggers.tekton.dev"]
+    resources: ["clustertriggerbindings"]
+    verbs: ["get", "list", "watch"]

--- a/examples/gitlab/binding.yaml
+++ b/examples/gitlab/binding.yaml
@@ -9,3 +9,16 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: tekton-triggers-gitlab-minimal
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-triggers-gitlab-binding
+subjects:
+  - kind: ServiceAccount
+    name: tekton-triggers-gitlab-sa
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-triggers-gitlab-minimal

--- a/examples/gitlab/role.yaml
+++ b/examples/gitlab/role.yaml
@@ -5,8 +5,8 @@ metadata:
 rules:
   # Permissions for every EventListener deployment to function
   - apiGroups: ["triggers.tekton.dev"]
-    resources: ["eventlisteners", "triggerbindings", "triggertemplates"]
-    verbs: ["get"]
+    resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     # secrets are only needed for GitHub/GitLab interceptors, serviceaccounts only for per trigger authorization
     resources: ["configmaps", "secrets", "serviceaccounts"]
@@ -15,3 +15,16 @@ rules:
   - apiGroups: ["tekton.dev"]
     resources: ["pipelineruns", "pipelineresources", "taskruns"]
     verbs: ["create"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-triggers-gitlab-minimal
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers
+rules:
+  # Permissions for every EventListener deployment to function
+  - apiGroups: ["triggers.tekton.dev"]
+    resources: ["clustertriggerbindings"]
+    verbs: ["get", "list", "watch"]

--- a/examples/role-resources/clustertriggerbinding-roles/clusterbinding.yaml
+++ b/examples/role-resources/clustertriggerbinding-roles/clusterbinding.yaml
@@ -5,6 +5,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: tekton-triggers-example-sa
+  namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/examples/role-resources/clustertriggerbinding-roles/clusterrole.yaml
+++ b/examples/role-resources/clustertriggerbinding-roles/clusterrole.yaml
@@ -6,7 +6,7 @@ rules:
 # Permissions for every EventListener deployment to function
 - apiGroups: ["triggers.tekton.dev"]
   resources: ["clustertriggerbindings", "eventlisteners", "triggerbindings", "triggertemplates", "triggers"]
-  verbs: ["get"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   # secrets are only needed for GitHub/GitLab interceptors
   resources: ["configmaps", "secrets"]

--- a/examples/role-resources/triggerbinding-roles/role.yaml
+++ b/examples/role-resources/triggerbinding-roles/role.yaml
@@ -6,7 +6,7 @@ rules:
 # Permissions for every EventListener deployment to function
 - apiGroups: ["triggers.tekton.dev"]
   resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers"]
-  verbs: ["get"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   # secrets are only needed for GitHub/GitLab interceptors
   resources: ["configmaps", "secrets"]

--- a/examples/triggers/rbac.yaml
+++ b/examples/triggers/rbac.yaml
@@ -7,7 +7,7 @@ rules:
 # Permissions for every EventListener deployment to function
 - apiGroups: ["triggers.tekton.dev"]
   resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers"]
-  verbs: ["get"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   # secrets are only needed for GitHub/GitLab interceptors
   resources: ["configmaps", "secrets"]
@@ -46,3 +46,29 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: tekton-triggers-example-minimal
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-triggers-example-binding
+subjects:
+  - kind: ServiceAccount
+    name: tekton-triggers-example-sa
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-triggers-example-minimal
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-triggers-example-minimal
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers
+rules:
+  # Permissions for every EventListener deployment to function
+  - apiGroups: ["triggers.tekton.dev"]
+    resources: ["clustertriggerbindings"]
+    verbs: ["get", "list", "watch"]

--- a/examples/v1alpha1-task/README.md
+++ b/examples/v1alpha1-task/README.md
@@ -7,6 +7,7 @@ Creates an EventListener that creates a v1alpha1 TaskRun.
 1. Create the service account:
 
    ```shell script
+   kubectl apply -f examples/role-resources/clustertriggerbinding-roles
    kubectl apply -f examples/role-resources/triggerbinding-roles
    kubectl apply -f examples/role-resources/
    ```

--- a/pkg/template/resource_test.go
+++ b/pkg/template/resource_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package template
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -206,19 +205,19 @@ var (
 			},
 		},
 	}
-	getTB = func(ctx context.Context, name string, options metav1.GetOptions) (*triggersv1.TriggerBinding, error) {
+	getTB = func(name string) (*triggersv1.TriggerBinding, error) {
 		if v, ok := triggerBindings[name]; ok {
 			return v, nil
 		}
 		return nil, fmt.Errorf("error invalid name: %s", name)
 	}
-	getCTB = func(ctx context.Context, name string, options metav1.GetOptions) (*triggersv1.ClusterTriggerBinding, error) {
+	getCTB = func(name string) (*triggersv1.ClusterTriggerBinding, error) {
 		if v, ok := clusterTriggerBindings[name]; ok {
 			return v, nil
 		}
 		return nil, fmt.Errorf("error invalid name: %s", name)
 	}
-	getTT = func(ctx context.Context, name string, options metav1.GetOptions) (*triggersv1.TriggerTemplate, error) {
+	getTT = func(name string) (*triggersv1.TriggerTemplate, error) {
 		if name == "my-triggertemplate" {
 			return &tt, nil
 		}

--- a/test/eventlistener_test.go
+++ b/test/eventlistener_test.go
@@ -240,8 +240,8 @@ func TestEventListenerCreate(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "my-role"},
 			Rules: []rbacv1.PolicyRule{{
 				APIGroups: []string{triggersv1.GroupName},
-				Resources: []string{"clustertriggerbindings", "eventlisteners", "triggerbindings", "triggertemplates"},
-				Verbs:     []string{"get"},
+				Resources: []string{"clustertriggerbindings", "eventlisteners", "triggerbindings", "triggertemplates", "triggers"},
+				Verbs:     []string{"get", "list", "watch"},
 			}, {
 				APIGroups: []string{"tekton.dev"},
 				Resources: []string{"pipelineresources"},


### PR DESCRIPTION

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

This PR uses Listers to fetch data from EventListeners, Triggers, TriggerBindings, TriggerTemplates, and
ClusterTriggerBindings, rather than directly making calls to the API server. Currently, multiple informers need to be
specified when creating a Sink object.
All Triggers in examples/ work under this change.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Use Listers to fetch data in the Sink
```