### PR TITLE
Fix permission issue for clusterrole

### DIFF
--- a/examples/bitbucket/role.yaml
+++ b/examples/bitbucket/role.yaml
@@ -58,5 +58,5 @@ metadata:
 rules:
   # Permissions for every EventListener deployment to function
   - apiGroups: ["triggers.tekton.dev"]
-    resources: ["clustertriggerbindings"]
+    resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers", "clustertriggerbindings"]
     verbs: ["get", "list", "watch"]

--- a/examples/cron/role.yaml
+++ b/examples/cron/role.yaml
@@ -26,5 +26,5 @@ metadata:
 rules:
   # Permissions for every EventListener deployment to function
   - apiGroups: ["triggers.tekton.dev"]
-    resources: ["clustertriggerbindings"]
+    resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers", "clustertriggerbindings"]
     verbs: ["get", "list", "watch"]

--- a/examples/eventlistener-tls-connection/role.yaml
+++ b/examples/eventlistener-tls-connection/role.yaml
@@ -58,5 +58,5 @@ metadata:
 rules:
   # Permissions for every EventListener deployment to function
   - apiGroups: ["triggers.tekton.dev"]
-    resources: ["clustertriggerbindings"]
+    resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers", "clustertriggerbindings"]
     verbs: ["get", "list", "watch"]

--- a/examples/github/role.yaml
+++ b/examples/github/role.yaml
@@ -58,5 +58,5 @@ metadata:
 rules:
   # Permissions for every EventListener deployment to function
   - apiGroups: ["triggers.tekton.dev"]
-    resources: ["clustertriggerbindings"]
+    resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers", "clustertriggerbindings"]
     verbs: ["get", "list", "watch"]

--- a/examples/gitlab/role.yaml
+++ b/examples/gitlab/role.yaml
@@ -26,5 +26,5 @@ metadata:
 rules:
   # Permissions for every EventListener deployment to function
   - apiGroups: ["triggers.tekton.dev"]
-    resources: ["clustertriggerbindings"]
+    resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers", "clustertriggerbindings"]
     verbs: ["get", "list", "watch"]

--- a/examples/triggers/rbac.yaml
+++ b/examples/triggers/rbac.yaml
@@ -70,5 +70,5 @@ metadata:
 rules:
   # Permissions for every EventListener deployment to function
   - apiGroups: ["triggers.tekton.dev"]
-    resources: ["clustertriggerbindings"]
+    resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers", "clustertriggerbindings"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
# Changes

**Issue:**
```
E1120 19:21:33.340895       1 reflector.go:178] k8s.io/client-go@v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible/tools/cache/reflector.go:125: Failed to list *v1alpha1.TriggerBinding: triggerbindings.triggers.tekton.dev is forbidden: User "system:serviceaccount:default:tekton-triggers-github-sa" cannot list resource "triggerbindings" in API group "triggers.tekton.dev" at the cluster scope
E1120 19:21:33.686462       1 reflector.go:178] k8s.io/client-go@v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible/tools/cache/reflector.go:125: Failed to list *v1alpha1.TriggerTemplate: triggertemplates.triggers.tekton.dev is forbidden: User "system:serviceaccount:default:tekton-triggers-github-sa" cannot list resource "triggertemplates" in API group "triggers.tekton.dev" at the cluster scope
E1120 19:21:34.547922       1 reflector.go:178] k8s.io/client-go@v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible/tools/cache/reflector.go:125: Failed to list *v1alpha1.Trigger: triggers.triggers.tekton.dev is forbidden: User "system:serviceaccount:default:tekton-triggers-github-sa" cannot list resource "triggers" in API group "triggers.tekton.dev" at the cluster scope
```

**Fix:**
Added `eventlisteners`, `triggerbindings`, `triggertemplates`, `triggers` to ClusterRole resources.

/assign @dibyom @khrm 
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```