### PR TITLE
Accept 0 as a valid value for EventListener replicas

### DIFF
--- a/pkg/apis/triggers/v1alpha1/event_listener_defaults.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_defaults.go
@@ -24,9 +24,6 @@ import (
 func (el *EventListener) SetDefaults(ctx context.Context) {
 	if IsUpgradeViaDefaulting(ctx) {
 		// set defaults
-		if el.Spec.Replicas != nil && *el.Spec.Replicas == 0 {
-			*el.Spec.Replicas = 1
-		}
 		for i := range el.Spec.Triggers {
 			triggerSpecBindingArray(el.Spec.Triggers[i].Bindings).
 				defaultBindings()

--- a/pkg/apis/triggers/v1alpha1/event_listener_defaults_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_defaults_test.go
@@ -76,19 +76,6 @@ func TestEventListenerSetDefaults(t *testing.T) {
 			},
 		},
 	}, {
-		name: "set replicas to 1 if provided replicas is 0 as part of eventlistener spec",
-		in: &v1alpha1.EventListener{
-			Spec: v1alpha1.EventListenerSpec{
-				Replicas: ptr.Int32(0),
-			},
-		},
-		wc: v1alpha1.WithUpgradeViaDefaulting,
-		want: &v1alpha1.EventListener{
-			Spec: v1alpha1.EventListenerSpec{
-				Replicas: ptr.Int32(1),
-			},
-		},
-	}, {
 		name: "deprecate podTemplate nodeselector to resource",
 		in: &v1alpha1.EventListener{
 			Spec: v1alpha1.EventListenerSpec{


### PR DESCRIPTION
# Changes

Accept 0 as a valid value for EventListener replicas. This change is intended as a workaround until a proper Knative EventListener implementation is available (see #892). Note: without additional work, replicas=0 results in a broken setup.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Accept 0 as a valid value for EventListener replicas. Previously, this was changed to 1. Note: without additional work, replicas=0 results in a broken setup.
```
