### PR TITLE
Update tekton eventlistener portname owing to istio naming conventions

### DIFF
--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
@@ -52,7 +52,7 @@ const (
 	// eventListenerConfigMapName is for the automatically created ConfigMap
 	eventListenerConfigMapName = "config-logging-triggers"
 	// eventListenerServicePortName defines service port name for EventListener Service
-	eventListenerServicePortName = "listener"
+	eventListenerServicePortName = "http-listener"
 	// GeneratedResourcePrefix is the name prefix for resources generated in the
 	// EventListener reconciler
 	GeneratedResourcePrefix = "el"


### PR DESCRIPTION
https://istio.io/docs/ops/deployment/requirements/

# Changes
we should follow service port naming convention as stated here -> https://istio.io/docs/setup/kubernetes/additional-setup/requirements/
Update new latest release for ```tektoncd/trigger v0.10.2```. Creation of underlying eventlistener svc gives error about service portname as per istio naming conventions.
```
Ports in your service are missing name in the format <protocol>[-<suffix>]. Supported protocols - istio.io/docs/setup/kubernetes/spec-requirements : Operation cannot be fulfilled on deployments.apps "el-valid-eventlistener": the object has been modified; please apply your changes to the latest version and try again
```

# Release Note

```release-note
Event listener port is now called `http-listener` instead of `listener`.
```