### PR TITLE
Implement marshalJSON CEL function

### DIFF
--- a/docs/cel_expressions.md
+++ b/docs/cel_expressions.md
@@ -335,4 +335,18 @@ which can be accessed by indexing.
      <pre>'https://example.com/test?query=testing'.parseURL().query['query'] == "testing"</pre>
     </td>
   </tr>
+  <tr>
+    <th>
+     marshalJSON()
+    </th>
+    <td>
+     <pre>&lt;jsonObjectOrList&gt;.marshalJSON() -> &lt;string&gt;</pre>
+    </td>
+    <td>
+     Returns the JSON encoding of 'jsonObjectOrList' as a string.
+    </td>
+    <td>
+     <pre>{"testing":"value"}.marshalJSON() == "{\"testing\": \"value\"}"</pre>
+    </td>
+  </tr>
 </table>

--- a/pkg/interceptors/cel/cel_test.go
+++ b/pkg/interceptors/cel/cel_test.go
@@ -415,6 +415,13 @@ func TestExpressionEvaluation(t *testing.T) {
 		"yaml_body": "key1: value1\nkey2: value2\nkey3: value3\n",
 		"testURL":   "https://user:password@site.example.com/path/to?query=search#first",
 		"multiURL":  "https://user:password@site.example.com/path/to?query=search&query=results",
+		"jsonObject": map[string]interface{}{
+			"string":  "value",
+			"integer": 2,
+		},
+		"jsonArray": []string{
+			"one", "two",
+		},
 	}
 
 	refParts := strings.Split(testRef, "/")
@@ -541,6 +548,16 @@ func TestExpressionEvaluation(t *testing.T) {
 			expr: "body.upperMsg.lowerAscii()",
 			want: types.String("this is lower case"),
 		},
+		{
+			name: "marshal JSON object to string",
+			expr: "body.jsonObject.marshalJSON()",
+			want: types.String(`{"integer":2,"string":"value"}`),
+		},
+		{
+			name: "marshal JSON array to string",
+			expr: "body.jsonArray.marshalJSON()",
+			want: types.String(`["one","two"]`),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(rt *testing.T) {
@@ -655,6 +672,11 @@ func TestExpressionEvaluation_Error(t *testing.T) {
 			name: "invalid YAML body",
 			expr: "body.invalid_yaml.parseYAML().key1 == 'value1'",
 			want: "failed to decode 'key1: value1key2: value2\n' in parseYAML:",
+		},
+		{
+			name: "marshalJSON marshalling string",
+			expr: "body.value.marshalJSON()",
+			want: "unexpected type 'string' passed to marshalJSON",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This adds a CEL function which takes a JSON Object or Array and returns the JSON
encoding of that object/array as a string.

This is useful if you have a JSON object/array in the body and you want to pass
to a pipeline with a string parameter for further processing.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
New CEL function `marshalJSON` that can encode a JSON object or array to a string.
```