### PR TITLE
Update CRD to apiextensions.k8s.io/v1

### DIFF
--- a/config/201-clusterrolebinding.yaml
+++ b/config/201-clusterrolebinding.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: tekton-triggers-controller-admin
@@ -30,7 +30,7 @@ roleRef:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: tekton-triggers-webhook-admin

--- a/config/300-clustertriggerbinding.yaml
+++ b/config/300-clustertriggerbinding.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clustertriggerbindings.triggers.tekton.dev
@@ -24,19 +24,29 @@ metadata:
 spec:
   group: triggers.tekton.dev
   scope: Cluster
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
   names:
     kind: ClusterTriggerBinding
     plural: clustertriggerbindings
     singular: clustertriggerbinding
     shortNames:
-      - ctb
+    - ctb
     categories:
-      - tekton
-      - tekton-triggers
-  subresources:
-    status: {}
-  version: v1alpha1
+    - tekton
+    - tekton-triggers
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        # One can use x-kubernetes-preserve-unknown-fields: true
+        # at the root of the schema (and inside any properties, additionalProperties)
+        # to get the traditional CRD behaviour that nothing is pruned, despite
+        # setting spec.preserveUnknownProperties: false.
+        #
+        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+        # See issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}

--- a/config/300-eventlistener.yaml
+++ b/config/300-eventlistener.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: eventlisteners.triggers.tekton.dev
@@ -24,10 +24,6 @@ metadata:
 spec:
   group: triggers.tekton.dev
   scope: Namespaced
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
   names:
     kind: EventListener
     plural: eventlisteners
@@ -37,18 +33,32 @@ spec:
     categories:
     - tekton
     - tekton-triggers
-  # Opt into the status subresource so metadata.generation
-  # starts to increment
-  subresources:
-    status: {}
-  version: v1alpha1
-  additionalPrinterColumns:
-  - name: Address
-    type: string
-    JSONPath: .status.address.url
-  - name: Available
-    type: string
-    JSONPath: ".status.conditions[?(@.type=='Available')].status"
-  - name: Reason
-    type: string
-    JSONPath: ".status.conditions[?(@.type=='Available')].reason"
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        # One can use x-kubernetes-preserve-unknown-fields: true
+        # at the root of the schema (and inside any properties, additionalProperties)
+        # to get the traditional CRD behaviour that nothing is pruned, despite
+        # setting spec.preserveUnknownProperties: false.
+        #
+        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+        # See issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    # Opt into the status subresource so metadata.generation
+    # starts to increment
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: Address
+      type: string
+      jsonPath: .status.address.url
+    - name: Available
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Available')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Available')].reason"

--- a/config/300-trigger.yaml
+++ b/config/300-trigger.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: triggers.triggers.tekton.dev
@@ -24,10 +24,6 @@ metadata:
 spec:
   group: triggers.tekton.dev
   scope: Namespaced
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
   names:
     kind: Trigger
     plural: triggers
@@ -37,8 +33,22 @@ spec:
     categories:
     - tekton
     - tekton-triggers
-  # Opt into the status subresource so metadata.generation
-  # starts to increment
-  subresources:
-    status: {}
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        # One can use x-kubernetes-preserve-unknown-fields: true
+        # at the root of the schema (and inside any properties, additionalProperties)
+        # to get the traditional CRD behaviour that nothing is pruned, despite
+        # setting spec.preserveUnknownProperties: false.
+        #
+        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+        # See issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    # Opt into the status subresource so metadata.generation
+    # starts to increment
+    subresources:
+      status: {}

--- a/config/300-triggerbinding.yaml
+++ b/config/300-triggerbinding.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: triggerbindings.triggers.tekton.dev
@@ -24,10 +24,6 @@ metadata:
 spec:
   group: triggers.tekton.dev
   scope: Namespaced
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
   names:
     kind: TriggerBinding
     plural: triggerbindings
@@ -37,8 +33,22 @@ spec:
     categories:
     - tekton
     - tekton-triggers
-  # Opt into the status subresource so metadata.generation
-  # starts to increment
-  subresources:
-    status: {}
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        # One can use x-kubernetes-preserve-unknown-fields: true
+        # at the root of the schema (and inside any properties, additionalProperties)
+        # to get the traditional CRD behaviour that nothing is pruned, despite
+        # setting spec.preserveUnknownProperties: false.
+        #
+        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+        # See issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    # Opt into the status subresource so metadata.generation
+    # starts to increment
+    subresources:
+      status: {}

--- a/config/300-triggertemplate.yaml
+++ b/config/300-triggertemplate.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: triggertemplates.triggers.tekton.dev
@@ -24,10 +24,6 @@ metadata:
 spec:
   group: triggers.tekton.dev
   scope: Namespaced
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
   names:
     kind: TriggerTemplate
     plural: triggertemplates
@@ -37,8 +33,22 @@ spec:
     categories:
     - tekton
     - tekton-triggers
-  # Opt into the status subresource so metadata.generation
-  # starts to increment
-  subresources:
-    status: {}
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        # One can use x-kubernetes-preserve-unknown-fields: true
+        # at the root of the schema (and inside any properties, additionalProperties)
+        # to get the traditional CRD behaviour that nothing is pruned, despite
+        # setting spec.preserveUnknownProperties: false.
+        #
+        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+        # See issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    # Opt into the status subresource so metadata.generation
+    # starts to increment
+    subresources:
+      status: {}


### PR DESCRIPTION
# Changes

Updated CRD apiVersion to use `apiextensions.k8s.io/v1` instead of `apiextensions.k8s.io/v1beta1`


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
Update CRD to use apiextensions.k8s.io/v1 instead of v1beta1
```
