### PR TITLE
[Cherry-Pick] Send Tekton installation namespace to EL

### DIFF
--- a/pkg/interceptors/interceptors.go
+++ b/pkg/interceptors/interceptors.go
@@ -24,9 +24,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
-
-	"github.com/tektoncd/triggers/pkg/system"
 
 	"google.golang.org/grpc/codes"
 
@@ -188,7 +187,7 @@ func ResolveURL(i *triggersv1.TriggerInterceptor) *url.URL {
 	}
 	return &url.URL{
 		Scheme: "http",
-		Host:   fmt.Sprintf("%s.%s.svc", CoreInterceptorsHost, system.DefaultNamespace),
+		Host:   fmt.Sprintf("%s.%s.svc", CoreInterceptorsHost, os.Getenv("TEKTON_INSTALL_NAMESPACE")),
 		Path:   path,
 	}
 }

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	listers "github.com/tektoncd/triggers/pkg/client/listers/triggers/v1alpha1"
+	"github.com/tektoncd/triggers/pkg/system"
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 	appsv1 "k8s.io/api/apps/v1"
@@ -462,6 +463,9 @@ func getContainer(el *v1alpha1.EventListener, c Config) corev1.Container {
 				FieldPath: "metadata.namespace",
 			},
 		},
+	}, {
+		Name:  "TEKTON_INSTALL_NAMESPACE",
+		Value: system.GetNamespace(),
 	}}
 
 	certEnv := map[string]*corev1.EnvVarSource{}

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
@@ -248,6 +248,9 @@ func makeDeployment(ops ...func(d *appsv1.Deployment)) *appsv1.Deployment {
 									FieldPath: "metadata.namespace",
 								},
 							},
+						}, {
+							Name:  "TEKTON_INSTALL_NAMESPACE",
+							Value: "tekton-pipelines",
 						}},
 					}},
 					Volumes: []corev1.Volume{{
@@ -333,6 +336,9 @@ var withTLSConfig = func(d *appsv1.Deployment) {
 					FieldPath: "metadata.namespace",
 				},
 			},
+		}, {
+			Name:  "TEKTON_INSTALL_NAMESPACE",
+			Value: "tekton-pipelines",
 		}, {
 			Name: "TLS_CERT",
 			ValueFrom: &corev1.EnvVarSource{


### PR DESCRIPTION
Cherry pick of #927 

The EventListener did not have knowledge of which namespace Triggers was
installed in. Instead it always assumed it was `tekton-pipelines` leading to
the bug described in #923.  This commit fixes this by having the Reconciler
send the installation namespace as a environment variable set on the
EventListener's pod.

NOTE: This fix is temporary and should not be necessary once #868 is
implemented since then we will resolve the Interceptor's address using
information from its CRD.

Fixes #923

Signed-off-by: Dibyo Mukherjee <dibyo@google.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
