### PR TITLE
Switch webhook apiVersions to v1

### DIFF
--- a/config/500-webhooks.yaml
+++ b/config/500-webhooks.yaml
@@ -25,7 +25,7 @@ metadata:
 # The data is populated at install time.
 
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.triggers.tekton.dev
@@ -37,6 +37,7 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1beta1
+  - v1
   clientConfig:
     service:
       name: tekton-triggers-webhook
@@ -46,7 +47,7 @@ webhooks:
   name: validation.webhook.triggers.tekton.dev
 ---
 
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.triggers.tekton.dev
@@ -58,6 +59,7 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1beta1
+  - v1
   clientConfig:
     service:
       name: tekton-triggers-webhook
@@ -66,7 +68,7 @@ webhooks:
   sideEffects: None
   name: webhook.triggers.tekton.dev
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.triggers.tekton.dev
@@ -78,6 +80,7 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1beta1
+  - v1
   clientConfig:
     service:
       name: tekton-triggers-webhook


### PR DESCRIPTION
# Changes

`apiextensions.k8s.io/v1beta1` is deprecated in Kubernetes v1.16. This change
moves our webhooks to use `apiextensions.k8s.io/v1` instead.

Port of https://github.com/tektoncd/pipeline/pull/3486

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```


/kind misc
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->
