### PR TITLE
Add flag to disable security context on EL Deployment

### DIFF
--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
@@ -174,7 +174,7 @@ func makeDeployment(ops ...func(d *appsv1.Deployment)) *appsv1.Deployment {
 					ServiceAccountName: "sa",
 					Containers: []corev1.Container{{
 						Name:  "event-listener",
-						Image: *elImage,
+						Image: *ELImage,
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: int32(*ElPort),
 							Protocol:      corev1.ProtocolTCP,
@@ -257,7 +257,7 @@ func makeDeployment(ops ...func(d *appsv1.Deployment)) *appsv1.Deployment {
 var withTLSConfig = func(d *appsv1.Deployment) {
 	d.Spec.Template.Spec.Containers = []corev1.Container{{
 		Name:  "event-listener",
-		Image: *elImage,
+		Image: *ELImage,
 		Ports: []corev1.ContainerPort{{
 			ContainerPort: int32(8443),
 			Protocol:      corev1.ProtocolTCP,


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

This is a follow up to #864 - it introduces a flag which removes the security context from all created deployments. This enables `triggers` to work correctly on OpenShift.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Add a flag to disable SecurityContext on the reconciled eventlistener Deployment
```

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:



For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
