### PR TITLE
Use system.DefaultNamespace for interceptor urls

### DIFF
--- a/cmd/interceptors/main.go
+++ b/cmd/interceptors/main.go
@@ -81,6 +81,7 @@ func main() {
 		ReadTimeout:  readTimeout,
 		WriteTimeout: writeTimeout,
 		IdleTimeout:  idleTimeout,
+		Handler:      mux,
 	}
 
 	logger.Infof("Listen and serve on port %d", Port)

--- a/pkg/interceptors/interceptors.go
+++ b/pkg/interceptors/interceptors.go
@@ -188,7 +188,7 @@ func ResolveURL(i *triggersv1.TriggerInterceptor) *url.URL {
 	}
 	return &url.URL{
 		Scheme: "http",
-		Host:   fmt.Sprintf("%s.%s.svc", CoreInterceptorsHost, system.GetNamespace()),
+		Host:   fmt.Sprintf("%s.%s.svc", CoreInterceptorsHost, system.DefaultNamespace),
 		Path:   path,
 	}
 }

--- a/pkg/interceptors/interceptors_test.go
+++ b/pkg/interceptors/interceptors_test.go
@@ -304,27 +304,27 @@ func TestResolvePath(t *testing.T) {
 		in: triggersv1.EventInterceptor{
 			CEL: &triggersv1.CELInterceptor{},
 		},
-		want: "http://tekton-triggers-core-interceptors.knative-testing.svc/cel",
+		want: "http://tekton-triggers-core-interceptors.tekton-pipelines.svc/cel",
 	}, {
 		in: triggersv1.EventInterceptor{
 			GitLab: &triggersv1.GitLabInterceptor{},
 		},
-		want: "http://tekton-triggers-core-interceptors.knative-testing.svc/gitlab",
+		want: "http://tekton-triggers-core-interceptors.tekton-pipelines.svc/gitlab",
 	}, {
 		in: triggersv1.EventInterceptor{
 			GitHub: &triggersv1.GitHubInterceptor{},
 		},
-		want: "http://tekton-triggers-core-interceptors.knative-testing.svc/github",
+		want: "http://tekton-triggers-core-interceptors.tekton-pipelines.svc/github",
 	}, {
 		in: triggersv1.EventInterceptor{
 			Bitbucket: &triggersv1.BitbucketInterceptor{},
 		},
-		want: "http://tekton-triggers-core-interceptors.knative-testing.svc/bitbucket",
+		want: "http://tekton-triggers-core-interceptors.tekton-pipelines.svc/bitbucket",
 	}, {
 		in: triggersv1.EventInterceptor{
 			Webhook: &triggersv1.WebhookInterceptor{},
 		},
-		want: "http://tekton-triggers-core-interceptors.knative-testing.svc",
+		want: "http://tekton-triggers-core-interceptors.tekton-pipelines.svc",
 	}} {
 		t.Run(tc.want, func(t *testing.T) {
 			got := interceptors.ResolveURL(&tc.in)


### PR DESCRIPTION


# Changes

SYSTEM_NAMESPACE is set to the namespace of the EventListener by the reconciler
which means that with the current logic the interceptor url is wrong. Use
default namespace to always use `tekton-pipelines` as the namespace. This is
hardcoded and the logic is temporary till we implement #868.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
