### PR TITLE
Change the webhook name to triggers-webhook

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -118,7 +118,10 @@ func main() {
 		SecretName:  secretName,
 	})
 
-	sharedmain.WebhookMainWithConfig(ctx, "webhook",
+	// NOTE(afrittoli) - we should have the name "webhook-triggers"
+	// configurable. Once the change is done on knative/pkg side
+	// knative/eventing#4530 we can inherit it from it
+	sharedmain.WebhookMainWithConfig(ctx, "webhook-triggers",
 		sharedmain.ParseAndGetConfigOrDie(),
 		certificates.NewController,
 		NewDefaultingAdmissionController,


### PR DESCRIPTION
# Changes

The "webhook" name is too generic and it creates conflicts on leases
when other services (like triggers) that use leader election run in
same namespace but with different configuration.

See https://github.com/tektoncd/pipeline/issues/3529 for more details.

Co-authored-by: Matt Moore <mattmoor@vmware.com>

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Fix an issue that caused the webhook, under certain conditions,  to fail to acquire a lease and not function correctly as a result. ```