### PR TITLE
Add validation to the length of EventListener name

### DIFF
--- a/pkg/apis/triggers/v1alpha1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation.go
@@ -35,7 +35,17 @@ var (
 
 // Validate EventListener.
 func (e *EventListener) Validate(ctx context.Context) *apis.FieldError {
-	return e.Spec.validate(ctx)
+	errs := e.validate(ctx)
+	errs = errs.Also(e.Spec.validate(ctx))
+	return errs
+}
+
+func (e *EventListener) validate(ctx context.Context) (errs *apis.FieldError) {
+	if len(e.ObjectMeta.Name) > 60 {
+		// Since `el-` is added as the prefix of EventListener services, the name of EventListener must be no more than 60 characters long.
+		errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("eventListener name '%s' must be no more than 60 characters long", e.ObjectMeta.Name), "metadata.name"))
+	}
+	return errs
 }
 
 func (s *EventListenerSpec) validate(ctx context.Context) (errs *apis.FieldError) {

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
@@ -229,6 +229,11 @@ func TestEventListenerValidate_error(t *testing.T) {
 		name string
 		el   *v1alpha1.EventListener
 	}{{
+		name: "Invalid EventListener name",
+		el: bldr.EventListener("longlonglonglonglonglonglonglonglonglonglonglonglonglonglname", "namespace",
+			bldr.EventListenerSpec(
+				bldr.EventListenerTrigger("tt", "v1alpha1"))),
+	}, {
 		name: "Valid EventListener with empty TriggerTemplate name",
 		el: bldr.EventListener("name", "namespace",
 			bldr.EventListenerSpec(


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

FIxes #928 

Add validation to the length of EventListener name.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
We now validate that the EventListener name has to be no more than 60 characters long.
```

