### PR TITLE
Drop escaping of strings in the JSON.

### DIFF
--- a/pkg/template/event_test.go
+++ b/pkg/template/event_test.go
@@ -472,6 +472,13 @@ func TestResolveParams_Error(t *testing.T) {
 	}
 }
 
+func addOldEscape(t *triggersv1.TriggerTemplate) *triggersv1.TriggerTemplate {
+	t.Annotations = map[string]string{
+		OldEscapeAnnotation: "yes",
+	}
+	return t
+}
+
 func TestResolveResources(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -543,7 +550,7 @@ func TestResolveResources(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Seeded for UID() to return "cbhtc"
 			utilrand.Seed(0)
-			got := ResolveResources(tt.template, tt.params)
+			got := ResolveResources(addOldEscape(tt.template), tt.params)
 			// Use toString so that it is easy to compare the json.RawMessage diffs
 			if diff := cmp.Diff(toString(tt.want), toString(got)); diff != "" {
 				t.Errorf("didn't get expected resource template -want + got: %s", diff)


### PR DESCRIPTION
# Changes

Add support for the old escaping mechanism through an annotation on the
TriggerTemplate.

This removes the old replacement of `"` with `\"` in parameters, which was yielding
invalid JSON when the strings were already quoted.

Fixes: #777

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Change the escaping of parameters into TriggerTemplates.

Previously, parameters were escaped as they were being replaced into a TriggerTemplate, by replacing double-quotes " with an escaped version \", this functionality has been removed, as it was breaking quoted strings, and in some cases, rendering the resulting output unparseable.

action required: If you were relying on the escaping, you can retain the old behaviour by adding an annotation to an affected TriggerTemplate, `tekton.dev/old-escape-quotes: true"`
```