### PR TITLE
[CHERRY-PICK] Merge extensions into body for webhook interceptors

### DIFF
--- a/pkg/interceptors/cel/cel.go
+++ b/pkg/interceptors/cel/cel.go
@@ -106,11 +106,12 @@ func makeCelEnv(ns string, k kubernetes.Interface) (*cel.Env, error) {
 		cel.Declarations(
 			decls.NewVar("body", mapStrDyn),
 			decls.NewVar("header", mapStrDyn),
+			decls.NewVar("extensions", mapStrDyn),
 			decls.NewVar("requestURL", decls.String),
 		))
 }
 
-func makeEvalContext(body []byte, h http.Header, url string) (map[string]interface{}, error) {
+func makeEvalContext(body []byte, h http.Header, url string, extensions map[string]interface{}) (map[string]interface{}, error) {
 	var jsonMap map[string]interface{}
 	err := json.Unmarshal(body, &jsonMap)
 	if err != nil {
@@ -120,6 +121,7 @@ func makeEvalContext(body []byte, h http.Header, url string) (map[string]interfa
 		"body":       jsonMap,
 		"header":     h,
 		"requestURL": url,
+		"extensions": extensions,
 	}, nil
 }
 
@@ -154,7 +156,7 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 		payload = r.Body
 	}
 
-	evalContext, err := makeEvalContext(payload, r.Header, r.Context.EventURL)
+	evalContext, err := makeEvalContext(payload, r.Header, r.Context.EventURL, r.Extensions)
 	if err != nil {
 		return &triggersv1.InterceptorResponse{
 			Continue: false,


### PR DESCRIPTION

# Changes

Cherry-pick of a079952 for release v0.10.2

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
 Extensions added by a CEL Interceptor will be passed on to webhook interceptors by merging the extension fields into the event body under a `extensions` field. See docs/eventlisteners.md##chaining-interceptors for more details.
```


/assign @khrm 
