### PR TITLE
Remove the template.Name field

### DIFF
--- a/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/ptr"
 )
 
 func Test_EventListenerValidate(t *testing.T) {
@@ -142,7 +143,7 @@ func Test_EventListenerValidate(t *testing.T) {
 			},
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
-					Template: &v1alpha1.EventListenerTemplate{Name: "tt"},
+					Template: &v1alpha1.EventListenerTemplate{Ref: ptr.String("tt")},
 					Bindings: []*v1alpha1.EventListenerBinding{{
 						Name: "bname",
 						Spec: &v1alpha1.TriggerBindingSpec{
@@ -270,7 +271,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			},
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
-					Template: &v1alpha1.EventListenerTemplate{Name: "tt"},
+					Template: &v1alpha1.EventListenerTemplate{Ref: ptr.String("tt")},
 					Bindings: []*v1alpha1.EventListenerBinding{{
 						Ref:  "tb",
 						Name: "",
@@ -294,7 +295,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{Ref: "", Kind: v1alpha1.NamespacedTriggerBindingKind}},
-					Template: &v1alpha1.EventListenerTemplate{Name: "tt"},
+					Template: &v1alpha1.EventListenerTemplate{Ref: ptr.String("tt")},
 				}},
 			},
 		},
@@ -308,7 +309,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{Ref: "tb", Kind: ""}},
-					Template: &v1alpha1.EventListenerTemplate{Name: "tt"},
+					Template: &v1alpha1.EventListenerTemplate{Ref: ptr.String("tt")},
 				}},
 			},
 		},
@@ -322,7 +323,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
-					Template: &v1alpha1.EventListenerTemplate{Name: "tt", APIVersion: "invalid"},
+					Template: &v1alpha1.EventListenerTemplate{Ref: ptr.String("tt"), APIVersion: "invalid"},
 				}},
 			},
 		},
@@ -336,7 +337,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
-					Template: &v1alpha1.EventListenerTemplate{Name: "", APIVersion: "v1alpha1"},
+					Template: &v1alpha1.EventListenerTemplate{Ref: ptr.String(""), APIVersion: "v1alpha1"},
 				}},
 			},
 		},
@@ -358,7 +359,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings:     []*v1alpha1.EventListenerBinding{{Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
-					Template:     &v1alpha1.EventListenerTemplate{Name: "tt"},
+					Template:     &v1alpha1.EventListenerTemplate{Ref: ptr.String("tt")},
 					Interceptors: []*v1alpha1.EventInterceptor{{}},
 				}},
 			},
@@ -373,7 +374,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
-					Template: &v1alpha1.EventListenerTemplate{Name: "tt"},
+					Template: &v1alpha1.EventListenerTemplate{Ref: ptr.String("tt")},
 					Interceptors: []*v1alpha1.EventInterceptor{{
 						Webhook: &v1alpha1.WebhookInterceptor{
 							ObjectRef: &corev1.ObjectReference{
@@ -447,7 +448,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
-					Template: &v1alpha1.EventListenerTemplate{Name: "tt"},
+					Template: &v1alpha1.EventListenerTemplate{Ref: ptr.String("tt")},
 					Interceptors: []*v1alpha1.EventInterceptor{{
 						GitHub:    &v1alpha1.GitHubInterceptor{},
 						GitLab:    &v1alpha1.GitLabInterceptor{},
@@ -466,7 +467,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
-					Template: &v1alpha1.EventListenerTemplate{Name: "tt"},
+					Template: &v1alpha1.EventListenerTemplate{Ref: ptr.String("tt")},
 					Interceptors: []*v1alpha1.EventInterceptor{{
 						CEL: &v1alpha1.CELInterceptor{},
 					}},

--- a/pkg/apis/triggers/v1alpha1/trigger_defaults.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_defaults.go
@@ -46,7 +46,6 @@ func (t *Trigger) SetDefaults(ctx context.Context) {
 		}
 	}
 	t.Spec.Bindings = bindings
-	templateNameToRef(&t.Spec.Template)
 }
 
 // set default TriggerBinding kind for Bindings in TriggerSpec
@@ -57,13 +56,5 @@ func (t triggerSpecBindingArray) defaultBindings() {
 				b.Kind = NamespacedTriggerBindingKind
 			}
 		}
-	}
-}
-
-func templateNameToRef(template *TriggerSpecTemplate) {
-	name := template.Name
-	if name != "" && template.Ref == nil {
-		template.Ref = &name
-		template.Name = ""
 	}
 }

--- a/pkg/apis/triggers/v1alpha1/trigger_defaults_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_defaults_test.go
@@ -113,25 +113,6 @@ func TestTriggerSetDefaults(t *testing.T) {
 				}},
 			},
 		},
-	}, {
-		name: "sets template name to ref",
-		wc:   v1alpha1.WithUpgradeViaDefaulting,
-		in: &v1alpha1.Trigger{
-			Spec: v1alpha1.TriggerSpec{
-				Template: v1alpha1.TriggerSpecTemplate{
-					Name: "tt-name",
-				},
-			},
-		},
-		want: &v1alpha1.Trigger{
-			Spec: v1alpha1.TriggerSpec{
-				Bindings: []*v1alpha1.TriggerSpecBinding{},
-				Template: v1alpha1.TriggerSpecTemplate{
-					Ref:  ptr.String("tt-name"),
-					Name: "",
-				},
-			},
-		},
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/apis/triggers/v1alpha1/trigger_types.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_types.go
@@ -39,8 +39,6 @@ type TriggerSpec struct {
 }
 
 type TriggerSpecTemplate struct {
-	// Deprecated: Use Ref instead
-	Name       string               `json:"name"`
 	Ref        *string              `json:"ref,omitempty"`
 	APIVersion string               `json:"apiversion,omitempty"`
 	Spec       *TriggerTemplateSpec `json:"spec,omitempty"`

--- a/pkg/apis/triggers/v1alpha1/trigger_types_convert_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_types_convert_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"knative.dev/pkg/ptr"
 )
 
 func TestToEventListenerTrigger(t *testing.T) {
@@ -38,13 +39,13 @@ func TestToEventListenerTrigger(t *testing.T) {
 			in: TriggerSpec{
 				Name: "foo",
 				Template: TriggerSpecTemplate{
-					Name: "baz",
+					Ref: ptr.String("baz"),
 				},
 			},
 			out: EventListenerTrigger{
 				Name: "foo",
 				Template: &EventListenerTemplate{
-					Name: "baz",
+					Ref: ptr.String("baz"),
 				},
 			},
 		},
@@ -69,7 +70,7 @@ func TestToEventListenerTrigger(t *testing.T) {
 					},
 				}},
 				Template: TriggerSpecTemplate{
-					Name:       "a",
+					Ref:        ptr.String("a"),
 					APIVersion: "b",
 				},
 			},
@@ -92,7 +93,7 @@ func TestToEventListenerTrigger(t *testing.T) {
 					},
 				}},
 				Template: &EventListenerTemplate{
-					Name:       "a",
+					Ref:        ptr.String("a"),
 					APIVersion: "b",
 				},
 			},

--- a/pkg/apis/triggers/v1alpha1/trigger_validation.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_validation.go
@@ -55,16 +55,6 @@ func (t TriggerSpecTemplate) validate(ctx context.Context) (errs *apis.FieldErro
 		}
 	}
 
-	// Validate only one of Name or Ref is set.
-	if t.Name != "" && t.Ref != nil {
-		errs = errs.Also(apis.ErrMultipleOneOf("template.name", "template.ref"))
-	}
-
-	// Set Ref to Name
-	if t.Name != "" {
-		t.Ref = &t.Name
-	}
-
 	switch {
 	case t.Spec != nil && t.Ref != nil:
 		errs = errs.Also(apis.ErrMultipleOneOf("template.spec", "template.ref"))

--- a/pkg/apis/triggers/v1alpha1/trigger_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_validation_test.go
@@ -80,7 +80,7 @@ func Test_TriggerValidate(t *testing.T) {
 					Ref:  "ref-to-another-binding",
 					Kind: v1alpha1.NamespacedTriggerBindingKind,
 				}},
-				Template: v1alpha1.TriggerSpecTemplate{Name: "my-tt"},
+				Template: v1alpha1.TriggerSpecTemplate{Ref: ptr.String("baz")},
 			},
 		},
 	}, {
@@ -144,7 +144,7 @@ func Test_TriggerValidate(t *testing.T) {
 			},
 			Spec: v1alpha1.TriggerSpec{
 				Bindings: []*v1alpha1.TriggerSpecBinding{{Spec: &v1alpha1.TriggerBindingSpec{}, Name: "foo"}},
-				Template: v1alpha1.TriggerSpecTemplate{Name: "tt"},
+				Template: v1alpha1.TriggerSpecTemplate{Ref: ptr.String("tt")},
 			},
 		},
 	}, {
@@ -187,7 +187,7 @@ func Test_TriggerValidate(t *testing.T) {
 			},
 			Spec: v1alpha1.TriggerSpec{
 				Template: v1alpha1.TriggerSpecTemplate{
-					Name: "ref-to-a-template",
+					Ref: ptr.String("ref-to-a-template"),
 				},
 			},
 		},
@@ -219,7 +219,7 @@ func TestTriggerValidate_error(t *testing.T) {
 			},
 			Spec: v1alpha1.TriggerSpec{
 				Bindings: []*v1alpha1.TriggerSpecBinding{{Name: "", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "", APIVersion: "v1alpha1"}},
-				Template: v1alpha1.TriggerSpecTemplate{Name: "tt"},
+				Template: v1alpha1.TriggerSpecTemplate{Ref: ptr.String("tt")},
 			},
 		},
 	}, {
@@ -231,7 +231,7 @@ func TestTriggerValidate_error(t *testing.T) {
 			},
 			Spec: v1alpha1.TriggerSpec{
 				Bindings: []*v1alpha1.TriggerSpecBinding{{Name: "tb", Kind: "", Ref: "tb", APIVersion: "v1alpha1"}},
-				Template: v1alpha1.TriggerSpecTemplate{Name: "tt"},
+				Template: v1alpha1.TriggerSpecTemplate{Ref: ptr.String("tt")},
 			},
 		},
 	}, {
@@ -243,7 +243,7 @@ func TestTriggerValidate_error(t *testing.T) {
 			},
 			Spec: v1alpha1.TriggerSpec{
 				Bindings: []*v1alpha1.TriggerSpecBinding{{Kind: "BadKind", Ref: "tb", APIVersion: "v1alpha1"}},
-				Template: v1alpha1.TriggerSpecTemplate{Name: "tt"},
+				Template: v1alpha1.TriggerSpecTemplate{Ref: ptr.String("tt")},
 			},
 		},
 	}, {
@@ -255,7 +255,7 @@ func TestTriggerValidate_error(t *testing.T) {
 			},
 			Spec: v1alpha1.TriggerSpec{
 				Bindings: []*v1alpha1.TriggerSpecBinding{{Name: "foo"}},
-				Template: v1alpha1.TriggerSpecTemplate{Name: "tt"},
+				Template: v1alpha1.TriggerSpecTemplate{Ref: ptr.String("tt")},
 			},
 		},
 	}, {
@@ -267,31 +267,7 @@ func TestTriggerValidate_error(t *testing.T) {
 			},
 			Spec: v1alpha1.TriggerSpec{
 				Bindings: []*v1alpha1.TriggerSpecBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb", APIVersion: "v1alpha1"}},
-				Template: v1alpha1.TriggerSpecTemplate{Name: "tt", APIVersion: "invalid"},
-			},
-		},
-	}, {
-		name: "Template with missing Name", // TODO(#791): Remove when Name is removed
-		tr: &v1alpha1.Trigger{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
-			Spec: v1alpha1.TriggerSpec{
-				Bindings: []*v1alpha1.TriggerSpecBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb", APIVersion: "v1alpha1"}},
-				Template: v1alpha1.TriggerSpecTemplate{Name: "", APIVersion: "v1alpha1"},
-			},
-		},
-	}, {
-		name: "Template with both Name and Ref", // TODO(#791): Remove when Name is removed
-		tr: &v1alpha1.Trigger{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
-			Spec: v1alpha1.TriggerSpec{
-				Bindings: []*v1alpha1.TriggerSpecBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb", APIVersion: "v1alpha1"}},
-				Template: v1alpha1.TriggerSpecTemplate{Name: "tt", Ref: ptr.String("tt"), APIVersion: "v1alpha1"},
+				Template: v1alpha1.TriggerSpecTemplate{Ref: ptr.String("tt"), APIVersion: "invalid"},
 			},
 		},
 	}, {
@@ -335,7 +311,7 @@ func TestTriggerValidate_error(t *testing.T) {
 			},
 			Spec: v1alpha1.TriggerSpec{
 				Bindings:     []*v1alpha1.TriggerSpecBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb", APIVersion: "v1alpha1"}},
-				Template:     v1alpha1.TriggerSpecTemplate{Name: "tt", APIVersion: "v1alpha1"},
+				Template:     v1alpha1.TriggerSpecTemplate{Ref: ptr.String("tt"), APIVersion: "v1alpha1"},
 				Interceptors: []*v1alpha1.TriggerInterceptor{{}},
 			},
 		},
@@ -348,7 +324,7 @@ func TestTriggerValidate_error(t *testing.T) {
 			},
 			Spec: v1alpha1.TriggerSpec{
 				Bindings: []*v1alpha1.TriggerSpecBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb", APIVersion: "v1alpha1"}},
-				Template: v1alpha1.TriggerSpecTemplate{Name: "tt", APIVersion: "v1alpha1"},
+				Template: v1alpha1.TriggerSpecTemplate{Ref: ptr.String("tt"), APIVersion: "v1alpha1"},
 				Interceptors: []*v1alpha1.TriggerInterceptor{{
 					Webhook: &v1alpha1.WebhookInterceptor{
 						ObjectRef: &corev1.ObjectReference{
@@ -420,7 +396,7 @@ func TestTriggerValidate_error(t *testing.T) {
 			},
 			Spec: v1alpha1.TriggerSpec{
 				Bindings: []*v1alpha1.TriggerSpecBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
-				Template: v1alpha1.TriggerSpecTemplate{Name: "tt"},
+				Template: v1alpha1.TriggerSpecTemplate{Ref: ptr.String("tt")},
 				Interceptors: []*v1alpha1.TriggerInterceptor{{
 					GitHub:    &v1alpha1.GitHubInterceptor{},
 					GitLab:    &v1alpha1.GitLabInterceptor{},
@@ -437,7 +413,7 @@ func TestTriggerValidate_error(t *testing.T) {
 			},
 			Spec: v1alpha1.TriggerSpec{
 				Bindings: []*v1alpha1.TriggerSpecBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
-				Template: v1alpha1.TriggerSpecTemplate{Name: "tt"},
+				Template: v1alpha1.TriggerSpecTemplate{Ref: ptr.String("tt")},
 				Interceptors: []*v1alpha1.TriggerInterceptor{{
 					CEL: &v1alpha1.CELInterceptor{},
 				}},
@@ -480,7 +456,7 @@ func TestTriggerValidate_error(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "name"},
 			Spec: v1alpha1.TriggerSpec{
 				Template: v1alpha1.TriggerSpecTemplate{
-					Name: "ttname",
+					Ref: ptr.String("tt-name"),
 					Spec: &v1alpha1.TriggerTemplateSpec{
 						ResourceTemplates: []v1alpha1.TriggerResourceTemplate{{
 							RawExtension: test.RawExtension(t, pipelinev1.PipelineRun{

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -679,7 +679,7 @@ func TestHandleEventPassesURLThrough(t *testing.T) {
 		Spec: triggersv1.EventListenerSpec{
 			Triggers: []triggersv1.EventListenerTrigger{{
 				Bindings: []*triggersv1.EventListenerBinding{{Ref: "tb", Kind: "TriggerBinding"}},
-				Template: &triggersv1.EventListenerTemplate{Name: "tt"},
+				Template: &triggersv1.EventListenerTemplate{Ref: ptr.String("tt")},
 				Interceptors: []*triggersv1.EventInterceptor{{
 					CEL: &triggersv1.CELInterceptor{
 						Overlays: []triggersv1.CELOverlay{
@@ -793,7 +793,7 @@ func TestHandleEventWithWebhookInterceptors(t *testing.T) {
 	for i := 0; i < numTriggers; i++ {
 		trigger := triggersv1.EventListenerTrigger{
 			Bindings: []*triggersv1.EventListenerBinding{{Ref: "tb", Kind: "TriggerBinding"}},
-			Template: &triggersv1.EventListenerTemplate{Name: "tt"},
+			Template: &triggersv1.EventListenerTemplate{Ref: ptr.String("tt")},
 			Interceptors: []*triggersv1.EventInterceptor{{
 				Webhook: &triggersv1.WebhookInterceptor{
 					ObjectRef: interceptorObjectRef,
@@ -1300,7 +1300,7 @@ func TestHandleEventWithInterceptorsAndTriggerAuth(t *testing.T) {
 				Triggers: []triggersv1.EventListenerTrigger{{
 					ServiceAccountName: testCase.userVal,
 					Bindings:           []*triggersv1.EventListenerBinding{{Ref: "tb", Kind: "TriggerBinding"}},
-					Template:           &triggersv1.EventListenerTemplate{Name: "tt"},
+					Template:           &triggersv1.EventListenerTemplate{Ref: ptr.String("tt")},
 					Interceptors: []*triggersv1.EventInterceptor{{
 						GitHub: &triggersv1.GitHubInterceptor{
 							SecretRef: &triggersv1.SecretRef{
@@ -1387,7 +1387,7 @@ func TestHandleEventWithBitbucketInterceptors(t *testing.T) {
 			Triggers: []triggersv1.EventListenerTrigger{{
 				ServiceAccountName: userWithPermissions,
 				Bindings:           []*triggersv1.EventListenerBinding{{Ref: "tb", Kind: "TriggerBinding"}},
-				Template:           &triggersv1.EventListenerTemplate{Name: "tt"},
+				Template:           &triggersv1.EventListenerTemplate{Ref: ptr.String("tt")},
 				Interceptors: []*triggersv1.EventInterceptor{{
 					Bitbucket: &triggersv1.BitbucketInterceptor{
 						SecretRef: &triggersv1.SecretRef{

--- a/pkg/template/resource.go
+++ b/pkg/template/resource.go
@@ -62,10 +62,6 @@ func ResolveTrigger(trigger triggersv1.Trigger, getTB getTriggerBinding, getCTB 
 		var ttName string
 		if trigger.Spec.Template.Ref != nil {
 			ttName = *trigger.Spec.Template.Ref
-		} else {
-			// TODO(#791): Remove Name field
-			// Ignore staticcheck linter as it will complain about using deprecated type
-			ttName = trigger.Spec.Template.Name //nolint:staticcheck
 		}
 		resolvedTT, err = getTT(ttName)
 		if err != nil {

--- a/pkg/template/resource_test.go
+++ b/pkg/template/resource_test.go
@@ -306,7 +306,7 @@ func Test_ResolveTrigger(t *testing.T) {
 						Kind: triggersv1.NamespacedTriggerBindingKind,
 					}},
 					Template: triggersv1.EventListenerTemplate{
-						Name:       "my-triggertemplate",
+						Ref:        ptr.String("my-triggertemplate"),
 						APIVersion: "v1alpha1",
 					},
 				},
@@ -325,7 +325,7 @@ func Test_ResolveTrigger(t *testing.T) {
 						Kind: triggersv1.ClusterTriggerBindingKind,
 					}},
 					Template: triggersv1.EventListenerTemplate{
-						Name:       "my-triggertemplate",
+						Ref:        ptr.String("my-triggertemplate"),
 						APIVersion: "v1alpha1",
 					},
 				},
@@ -349,7 +349,7 @@ func Test_ResolveTrigger(t *testing.T) {
 						},
 					}},
 					Template: triggersv1.EventListenerTemplate{
-						Name:       "my-triggertemplate",
+						Ref:        ptr.String("my-triggertemplate"),
 						APIVersion: "v1alpha1",
 					},
 				},
@@ -367,7 +367,7 @@ func Test_ResolveTrigger(t *testing.T) {
 			trigger: triggersv1.Trigger{
 				Spec: triggersv1.TriggerSpec{
 					Template: triggersv1.EventListenerTemplate{
-						Name:       "my-triggertemplate",
+						Ref:        ptr.String("my-triggertemplate"),
 						APIVersion: "v1alpha1",
 					},
 				},
@@ -379,7 +379,7 @@ func Test_ResolveTrigger(t *testing.T) {
 			trigger: triggersv1.Trigger{
 				Spec: triggersv1.TriggerSpec{
 					Template: triggersv1.EventListenerTemplate{
-						Name: "my-triggertemplate",
+						Ref: ptr.String("my-triggertemplate"),
 					},
 					Bindings: []*triggersv1.EventListenerBinding{{
 						Name:  "p1",
@@ -425,7 +425,7 @@ func Test_ResolveTrigger(t *testing.T) {
 						Value: ptr.String("v2"),
 					}},
 					Template: triggersv1.EventListenerTemplate{
-						Name:       "my-triggertemplate",
+						Ref:        ptr.String("my-triggertemplate"),
 						APIVersion: "v1alpha1",
 					},
 				},
@@ -457,7 +457,7 @@ func Test_ResolveTrigger(t *testing.T) {
 						Ref:        "my-triggerbinding",
 					}},
 					Template: triggersv1.EventListenerTemplate{
-						Name:       "my-triggertemplate",
+						Ref:        ptr.String("my-triggertemplate"),
 						APIVersion: "v1alpha1",
 					},
 				},
@@ -541,7 +541,7 @@ func Test_ResolveTrigger_error(t *testing.T) {
 						Kind: triggersv1.NamespacedTriggerBindingKind,
 					}},
 					Template: triggersv1.EventListenerTemplate{
-						Name:       "my-triggertemplate",
+						Ref:        ptr.String("my-triggertemplate"),
 						APIVersion: "v1alpha1",
 					},
 				},
@@ -559,7 +559,7 @@ func Test_ResolveTrigger_error(t *testing.T) {
 						Kind: triggersv1.ClusterTriggerBindingKind,
 					}},
 					Template: triggersv1.EventListenerTemplate{
-						Name:       "my-triggertemplate",
+						Ref:        ptr.String("my-triggertemplate"),
 						APIVersion: "v1alpha1",
 					},
 				},
@@ -577,7 +577,7 @@ func Test_ResolveTrigger_error(t *testing.T) {
 						Kind: triggersv1.NamespacedTriggerBindingKind,
 					}},
 					Template: triggersv1.EventListenerTemplate{
-						Name:       "invalid-tt-name",
+						Ref:        ptr.String("invalid-tt-name"),
 						APIVersion: "v1alpha1",
 					},
 				},
@@ -595,7 +595,7 @@ func Test_ResolveTrigger_error(t *testing.T) {
 						Kind: triggersv1.NamespacedTriggerBindingKind,
 					}},
 					Template: triggersv1.EventListenerTemplate{
-						Name:       "invalid-tt-name",
+						Ref:        ptr.String("invalid-tt-name"),
 						APIVersion: "v1alpha1",
 					},
 				},
@@ -605,11 +605,11 @@ func Test_ResolveTrigger_error(t *testing.T) {
 			getTT:  getTT,
 		},
 		{
-			name: "trigger template missing name",
+			name: "trigger template missing ref",
 			trigger: triggersv1.Trigger{
 				Spec: triggersv1.TriggerSpec{
 					Template: triggersv1.EventListenerTemplate{
-						Name: "",
+						Ref: ptr.String(""),
 					},
 				},
 			},
@@ -620,7 +620,7 @@ func Test_ResolveTrigger_error(t *testing.T) {
 			trigger: triggersv1.Trigger{
 				Spec: triggersv1.TriggerSpec{
 					Template: triggersv1.EventListenerTemplate{
-						Name: "my-triggertemplate",
+						Ref: ptr.String("my-triggertemplate"),
 					},
 					Bindings: []*triggersv1.EventListenerBinding{{
 						Value: ptr.String("only-val"),

--- a/test/builder/eventlistener.go
+++ b/test/builder/eventlistener.go
@@ -109,7 +109,7 @@ func EventListenerTrigger(ttName, apiVersion string, ops ...EventListenerTrigger
 	return func(spec *v1alpha1.EventListenerSpec) {
 		t := v1alpha1.EventListenerTrigger{
 			Template: &v1alpha1.EventListenerTemplate{
-				Name:       ttName,
+				Ref:        &ttName,
 				APIVersion: apiVersion,
 			},
 		}

--- a/test/builder/eventlistener_test.go
+++ b/test/builder/eventlistener_test.go
@@ -28,6 +28,7 @@ import (
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
+	"knative.dev/pkg/ptr"
 )
 
 func TestEventListenerBuilder(t *testing.T) {
@@ -203,7 +204,7 @@ func TestEventListenerBuilder(t *testing.T) {
 						APIVersion: "v1alpha1",
 					}},
 					Template: &v1alpha1.EventListenerTemplate{
-						Name:       "tt1",
+						Ref:        ptr.String("tt1"),
 						APIVersion: "v1alpha1",
 					},
 				}},
@@ -233,7 +234,7 @@ func TestEventListenerBuilder(t *testing.T) {
 						APIVersion: "v1alpha1",
 					}},
 					Template: &v1alpha1.EventListenerTemplate{
-						Name:       "tt1",
+						Ref:        ptr.String("tt1"),
 						APIVersion: "v1alpha1",
 					},
 				}},
@@ -263,7 +264,7 @@ func TestEventListenerBuilder(t *testing.T) {
 						APIVersion: "v1alpha1",
 					}},
 					Template: &v1alpha1.EventListenerTemplate{
-						Name:       "tt1",
+						Ref:        ptr.String("tt1"),
 						APIVersion: "v1alpha1",
 					},
 				}},
@@ -300,7 +301,7 @@ func TestEventListenerBuilder(t *testing.T) {
 						},
 					},
 					Template: &v1alpha1.EventListenerTemplate{
-						Name:       "tt1",
+						Ref:        ptr.String("tt1"),
 						APIVersion: "v1alpha1",
 					},
 				}},
@@ -338,7 +339,7 @@ func TestEventListenerBuilder(t *testing.T) {
 						APIVersion: "v1alpha1",
 					}},
 					Template: &v1alpha1.EventListenerTemplate{
-						Name:       "tt1",
+						Ref:        ptr.String("tt1"),
 						APIVersion: "v1alpha1",
 					},
 				}, {
@@ -348,7 +349,7 @@ func TestEventListenerBuilder(t *testing.T) {
 						APIVersion: "v1alpha1",
 					}},
 					Template: &v1alpha1.EventListenerTemplate{
-						Name:       "tt2",
+						Ref:        ptr.String("tt2"),
 						APIVersion: "v1alpha1",
 					},
 				},
@@ -397,7 +398,7 @@ func TestEventListenerBuilder(t *testing.T) {
 						APIVersion: "v1alpha1",
 					}},
 					Template: &v1alpha1.EventListenerTemplate{
-						Name:       "tt1",
+						Ref:        ptr.String("tt1"),
 						APIVersion: "v1alpha1",
 					},
 				}},
@@ -449,7 +450,7 @@ func TestEventListenerBuilder(t *testing.T) {
 						APIVersion: "v1alpha1",
 					}},
 					Template: &v1alpha1.EventListenerTemplate{
-						Name:       "tt1",
+						Ref:        ptr.String("tt1"),
 						APIVersion: "v1alpha1",
 					},
 				}},
@@ -491,7 +492,7 @@ func TestEventListenerBuilder(t *testing.T) {
 						APIVersion: "v1alpha1",
 					}},
 					Template: &v1alpha1.EventListenerTemplate{
-						Name:       "tt1",
+						Ref:        ptr.String("tt1"),
 						APIVersion: "v1alpha1",
 					},
 				}},
@@ -523,7 +524,7 @@ func TestEventListenerBuilder(t *testing.T) {
 						APIVersion: "v1alpha1",
 					}},
 					Template: &v1alpha1.EventListenerTemplate{
-						Name:       "tt1",
+						Ref:        ptr.String("tt1"),
 						APIVersion: "v1alpha1",
 					},
 				}},

--- a/test/eventlistener_scale_test.go
+++ b/test/eventlistener_scale_test.go
@@ -84,7 +84,7 @@ func TestEventListenerScale(t *testing.T) {
 				APIVersion: "v1alpha1",
 			}},
 			Template: &triggersv1.EventListenerTemplate{
-				Name:       "my-triggertemplate",
+				Ref:        ptr.String("my-triggertemplate"),
 				APIVersion: "v1alpha1",
 			},
 		}


### PR DESCRIPTION
# Changes


Simple PR which removes the already deprecated field.

Closes: #791 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Remove the Name field from the trigger spec. Use Ref instead.
```

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
