### PR TITLE
Revert removal of template.Name field and handle Deprecation of template.Name field

### DIFF
--- a/pkg/apis/triggers/v1alpha1/event_listener_defaults.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_defaults.go
@@ -30,6 +30,9 @@ func (el *EventListener) SetDefaults(ctx context.Context) {
 		for i := range el.Spec.Triggers {
 			triggerSpecBindingArray(el.Spec.Triggers[i].Bindings).
 				defaultBindings()
+			if el.Spec.Triggers[i].Template != nil {
+				templateNameToRef(el.Spec.Triggers[i].Template)
+			}
 		}
 		// Remove Deprecated Resource Fields
 		// To be removed in a later release #904

--- a/pkg/apis/triggers/v1alpha1/event_listener_defaults_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_defaults_test.go
@@ -162,6 +162,27 @@ func TestEventListenerSetDefaults(t *testing.T) {
 				Replicas: ptr.Int32(2),
 			},
 		},
+	}, {
+		name: "deprecate template name",
+		in: &v1alpha1.EventListener{
+			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					Template: &v1alpha1.TriggerSpecTemplate{
+						DeprecatedName: "foo",
+					},
+				}},
+			},
+		},
+		wc: v1alpha1.WithUpgradeViaDefaulting,
+		want: &v1alpha1.EventListener{
+			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					Template: &v1alpha1.TriggerSpecTemplate{
+						Ref: ptr.String("foo"),
+					},
+				}},
+			},
+		},
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
-	"knative.dev/pkg/ptr"
 )
 
 func Test_EventListenerValidate(t *testing.T) {
@@ -250,7 +249,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{Ref: "", Kind: v1alpha1.NamespacedTriggerBindingKind}},
-					Template: &v1alpha1.EventListenerTemplate{Ref: ptr.String("tt")},
+					Template: &v1alpha1.EventListenerTemplate{DeprecatedName: "tt"},
 				}},
 			},
 		},
@@ -264,7 +263,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{Ref: "tb", Kind: ""}},
-					Template: &v1alpha1.EventListenerTemplate{Ref: ptr.String("tt")},
+					Template: &v1alpha1.EventListenerTemplate{DeprecatedName: "tt"},
 				}},
 			},
 		},
@@ -278,7 +277,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
-					Template: &v1alpha1.EventListenerTemplate{Ref: ptr.String("tt"), APIVersion: "invalid"},
+					Template: &v1alpha1.EventListenerTemplate{DeprecatedName: "tt", APIVersion: "invalid"},
 				}},
 			},
 		},
@@ -292,7 +291,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
-					Template: &v1alpha1.EventListenerTemplate{Ref: ptr.String(""), APIVersion: "v1alpha1"},
+					Template: &v1alpha1.EventListenerTemplate{DeprecatedName: "", APIVersion: "v1alpha1"},
 				}},
 			},
 		},
@@ -314,7 +313,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings:     []*v1alpha1.EventListenerBinding{{Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
-					Template:     &v1alpha1.EventListenerTemplate{Ref: ptr.String("tt")},
+					Template:     &v1alpha1.EventListenerTemplate{DeprecatedName: "tt"},
 					Interceptors: []*v1alpha1.EventInterceptor{{}},
 				}},
 			},
@@ -329,7 +328,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
-					Template: &v1alpha1.EventListenerTemplate{Ref: ptr.String("tt")},
+					Template: &v1alpha1.EventListenerTemplate{DeprecatedName: "tt"},
 					Interceptors: []*v1alpha1.EventInterceptor{{
 						Webhook: &v1alpha1.WebhookInterceptor{
 							ObjectRef: &corev1.ObjectReference{
@@ -403,7 +402,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
-					Template: &v1alpha1.EventListenerTemplate{Ref: ptr.String("tt")},
+					Template: &v1alpha1.EventListenerTemplate{DeprecatedName: "tt"},
 					Interceptors: []*v1alpha1.EventInterceptor{{
 						GitHub:    &v1alpha1.GitHubInterceptor{},
 						GitLab:    &v1alpha1.GitLabInterceptor{},
@@ -422,7 +421,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
 					Bindings: []*v1alpha1.EventListenerBinding{{Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
-					Template: &v1alpha1.EventListenerTemplate{Ref: ptr.String("tt")},
+					Template: &v1alpha1.EventListenerTemplate{DeprecatedName: "tt"},
 					Interceptors: []*v1alpha1.EventInterceptor{{
 						CEL: &v1alpha1.CELInterceptor{},
 					}},

--- a/pkg/apis/triggers/v1alpha1/trigger_defaults.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_defaults.go
@@ -28,6 +28,7 @@ func (t *Trigger) SetDefaults(ctx context.Context) {
 		return
 	}
 	triggerSpecBindingArray(t.Spec.Bindings).defaultBindings()
+	templateNameToRef(&t.Spec.Template)
 }
 
 // set default TriggerBinding kind for Bindings in TriggerSpec
@@ -38,5 +39,14 @@ func (t triggerSpecBindingArray) defaultBindings() {
 				b.Kind = NamespacedTriggerBindingKind
 			}
 		}
+	}
+}
+
+// To be Removed in a later release #911
+func templateNameToRef(template *TriggerSpecTemplate) {
+	name := template.DeprecatedName
+	if name != "" && template.Ref == nil {
+		template.Ref = &name
+		template.DeprecatedName = ""
 	}
 }

--- a/pkg/apis/triggers/v1alpha1/trigger_defaults_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_defaults_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	"knative.dev/pkg/ptr"
 )
 
 func TestTriggerSetDefaults(t *testing.T) {
@@ -74,6 +75,24 @@ func TestTriggerSetDefaults(t *testing.T) {
 				Bindings: []*v1alpha1.TriggerSpecBinding{{
 					Ref: "binding", // If upgrade context was set, Kind should have been added
 				}},
+			},
+		},
+	}, {
+		name: "sets template name to ref",
+		wc:   v1alpha1.WithUpgradeViaDefaulting,
+		in: &v1alpha1.Trigger{
+			Spec: v1alpha1.TriggerSpec{
+				Template: v1alpha1.TriggerSpecTemplate{
+					DeprecatedName: "tt-name",
+				},
+			},
+		},
+		want: &v1alpha1.Trigger{
+			Spec: v1alpha1.TriggerSpec{
+				Template: v1alpha1.TriggerSpecTemplate{
+					Ref:            ptr.String("tt-name"),
+					DeprecatedName: "",
+				},
 			},
 		},
 	}}

--- a/pkg/apis/triggers/v1alpha1/trigger_types.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_types.go
@@ -39,9 +39,12 @@ type TriggerSpec struct {
 }
 
 type TriggerSpecTemplate struct {
-	Ref        *string              `json:"ref,omitempty"`
-	APIVersion string               `json:"apiversion,omitempty"`
-	Spec       *TriggerTemplateSpec `json:"spec,omitempty"`
+	// Deprecated: Use Ref instead
+	// To be removed in a later release #911
+	DeprecatedName string               `json:"name,omitempty"`
+	Ref            *string              `json:"ref,omitempty"`
+	APIVersion     string               `json:"apiversion,omitempty"`
+	Spec           *TriggerTemplateSpec `json:"spec,omitempty"`
 }
 
 type TriggerSpecBinding struct {

--- a/pkg/apis/triggers/v1alpha1/trigger_types_convert_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_types_convert_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"knative.dev/pkg/ptr"
 )
 
 func TestToEventListenerTrigger(t *testing.T) {
@@ -39,13 +38,13 @@ func TestToEventListenerTrigger(t *testing.T) {
 			in: TriggerSpec{
 				Name: "foo",
 				Template: TriggerSpecTemplate{
-					Ref: ptr.String("baz"),
+					DeprecatedName: "baz",
 				},
 			},
 			out: EventListenerTrigger{
 				Name: "foo",
 				Template: &EventListenerTemplate{
-					Ref: ptr.String("baz"),
+					DeprecatedName: "baz",
 				},
 			},
 		},
@@ -64,8 +63,8 @@ func TestToEventListenerTrigger(t *testing.T) {
 					Ref:        "d",
 				}},
 				Template: TriggerSpecTemplate{
-					Ref:        ptr.String("a"),
-					APIVersion: "b",
+					DeprecatedName: "a",
+					APIVersion:     "b",
 				},
 			},
 			out: EventListenerTrigger{
@@ -81,8 +80,8 @@ func TestToEventListenerTrigger(t *testing.T) {
 					Ref:        "d",
 				}},
 				Template: &EventListenerTemplate{
-					Ref:        ptr.String("a"),
-					APIVersion: "b",
+					DeprecatedName: "a",
+					APIVersion:     "b",
 				},
 			},
 		},

--- a/pkg/apis/triggers/v1alpha1/trigger_validation.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_validation.go
@@ -55,6 +55,16 @@ func (t TriggerSpecTemplate) validate(ctx context.Context) (errs *apis.FieldErro
 		}
 	}
 
+	// Validate only one of Name or Ref is set.
+	if t.DeprecatedName != "" && t.Ref != nil {
+		errs = errs.Also(apis.ErrMultipleOneOf("template.name", "template.ref"))
+	}
+
+	// Set Ref to Name
+	if t.DeprecatedName != "" {
+		t.Ref = &t.DeprecatedName
+	}
+
 	switch {
 	case t.Spec != nil && t.Ref != nil:
 		errs = errs.Also(apis.ErrMultipleOneOf("template.spec", "template.ref"))

--- a/pkg/apis/triggers/v1alpha1/trigger_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_validation_test.go
@@ -248,7 +248,31 @@ func TestTriggerValidate_error(t *testing.T) {
 			},
 			Spec: v1alpha1.TriggerSpec{
 				Bindings: []*v1alpha1.TriggerSpecBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb", APIVersion: "v1alpha1"}},
-				Template: v1alpha1.TriggerSpecTemplate{Ref: ptr.String("tt"), APIVersion: "invalid"},
+				Template: v1alpha1.TriggerSpecTemplate{DeprecatedName: "tt", APIVersion: "invalid"},
+			},
+		},
+	}, {
+		name: "Template with missing Name", // TODO(#911): Remove when Name is removed
+		tr: &v1alpha1.Trigger{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Spec: v1alpha1.TriggerSpec{
+				Bindings: []*v1alpha1.TriggerSpecBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb", APIVersion: "v1alpha1"}},
+				Template: v1alpha1.TriggerSpecTemplate{DeprecatedName: "", APIVersion: "v1alpha1"},
+			},
+		},
+	}, {
+		name: "Template with both Name and Ref", // TODO(#791): Remove when Name is removed
+		tr: &v1alpha1.Trigger{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Spec: v1alpha1.TriggerSpec{
+				Bindings: []*v1alpha1.TriggerSpecBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb", APIVersion: "v1alpha1"}},
+				Template: v1alpha1.TriggerSpecTemplate{DeprecatedName: "tt", Ref: ptr.String("tt"), APIVersion: "v1alpha1"},
 			},
 		},
 	}, {

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -424,7 +424,7 @@ func TestHandleEvent(t *testing.T) {
 				},
 				Spec: triggersv1.TriggerSpec{
 					Bindings: []*triggersv1.TriggerSpecBinding{{Ref: "git-clone"}},
-					Template: triggersv1.TriggerSpecTemplate{Ref: ptr.String("git-clone")},
+					Template: triggersv1.TriggerSpecTemplate{DeprecatedName: "git-clone"},
 				},
 			}},
 			EventListeners: []*triggersv1.EventListener{{

--- a/pkg/template/resource.go
+++ b/pkg/template/resource.go
@@ -62,6 +62,10 @@ func ResolveTrigger(trigger triggersv1.Trigger, getTB getTriggerBinding, getCTB 
 		var ttName string
 		if trigger.Spec.Template.Ref != nil {
 			ttName = *trigger.Spec.Template.Ref
+		} else {
+			// TODO(#911): Remove Name field
+			// Ignore staticcheck linter as it will complain about using deprecated type
+			ttName = trigger.Spec.Template.DeprecatedName //nolint:staticcheck
 		}
 		resolvedTT, err = getTT(ttName)
 		if err != nil {

--- a/pkg/template/resource_test.go
+++ b/pkg/template/resource_test.go
@@ -536,8 +536,8 @@ func Test_ResolveTrigger_error(t *testing.T) {
 						Kind: triggersv1.NamespacedTriggerBindingKind,
 					}},
 					Template: triggersv1.EventListenerTemplate{
-						Ref:        ptr.String("my-triggertemplate"),
-						APIVersion: "v1alpha1",
+						DeprecatedName: "my-triggertemplate",
+						APIVersion:     "v1alpha1",
 					},
 				},
 			},

--- a/test/builder/eventlistener.go
+++ b/test/builder/eventlistener.go
@@ -144,8 +144,8 @@ func EventListenerTrigger(ttName, apiVersion string, ops ...EventListenerTrigger
 	return func(spec *v1alpha1.EventListenerSpec) {
 		t := v1alpha1.EventListenerTrigger{
 			Template: &v1alpha1.EventListenerTemplate{
-				Ref:        &ttName,
-				APIVersion: apiVersion,
+				DeprecatedName: ttName,
+				APIVersion:     apiVersion,
 			},
 		}
 

--- a/test/builder/eventlistener_test.go
+++ b/test/builder/eventlistener_test.go
@@ -28,7 +28,6 @@ import (
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
-	"knative.dev/pkg/ptr"
 )
 
 func TestEventListenerBuilder(t *testing.T) {
@@ -204,8 +203,8 @@ func TestEventListenerBuilder(t *testing.T) {
 						APIVersion: "v1alpha1",
 					}},
 					Template: &v1alpha1.EventListenerTemplate{
-						Ref:        ptr.String("tt1"),
-						APIVersion: "v1alpha1",
+						DeprecatedName: "tt1",
+						APIVersion:     "v1alpha1",
 					},
 				}},
 			},
@@ -234,8 +233,8 @@ func TestEventListenerBuilder(t *testing.T) {
 						APIVersion: "v1alpha1",
 					}},
 					Template: &v1alpha1.EventListenerTemplate{
-						Ref:        ptr.String("tt1"),
-						APIVersion: "v1alpha1",
+						DeprecatedName: "tt1",
+						APIVersion:     "v1alpha1",
 					},
 				}},
 			},
@@ -264,8 +263,8 @@ func TestEventListenerBuilder(t *testing.T) {
 						APIVersion: "v1alpha1",
 					}},
 					Template: &v1alpha1.EventListenerTemplate{
-						Ref:        ptr.String("tt1"),
-						APIVersion: "v1alpha1",
+						DeprecatedName: "tt1",
+						APIVersion:     "v1alpha1",
 					},
 				}},
 			},
@@ -301,8 +300,8 @@ func TestEventListenerBuilder(t *testing.T) {
 						},
 					},
 					Template: &v1alpha1.EventListenerTemplate{
-						Ref:        ptr.String("tt1"),
-						APIVersion: "v1alpha1",
+						DeprecatedName: "tt1",
+						APIVersion:     "v1alpha1",
 					},
 				}},
 			},
@@ -339,8 +338,8 @@ func TestEventListenerBuilder(t *testing.T) {
 						APIVersion: "v1alpha1",
 					}},
 					Template: &v1alpha1.EventListenerTemplate{
-						Ref:        ptr.String("tt1"),
-						APIVersion: "v1alpha1",
+						DeprecatedName: "tt1",
+						APIVersion:     "v1alpha1",
 					},
 				}, {
 					Bindings: []*v1alpha1.EventListenerBinding{{
@@ -349,8 +348,8 @@ func TestEventListenerBuilder(t *testing.T) {
 						APIVersion: "v1alpha1",
 					}},
 					Template: &v1alpha1.EventListenerTemplate{
-						Ref:        ptr.String("tt2"),
-						APIVersion: "v1alpha1",
+						DeprecatedName: "tt2",
+						APIVersion:     "v1alpha1",
 					},
 				},
 				},
@@ -398,8 +397,8 @@ func TestEventListenerBuilder(t *testing.T) {
 						APIVersion: "v1alpha1",
 					}},
 					Template: &v1alpha1.EventListenerTemplate{
-						Ref:        ptr.String("tt1"),
-						APIVersion: "v1alpha1",
+						DeprecatedName: "tt1",
+						APIVersion:     "v1alpha1",
 					},
 				}},
 			},
@@ -450,8 +449,8 @@ func TestEventListenerBuilder(t *testing.T) {
 						APIVersion: "v1alpha1",
 					}},
 					Template: &v1alpha1.EventListenerTemplate{
-						Ref:        ptr.String("tt1"),
-						APIVersion: "v1alpha1",
+						DeprecatedName: "tt1",
+						APIVersion:     "v1alpha1",
 					},
 				}},
 			}},
@@ -492,8 +491,8 @@ func TestEventListenerBuilder(t *testing.T) {
 						APIVersion: "v1alpha1",
 					}},
 					Template: &v1alpha1.EventListenerTemplate{
-						Ref:        ptr.String("tt1"),
-						APIVersion: "v1alpha1",
+						DeprecatedName: "tt1",
+						APIVersion:     "v1alpha1",
 					},
 				}},
 			},
@@ -524,8 +523,8 @@ func TestEventListenerBuilder(t *testing.T) {
 						APIVersion: "v1alpha1",
 					}},
 					Template: &v1alpha1.EventListenerTemplate{
-						Ref:        ptr.String("tt1"),
-						APIVersion: "v1alpha1",
+						DeprecatedName: "tt1",
+						APIVersion:     "v1alpha1",
 					},
 				}},
 				Resources: v1alpha1.Resources{

--- a/test/eventlistener_scale_test.go
+++ b/test/eventlistener_scale_test.go
@@ -84,8 +84,8 @@ func TestEventListenerScale(t *testing.T) {
 				APIVersion: "v1alpha1",
 			}},
 			Template: &triggersv1.EventListenerTemplate{
-				Ref:        ptr.String("my-triggertemplate"),
-				APIVersion: "v1alpha1",
+				DeprecatedName: "my-triggertemplate",
+				APIVersion:     "v1alpha1",
 			},
 		}
 		trigger.Name = fmt.Sprintf("%d", i)


### PR DESCRIPTION
**Issue:** [slack discussion](https://tektoncd.slack.com/archives/CL3T51NRF/p1610982177013500)
**RootCause:** https://tektoncd.slack.com/archives/CL3T51NRF/p1611039325020300?thread_ts=1610982177.013500&cid=CL3T51NRF

From https://github.com/tektoncd/triggers/pull/912#issuecomment-762921828

```
We had logic in triggers_default.go to change template.Name to template.Ref. But because the Name field did not have a omitempty tag, the resource still contained a Name: "" field. This makes it impossible to upgrade running trigger resources from v0.10.2 to v0.11.0

(another candidate for #619)
```

# Changes

Reverted back changes done as part of this [PR](https://github.com/tektoncd/triggers/pull/898) and handled Deprecation for template.Name field
Will remove template.Name field may be in the next release v0.12.0

We may need to do patch release to handle this issue

Signed-off-by: Savita Ashture sashture@redhat.com


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
Deprecate template.Name in favor of template.Ref
```