### PR TITLE
refactor: Do not use %w unless in fmt.Errorf

### DIFF
--- a/cmd/triggerrun/cmd/root.go
+++ b/cmd/triggerrun/cmd/root.go
@@ -254,7 +254,7 @@ func newSink(config *rest.Config, sugerLogger *zap.SugaredLogger) sink.Sink {
 	dynamicCS := dynamicClientset.New(tekton.WithClient(dynamicClient))
 	kubeClient, _, err := getKubeClient(kubeconfig)
 	if err != nil {
-		log.Fatal("fail to get clients: %w", err)
+		log.Fatalf("fail to get clients: %v", err)
 	}
 
 	s := sink.Sink{

--- a/pkg/sink/sink.go
+++ b/pkg/sink/sink.go
@@ -166,7 +166,7 @@ func (r Sink) HandleEvent(response http.ResponseWriter, request *http.Request) {
 		EventID:       eventID,
 	}
 	if err := json.NewEncoder(response).Encode(body); err != nil {
-		eventLog.Errorf("failed to write back sink response: %w", err)
+		eventLog.Errorf("failed to write back sink response: %v", err)
 	}
 }
 
@@ -211,7 +211,7 @@ func (r Sink) processTrigger(t triggersv1.Trigger, request *http.Request, event 
 
 	if iresp != nil {
 		if !iresp.Continue {
-			log.Infof("interceptor stopped trigger processing: %w", iresp.Status.Err())
+			log.Infof("interceptor stopped trigger processing: %v", iresp.Status.Err())
 			return iresp.Status.Err()
 		}
 	}

--- a/test/init_test.go
+++ b/test/init_test.go
@@ -28,7 +28,6 @@ import (
 	"testing"
 
 	"github.com/tektoncd/pipeline/pkg/names"
-	"golang.org/x/xerrors"
 	yaml "gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -166,7 +165,7 @@ func getCRDYaml(cs *clients, ns string) ([]byte, error) {
 
 	ctbs, err := cs.TriggersClient.TriggersV1alpha1().ClusterTriggerBindings().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
-		return nil, xerrors.Errorf("could not get ClusterTriggerBindings: %w", err)
+		return nil, fmt.Errorf("could not get ClusterTriggerBindings: %w", err)
 	}
 	for _, i := range ctbs.Items {
 		printOrAdd("ClusterTriggerBinding", i.Name, i)
@@ -174,7 +173,7 @@ func getCRDYaml(cs *clients, ns string) ([]byte, error) {
 
 	els, err := cs.TriggersClient.TriggersV1alpha1().EventListeners(ns).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
-		return nil, xerrors.Errorf("could not get EventListeners: %w", err)
+		return nil, fmt.Errorf("could not get EventListeners: %w", err)
 	}
 	for _, i := range els.Items {
 		printOrAdd("EventListener", i.Name, i)
@@ -182,7 +181,7 @@ func getCRDYaml(cs *clients, ns string) ([]byte, error) {
 
 	tbs, err := cs.TriggersClient.TriggersV1alpha1().TriggerBindings(ns).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
-		return nil, xerrors.Errorf("could not get TriggerBindings: %w", err)
+		return nil, fmt.Errorf("could not get TriggerBindings: %w", err)
 	}
 	for _, i := range tbs.Items {
 		printOrAdd("TriggerBindings", i.Name, i)
@@ -190,7 +189,7 @@ func getCRDYaml(cs *clients, ns string) ([]byte, error) {
 	// TODO: Update TriggerTemplates Marshalling so it isn't a byte array in debug log
 	tts, err := cs.TriggersClient.TriggersV1alpha1().TriggerTemplates(ns).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
-		return nil, xerrors.Errorf("could not get TriggerTemplates: %w", err)
+		return nil, fmt.Errorf("could not get TriggerTemplates: %w", err)
 	}
 	for _, i := range tts.Items {
 		printOrAdd("TriggerTemplate", i.Name, i)
@@ -198,7 +197,7 @@ func getCRDYaml(cs *clients, ns string) ([]byte, error) {
 
 	pods, err := cs.KubeClient.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
-		return nil, xerrors.Errorf("could not get Pods: %w", err)
+		return nil, fmt.Errorf("could not get Pods: %w", err)
 	}
 	for _, i := range pods.Items {
 		printOrAdd("Pod", i.Name, i)
@@ -206,7 +205,7 @@ func getCRDYaml(cs *clients, ns string) ([]byte, error) {
 
 	services, err := cs.KubeClient.CoreV1().Services(ns).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
-		return nil, xerrors.Errorf("could not get Services: %w", err)
+		return nil, fmt.Errorf("could not get Services: %w", err)
 	}
 	for _, i := range services.Items {
 		printOrAdd("Service", i.Name, i)
@@ -214,7 +213,7 @@ func getCRDYaml(cs *clients, ns string) ([]byte, error) {
 
 	roles, err := cs.KubeClient.RbacV1().Roles(ns).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
-		return nil, xerrors.Errorf("could not get Roles: %w", err)
+		return nil, fmt.Errorf("could not get Roles: %w", err)
 	}
 	for _, i := range roles.Items {
 		printOrAdd("Role", i.Name, i)
@@ -222,7 +221,7 @@ func getCRDYaml(cs *clients, ns string) ([]byte, error) {
 
 	roleBindings, err := cs.KubeClient.RbacV1().RoleBindings(ns).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
-		return nil, xerrors.Errorf("could not get RoleBindings: %w", err)
+		return nil, fmt.Errorf("could not get RoleBindings: %w", err)
 	}
 	for _, i := range roleBindings.Items {
 		printOrAdd("Role", i.Name, i)


### PR DESCRIPTION
# Changes

We were using %w in some Zap logger calls. %w is only supported in `fmt.Errorf`
calls and calling it in `fmt.Sprintf` will cause `go vet` to fail.
Unfortunately, since the call to Sprintf happens inside the zap library, we do
not trigger the go vet failure.

Also, cleaned up some old usages of xerrors.Errorf to just fmt.Errorf.

Fixes #853


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
NONE
```

/kind bug