### PR TITLE
if eventlistenertrigger sa not set, assume user means default sa

### DIFF
--- a/pkg/sink/sink.go
+++ b/pkg/sink/sink.go
@@ -242,7 +242,11 @@ func (r Sink) processTrigger(t triggersv1.Trigger, request *http.Request, event 
 
 	log.Infof("ResolvedParams : %+v", params)
 	resources := template.ResolveResources(rt.TriggerTemplate, params)
-	if err := r.CreateResources(t.Namespace, t.Spec.ServiceAccountName, resources, t.Name, eventID, log); err != nil {
+	saName := "default"
+	if len(t.Spec.ServiceAccountName) > 0 {
+		saName = t.Spec.ServiceAccountName
+	}
+	if err := r.CreateResources(t.Namespace, saName, resources, t.Name, eventID, log); err != nil {
 		log.Error(err)
 		return err
 	}


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

/hold 

A POC experiment related to https://github.com/tektoncd/triggers/issues/77 and mult-tenant event listeners

@dibyom @khrm @vdemeester FYI

First, I'm curious what breaks and what does not today when we take the "optional" nature of the ELT SA ref toward
always relevant, in that if they don't set it, we do the same thing k8s does with Pods, and assigns the `default` SA to the Pod.

Today, we end up using the EL's SA and its permissions when executing the trigger if this ELT SA is not set.

When multi-tenant event listeners become a full reality, the permission ramifications if any increase, as the multi tenant EL, presumably with enough permissions to operator on triggers with any of the namespaces it manages, come into play and only increases the potential enhanced and escalated permission flaw.

And thus, the need for making the ELT SA minimally explicit (i.e. we use default if not set) or required (they user has to put a valid sa ref) is more vital in the multi-tenant event listener case.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
