### PR TITLE
Resolve TriggerTemplate and TriggerBinding Ref

### DIFF
--- a/docs/cel_expressions.md
+++ b/docs/cel_expressions.md
@@ -301,7 +301,9 @@ interceptor.
      This parses a string that contains a YAML body into a map which which can be subsequently used in other expressions.
     </td>
     <td>
-     <pre>'key1: value1\nkey2: value2\n'.parseYAML().key1 == "value"</pre>
+     <pre>'key1: value1
+key2: value2
+'.parseYAML().key1 == "value"</pre>
     </td>
   </tr>
   <tr>

--- a/docs/exposing-eventlisteners.md
+++ b/docs/exposing-eventlisteners.md
@@ -34,7 +34,8 @@ services can be found
    ```
 2. Find the service name expose by the Eventlistener service:
    ```sh
-    kubectl get el <EVENTLISTENR_NAME> -o=jsonpath='{.status.configuration.generatedName}{"\n"}'
+    kubectl get el <EVENTLISTENR_NAME> -o=jsonpath='{.status.configuration.generatedName}{"
+"}'
    ```
 3. Create the Ingress resource. A sample Ingress is below. Check the docs
    [here](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/)

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -49,6 +49,31 @@ spec:
     ref: pipeline-template
 ```
 
+Triggers can reference templates and bindings based on data in the event body, headers, or processed extensions using the `dynamicRef` field. This allows contextual information to be pulled in from the event to determine which binding or template should be populated. The `dynamicRef` field for `bindings` and `templates` can be populated in the same manner as triggertemplate params.
+
+This can be useful when different pipelines require different resources or workspaces to run. `TriggerTemplate` objects by themselves must have a static configuration structure, even if individual strings are able to be populated.
+
+These dynamic resolutions also allow for a fallback option if the dynamic resolution does not succeed. If the `dynamicRef` fields are not present in the event body, the Trigger processing will use the `ref` field if populated.
+
+<!-- FILE: examples/triggers/trigger-with-event-reference.yaml -->
+```YAML
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: Trigger
+metadata:
+  name: trigger
+spec:
+  interceptors:
+    - cel:
+        overlays:
+        - key: extensions.truncated_sha
+          expression: "body.pull_request.head.sha.truncate(7)"
+  bindings:
+  - dynamicRef: pipeline-$(body.repository.owner.login)-binding
+  template:
+    dynamicRef: pipeline-$(header.X-GitHub-Event)-trigger
+    ref: pipeline-default-trigger
+```
+
 ## Specifying the corresponding `TriggerTemplate`
 
 In the `template` field,  you can do one of the following:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -92,7 +92,10 @@ This returns the logging level to `info`.
 You may see the following message in your logs:
 
 ```json
-A{"level":"error","ts":"2021-02-10T08:43:47.409Z","logger":"eventlistener","caller":"sink/sink.go:230","msg":"failed to ApplyEventValuesToParams: failed to replace JSONPath value for param message: $(body.message): message is not found","knative.dev/controller":"eventlistener","/triggers-eventid":"c8f88","/trigger":"demo-trigger","logging.googleapis.com/labels":{},"logging.googleapis.com/sourceLocation":{"file":"github.com/tektoncd/triggers/pkg/sink/sink.go","line":"230","function":"github.com/tektoncd/triggers/pkg/sink.Sink.processTrigger"},"stacktrace":"github.com/tektoncd/triggers/pkg/sink.Sink.processTrigger\n\tgithub.com/tektoncd/triggers/pkg/sink/sink.go:230\ngithub.com/tektoncd/triggers/pkg/sink.Sink.HandleEvent.func1\n\tgithub.com/tektoncd/triggers/pkg/sink/sink.go:125"}
+A{"level":"error","ts":"2021-02-10T08:43:47.409Z","logger":"eventlistener","caller":"sink/sink.go:230","msg":"failed to ApplyEventValuesToParams: failed to replace JSONPath value for param message: $(body.message): message is not found","knative.dev/controller":"eventlistener","/triggers-eventid":"c8f88","/trigger":"demo-trigger","logging.googleapis.com/labels":{},"logging.googleapis.com/sourceLocation":{"file":"github.com/tektoncd/triggers/pkg/sink/sink.go","line":"230","function":"github.com/tektoncd/triggers/pkg/sink.Sink.processTrigger"},"stacktrace":"github.com/tektoncd/triggers/pkg/sink.Sink.processTrigger
+	github.com/tektoncd/triggers/pkg/sink/sink.go:230
+github.com/tektoncd/triggers/pkg/sink.Sink.HandleEvent.func1
+	github.com/tektoncd/triggers/pkg/sink/sink.go:125"}
 ```
 
 This means that the selected `Interceptor` is unable to parse the structure of the received JSON payload. To troubleshoot this, you must capture and inspect the payload for inconsistencies.

--- a/examples/triggers/trigger-with-event-reference.yaml
+++ b/examples/triggers/trigger-with-event-reference.yaml
@@ -1,0 +1,15 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: Trigger
+metadata:
+  name: trigger
+spec:
+  interceptors:
+    - cel:
+        overlays:
+        - key: extensions.truncated_sha
+          expression: "body.pull_request.head.sha.truncate(7)"
+  bindings:
+  - dynamicRef: pipeline-$(body.repository.owner.login)-binding
+  template:
+    dynamicRef: pipeline-$(header.X-GitHub-Event)-trigger
+    ref: pipeline-default-trigger

--- a/pkg/apis/triggers/v1alpha1/trigger_types.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_types.go
@@ -42,6 +42,7 @@ type TriggerSpec struct {
 
 type TriggerSpecTemplate struct {
 	Ref        *string              `json:"ref,omitempty"`
+	DynamicRef *string              `json:"dynamicRef,omitempty"`
 	APIVersion string               `json:"apiversion,omitempty"`
 	Spec       *TriggerTemplateSpec `json:"spec,omitempty"`
 }
@@ -58,6 +59,11 @@ type TriggerSpecBinding struct {
 	// Ref is a reference to a TriggerBinding kind.
 	// Mutually exclusive with Name
 	Ref string `json:"ref,omitempty"`
+
+	// DynamicRef is a reference to a TriggerBinding that resolves with the current
+	// event context
+	// Shares the same exclusivity as Ref, falls back to ref if unresolved
+	DynamicRef string `json:"dynamicRef,omitempty"`
 
 	// Kind can only be provided if Ref is also provided. Defaults to TriggerBinding
 	Kind TriggerBindingKind `json:"kind,omitempty"`

--- a/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
@@ -1065,6 +1065,11 @@ func (in *TriggerSpecTemplate) DeepCopyInto(out *TriggerSpecTemplate) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DynamicRef != nil {
+		in, out := &in.DynamicRef, &out.DynamicRef
+		*out = new(string)
+		**out = **in
+	}
 	if in.Spec != nil {
 		in, out := &in.Spec, &out.Spec
 		*out = new(TriggerTemplateSpec)

--- a/test/builder/trigger.go
+++ b/test/builder/trigger.go
@@ -70,6 +70,29 @@ func TriggerSpecTemplate(ttName, apiVersion string) TriggerSpecOp {
 	}
 }
 
+// DynamicTriggerSpecTemplate adds an TriggerTemplate to the TriggerSpec with DynamicRef.
+func DynamicTriggerSpecTemplate(ttDynamicRef, apiVersion string) TriggerSpecOp {
+	return func(spec *v1alpha1.TriggerSpec) {
+		tt := v1alpha1.TriggerSpecTemplate{
+			DynamicRef: &ttDynamicRef,
+			APIVersion: apiVersion,
+		}
+		spec.Template = tt
+	}
+}
+
+// DynamicTriggerSpecTemplate adds an TriggerTemplate to the TriggerSpec with DynamicRef.
+func DynamicStaticTriggerSpecTemplate(ttDynamicRef, ttRef, apiVersion string) TriggerSpecOp {
+	return func(spec *v1alpha1.TriggerSpec) {
+		tt := v1alpha1.TriggerSpecTemplate{
+			DynamicRef: &ttDynamicRef,
+			Ref:        &ttRef,
+			APIVersion: apiVersion,
+		}
+		spec.Template = tt
+	}
+}
+
 // TriggerSpecName adds a Name to the Trigger in TriggerSpec.
 func TriggerSpecName(name string) TriggerSpecOp {
 	return func(spec *v1alpha1.TriggerSpec) {
@@ -94,6 +117,49 @@ func TriggerSpecBinding(ref, kind, name, apiVersion string) TriggerSpecOp {
 
 		if len(ref) != 0 {
 			binding.Ref = ref
+			if kind == "ClusterTriggerBinding" {
+				binding.Kind = v1alpha1.ClusterTriggerBindingKind
+			}
+
+			if kind == "TriggerBinding" || kind == "" {
+				binding.Kind = v1alpha1.NamespacedTriggerBindingKind
+			}
+		}
+		spec.Bindings = append(spec.Bindings, binding)
+	}
+}
+
+func DynamicStaticTriggerSpecBinding(dynamicRef, ref, kind, name, apiVersion string) TriggerSpecOp {
+	return func(spec *v1alpha1.TriggerSpec) {
+		binding := &v1alpha1.TriggerSpecBinding{
+			Name:       name,
+			APIVersion: apiVersion,
+		}
+
+		if len(dynamicRef) != 0 || len(ref) != 0 {
+			binding.DynamicRef = dynamicRef
+			binding.Ref = ref
+			if kind == "ClusterTriggerBinding" {
+				binding.Kind = v1alpha1.ClusterTriggerBindingKind
+			}
+
+			if kind == "TriggerBinding" || kind == "" {
+				binding.Kind = v1alpha1.NamespacedTriggerBindingKind
+			}
+		}
+		spec.Bindings = append(spec.Bindings, binding)
+	}
+}
+
+func DynamicTriggerSpecBinding(dynamicRef, kind, name, apiVersion string) TriggerSpecOp {
+	return func(spec *v1alpha1.TriggerSpec) {
+		binding := &v1alpha1.TriggerSpecBinding{
+			Name:       name,
+			APIVersion: apiVersion,
+		}
+
+		if len(dynamicRef) != 0 {
+			binding.DynamicRef = dynamicRef
 			if kind == "ClusterTriggerBinding" {
 				binding.Kind = v1alpha1.ClusterTriggerBindingKind
 			}

--- a/test/interceptor/interceptors.go
+++ b/test/interceptor/interceptors.go
@@ -1,0 +1,48 @@
+package test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/tektoncd/triggers/pkg/interceptors"
+	"github.com/tektoncd/triggers/pkg/interceptors/server"
+	"go.uber.org/zap"
+	"k8s.io/client-go/kubernetes"
+)
+
+// SetupInterceptors creates a httptest server with all coreInterceptors and any passed in webhook interceptor
+// It returns a http.Client that can be used to talk to these interceptors
+func SetupInterceptors(t *testing.T, k kubernetes.Interface, l *zap.SugaredLogger, webhookInterceptor http.Handler) *http.Client {
+	t.Helper()
+	// Setup a handler for core interceptors using httptest
+	coreInterceptors, err := server.NewWithCoreInterceptors(k, l)
+	if err != nil {
+		t.Fatalf("failed to initialize core interceptors: %v", err)
+	}
+	rtr := mux.NewRouter()
+	// server core interceptors by matching on req host
+	rtr.MatcherFunc(func(r *http.Request, _ *mux.RouteMatch) bool {
+		return strings.Contains(r.Host, interceptors.CoreInterceptorsHost)
+	}).Handler(coreInterceptors)
+
+	if webhookInterceptor != nil {
+		rtr.Handle("/", webhookInterceptor)
+	}
+	srv := httptest.NewServer(rtr)
+	t.Cleanup(func() {
+		srv.Close()
+	})
+	httpClient := srv.Client()
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("testServer() url parse err: %v", err)
+	}
+	httpClient.Transport = &http.Transport{
+		Proxy: http.ProxyURL(u),
+	}
+	return httpClient
+}


### PR DESCRIPTION
This PR demonstrates a capability to pre-process TriggerTemplate and TriggerBinding
objects with the event context to allow the Ref field to include tekton  expressions
in order to allow body and header context to be populated into these names.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Closes #948

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

Tests and documentation in progress.

# Release Notes

```release-note 
TriggerTemplate and TriggerBindings can now use Tekton variable substitution to resolve resource names
```
