### PR TITLE
Change InterceptorRequest.Body to string

### DIFF
--- a/pkg/apis/triggers/v1alpha1/interceptor_types.go
+++ b/pkg/apis/triggers/v1alpha1/interceptor_types.go
@@ -2,7 +2,6 @@ package v1alpha1
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -20,10 +19,16 @@ type InterceptorInterface interface {
 // Do not generate DeepCopy(). See #827
 // +k8s:deepcopy-gen=false
 type InterceptorRequest struct {
-	// Body is the incoming HTTP event body
-	Body json.RawMessage `json:"body,omitempty"`
+	// Body is the incoming HTTP event body. We use a "string" representation of the JSON body
+	// in order to preserve the body exactly as it was sent (including spaces etc.). This is necessary
+	// for some interceptors e.g. GitHub for validating the body with a signature. While []byte can also
+	// store an exact representation of the body, `json.Marshal` will compact []byte to a base64 encoded
+	// string which means that we will lose the spaces any time we marshal this struct.
+	Body string `json:"body,omitempty"`
+
 	// Header are the headers for the incoming HTTP event
 	Header map[string][]string `json:"header,omitempty"`
+
 	// Extensions are extra values that are added by previous interceptors in a chain
 	Extensions map[string]interface{} `json:"extensions,omitempty"`
 

--- a/pkg/interceptors/bitbucket/bitbucket.go
+++ b/pkg/interceptors/bitbucket/bitbucket.go
@@ -65,7 +65,7 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 		}
 		secretToken := secret.Data[p.SecretRef.SecretKey]
 
-		if err := gh.ValidateSignature(header, r.Body, secretToken); err != nil {
+		if err := gh.ValidateSignature(header, []byte(r.Body), secretToken); err != nil {
 			return interceptors.Failf(codes.FailedPrecondition, err.Error())
 		}
 	}

--- a/pkg/interceptors/bitbucket/bitbucket_test.go
+++ b/pkg/interceptors/bitbucket/bitbucket_test.go
@@ -117,7 +117,7 @@ func TestInterceptor_Process_ShouldContinue(t *testing.T) {
 			}
 
 			req := &triggersv1.InterceptorRequest{
-				Body: tt.payload,
+				Body: string(tt.payload),
 				Header: http.Header{
 					"Content-Type": []string{"application/json"},
 				},
@@ -263,7 +263,7 @@ func TestInterceptor_Process_ShouldNotContinue(t *testing.T) {
 			}
 
 			req := &triggersv1.InterceptorRequest{
-				Body: tt.payload,
+				Body: string(tt.payload),
 				Header: http.Header{
 					"Content-Type": []string{"application/json"},
 				},
@@ -308,7 +308,7 @@ func TestInterceptor_Process_InvalidParams(t *testing.T) {
 	}
 
 	req := &triggersv1.InterceptorRequest{
-		Body: json.RawMessage(`{}`),
+		Body: `{}`,
 		Header: http.Header{
 			"Content-Type": []string{"application/json"},
 		},

--- a/pkg/interceptors/cel/cel.go
+++ b/pkg/interceptors/cel/cel.go
@@ -131,8 +131,8 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 	}
 
 	var payload = []byte(`{}`)
-	if r.Body != nil {
-		payload = r.Body
+	if r.Body != "" {
+		payload = []byte(r.Body)
 	}
 
 	evalContext, err := makeEvalContext(payload, r.Header, r.Context.EventURL, r.Extensions)

--- a/pkg/interceptors/cel/cel_test.go
+++ b/pkg/interceptors/cel/cel_test.go
@@ -259,7 +259,7 @@ func TestInterceptor_Process(t *testing.T) {
 				Logger:        logger.Sugar(),
 			}
 			res := w.Process(ctx, &triggersv1.InterceptorRequest{
-				Body: tt.body,
+				Body: string(tt.body),
 				Header: http.Header{
 					"Content-Type":   []string{"application/json"},
 					"X-Test":         []string{"test-value"},
@@ -356,7 +356,7 @@ func TestInterceptor_Process_Error(t *testing.T) {
 				Logger: logger.Sugar(),
 			}
 			res := w.Process(context.Background(), &triggersv1.InterceptorRequest{
-				Body: tt.body,
+				Body: string(tt.body),
 				Header: http.Header{
 					"Content-Type": []string{"application/json"},
 					"X-Test":       []string{"test-value"},
@@ -392,7 +392,7 @@ func TestInterceptor_Process_InvalidParams(t *testing.T) {
 		Logger: logger.Sugar(),
 	}
 	res := w.Process(context.Background(), &triggersv1.InterceptorRequest{
-		Body:   json.RawMessage(`{}`),
+		Body:   `{}`,
 		Header: http.Header{},
 		InterceptorParams: map[string]interface{}{
 			"filter": func() {}, // Should fail JSON unmarshal

--- a/pkg/interceptors/github/github.go
+++ b/pkg/interceptors/github/github.go
@@ -71,7 +71,7 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 		}
 		secretToken := secret.Data[p.SecretRef.SecretKey]
 
-		if err := gh.ValidateSignature(header, r.Body, secretToken); err != nil {
+		if err := gh.ValidateSignature(header, []byte(r.Body), secretToken); err != nil {
 			return interceptors.Fail(codes.FailedPrecondition, err.Error())
 		}
 	}

--- a/pkg/interceptors/github/github_test.go
+++ b/pkg/interceptors/github/github_test.go
@@ -113,7 +113,7 @@ func TestInterceptor_ExecuteTrigger_Signature(t *testing.T) {
 			kubeClient := fakekubeclient.Get(ctx)
 
 			req := &triggersv1.InterceptorRequest{
-				Body: tt.payload,
+				Body: string(tt.payload),
 				Header: http.Header{
 					"Content-Type": []string{"application/json"},
 				},
@@ -258,7 +258,7 @@ func TestInterceptor_ExecuteTrigger_ShouldNotContinue(t *testing.T) {
 			kubeClient := fakekubeclient.Get(ctx)
 
 			req := &triggersv1.InterceptorRequest{
-				Body: tt.payload,
+				Body: string(tt.payload),
 				Header: http.Header{
 					"Content-Type": []string{"application/json"},
 				},
@@ -301,7 +301,7 @@ func TestInterceptor_ExecuteTrigger_with_invalid_content_type(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	kubeClient := fakekubeclient.Get(ctx)
 	req := &triggersv1.InterceptorRequest{
-		Body: json.RawMessage(`{}`),
+		Body: `{}`,
 		Header: http.Header{
 			"Content-Type":    []string{"application/x-www-form-urlencoded"},
 			"X-Hub-Signature": []string{"foo"},
@@ -337,7 +337,7 @@ func TestInterceptor_Process_InvalidParams(t *testing.T) {
 	}
 
 	req := &triggersv1.InterceptorRequest{
-		Body: json.RawMessage(`{}`),
+		Body: `{}`,
 		Header: http.Header{
 			"Content-Type": []string{"application/json"},
 		},

--- a/pkg/interceptors/gitlab/gitlab_test.go
+++ b/pkg/interceptors/gitlab/gitlab_test.go
@@ -18,7 +18,6 @@ package gitlab
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"testing"
 
@@ -99,7 +98,7 @@ func TestInterceptor_ExecuteTrigger_ShouldContinue(t *testing.T) {
 			logger := zaptest.NewLogger(t)
 			kubeClient := fakekubeclient.Get(ctx)
 			req := &triggersv1.InterceptorRequest{
-				Body: tt.payload,
+				Body: string(tt.payload),
 				Header: http.Header{
 					"Content-Type": []string{"application/json"},
 				},
@@ -238,7 +237,7 @@ func TestInterceptor_ExecuteTrigger_ShouldNotContinue(t *testing.T) {
 			logger := zaptest.NewLogger(t)
 			kubeClient := fakekubeclient.Get(ctx)
 			req := &triggersv1.InterceptorRequest{
-				Body: tt.payload,
+				Body: string(tt.payload),
 				Header: http.Header{
 					"Content-Type": []string{"application/json"},
 				},
@@ -286,7 +285,7 @@ func TestInterceptor_Process_InvalidParams(t *testing.T) {
 	}
 
 	req := &triggersv1.InterceptorRequest{
-		Body: json.RawMessage(`{}`),
+		Body: `{}`,
 		Header: http.Header{
 			"Content-Type": []string{"application/json"},
 		},

--- a/pkg/interceptors/server/server_test.go
+++ b/pkg/interceptors/server/server_test.go
@@ -37,7 +37,7 @@ func TestServer_ServeHTTP(t *testing.T) {
 		name: "valid request that should continue",
 		path: "/cel",
 		req: &v1alpha1.InterceptorRequest{
-			Body: json.RawMessage(`{}`),
+			Body: `{}`,
 			Header: map[string][]string{
 				"X-Event-Type": {"push"},
 			},
@@ -53,7 +53,7 @@ func TestServer_ServeHTTP(t *testing.T) {
 		name: "valid request that should not continue",
 		path: "/cel",
 		req: &v1alpha1.InterceptorRequest{
-			Body: json.RawMessage(`{}`),
+			Body: `{}`,
 			Header: map[string][]string{
 				"X-Event-Type": {"push"},
 			},


### PR DESCRIPTION
# Changes

Storing the body as `json.RawMessage` can lead to loss of information about
spaces in the incoming body when the InterceptorRequest is marshaled as JSON
before sending it over HTTP.

This is because Go's `json.Marshal` will encode `[]byte` as a base64 string and
base64 does not preserve spaces. Adding a custom `MarshalJSON` does not help
here since `MarshalJSON` will return a `[]byte` that will then get compacted as
base64 by `json.Marshal`.

This loss of spaces can be problematic for some use cases. For instance, the
GitHub payload signature validation requires us to compare using the exact body
as it was sent. Otherwise, the validation fails. Note that this will only be a
problem when we marshal the InterceptorRequest i.e. when we move the core
interceptors out to its own server.

Using a string means that the string will be quoted e.g. `{\"foo\": \"bar\"}`.
Go should take care of unquoting it during the unmarshaling process. However,
intercetpor authors using a different language will have to manually unquote
the string by parsing it as a JSON object.

Part of #271, #867


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
InterceptorRequest.Body is now of type string. No immediate action is required but once #271 is fully implemented, interceptor authors will have to parse the Body separately as a JSON object.
```
