### PR TITLE
Merge extensions into body for webhook interceptors

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -34,6 +34,7 @@ using [Event Interceptors](#Interceptors).
     - [Bitbucket Interceptors](#bitbucket-interceptors)
     - [CEL Interceptors](#cel-interceptors)
       - [Overlays](#overlays)
+    - [Chaining Interceptors](#chaining-interceptors)
   - [EventListener Response](#eventlistener-response)
   - [How does the EventListener work?](#how-does-the-eventlistener-work)
   - [Examples](#examples)
@@ -678,6 +679,41 @@ spec:
   - name: branch
     value: $(extensions.short_sha)
 ```
+
+### Chaining Interceptors
+
+This section documents the current behavior for passing data between interceptors. This will change as we fully implement #271.
+
+**CEL Interceptor:** Overlays from the CEL interceptor do not modify the event body. Instead they add fields to the top level `extensions` field.
+
+**Webhook Interceptors:** Webhook Interceptors *can* modify the event body currently. However, this will change in a future release when they will have to write to the extensions field like the CEL interceptor. Since the webhook interceptor does not have access to the top level `extensions` field, the EventListener will add the `extensions` field to the body before sending it to the webhook interceptor. As an example, consider the following interceptor chain:
+  
+  ```yaml
+    interceptors:
+      - cel:
+          overlays:
+            - key: "truncated_sha"
+              expression: "body.sha.truncate(5)"
+      - webhook:
+        objectRef:
+          kind: Service
+          name: some-interceptor
+          apiVersion: v1
+      - cel:
+          filter: "body.extensions.truncated_sha == \"abcde\"" # Can also be extensions.truncated_sha == \"abcde\"
+  ```
+
+In the above snipped, the first CEL interceptor adds the `truncated_sha` field. To ensure the following webhook interceptor can use this field, the EventListener will add it to the body. So, the body received by the webhook interceptor will look as follows:
+
+```
+{
+  "sha": "abcdefghi", // Original field
+  "extensions": {
+     "truncated_sha": "abcde" 
+  }
+}
+```
+Assuming the webhook interceptor does not then modify the body, the last CEL interceptor (as well as any bindings) will have access to truncated_sha both via the body as well as via extensions i.e both `$(body.extensions.truncated_sha)` as well as `$(extensions.truncated_sha)`
 
 ## EventListener Response
 

--- a/pkg/interceptors/cel/cel_test.go
+++ b/pkg/interceptors/cel/cel_test.go
@@ -49,6 +49,7 @@ func TestInterceptor_Process(t *testing.T) {
 		name           string
 		CEL            *triggersv1.CELInterceptor
 		body           []byte
+		extensions     map[string]interface{}
 		wantExtensions map[string]interface{}
 	}{{
 		name: "simple body check with matching body",
@@ -229,6 +230,20 @@ func TestInterceptor_Process(t *testing.T) {
 				"other": "thing",
 			},
 		},
+	}, {
+		name: "filters and overlays can access passed in extensions",
+		CEL: &triggersv1.CELInterceptor{
+			Filter: `extensions.foo == "bar"`,
+			Overlays: []triggersv1.CELOverlay{
+				{Key: "one", Expression: "extensions.foo"},
+			},
+		},
+		extensions: map[string]interface{}{
+			"foo": "bar",
+		},
+		wantExtensions: map[string]interface{}{
+			"one": "bar",
+		},
 	},
 	}
 	for _, tt := range tests {
@@ -247,7 +262,7 @@ func TestInterceptor_Process(t *testing.T) {
 					"X-Test":         []string{"test-value"},
 					"X-Secret-Token": []string{"secrettoken"},
 				},
-				Extensions: nil,
+				Extensions: tt.extensions,
 				InterceptorParams: map[string]interface{}{
 					"filter":   tt.CEL.Filter,
 					"overlays": tt.CEL.Overlays,
@@ -736,7 +751,7 @@ func TestMakeEvalContextWithError(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
 	payload := []byte(`{"tes`)
 
-	_, err := makeEvalContext(payload, req.Header, req.URL.String())
+	_, err := makeEvalContext(payload, req.Header, req.URL.String(), map[string]interface{}{})
 
 	if err == nil {
 		t.Fatalf("makeEvalContext(). expected err was nil")

--- a/pkg/sink/sink.go
+++ b/pkg/sink/sink.go
@@ -36,6 +36,7 @@ import (
 	"github.com/tektoncd/triggers/pkg/interceptors/webhook"
 	"github.com/tektoncd/triggers/pkg/resources"
 	"github.com/tektoncd/triggers/pkg/template"
+	"github.com/tidwall/sjson"
 	"go.uber.org/zap"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -299,12 +300,17 @@ func (r Sink) ExecuteInterceptors(t triggersv1.Trigger, in *http.Request, event 
 			// Clear interceptorParams for the next interceptor in chain
 			request.InterceptorParams = map[string]interface{}{}
 		} else {
-			// Old style interceptor (everything but CEL at the moment)
+			// Old style interceptors (Webhook)
+			// Merge any extensions into body to enable chaining behavior
+			body, err := extendBodyWithExtensions(request.Body, request.Extensions)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("could not merge extensions with body: %w", err)
+			}
 			req := &http.Request{
 				Method: http.MethodPost,
 				Header: request.Header,
 				URL:    in.URL,
-				Body:   ioutil.NopCloser(bytes.NewBuffer(request.Body)),
+				Body:   ioutil.NopCloser(bytes.NewBuffer(body)),
 			}
 
 			res, err := interceptor.ExecuteTrigger(req)
@@ -353,4 +359,20 @@ func (r Sink) CreateResources(triggerNS, sa string, res []json.RawMessage, trigg
 		}
 	}
 	return nil
+}
+
+// extendBodyWithExtensions merges the extensions into the given body.
+func extendBodyWithExtensions(body []byte, extensions map[string]interface{}) ([]byte, error) {
+	for k, v := range extensions {
+		vb, err := json.Marshal(v)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal value to JSON: %w", err)
+		}
+		body, err = sjson.SetRawBytes(body, fmt.Sprintf("extensions.%s", k), vb)
+		if err != nil {
+			return nil, fmt.Errorf("failed to sjson extensions to body: %w", err)
+		}
+	}
+
+	return body, nil
 }


### PR DESCRIPTION
With CEL interceptor writing to the `extensions` field, it is impossible to
chain added fields from a CEL interceptor to a webhook interceptor today. This
is because we do not pass the extensions field to the webhook interceptor yet.
This commit attempts to fix this by merging any extensions to the body before
sending it over to the Webhook interceptor. This is temporary until we fully
move webhook interceptors to the new pluggable interface. One implication of
this change is that the body may now contain an `extensions` field separate
from the top level extensions field if one uses the Webhook interceptor.

In addition, the CEL environment also did not have access to extensions which I
fixed.

Fixes #857

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
 Extensions added by a CEL Interceptor will be passed on to webhook interceptors by merging the extension fields into the event body under a `extensions` field. See docs/eventlisteners.md##chaining-interceptors for more details.
```
