### PR TITLE
Resolving newline in TriggerBinding param

### DIFF
--- a/pkg/template/resource.go
+++ b/pkg/template/resource.go
@@ -126,13 +126,14 @@ func applyParamsToResourceTemplate(params []triggersv1.Param, rt json.RawMessage
 func applyParamToResourceTemplate(param triggersv1.Param, rt json.RawMessage, oldEscape bool) json.RawMessage {
 	// Assume the param is valid
 	paramVariable := fmt.Sprintf("$(tt.params.%s)", param.Name)
+	paramValue := strings.Replace(param.Value, "\n", "\\n", -1)
 	// Escape quotes so that that JSON strings can be appended to regular strings.
 	// See #257 for discussion on this behavior.
 	if oldEscape {
-		paramValue := strings.Replace(param.Value, `"`, `\"`, -1)
+		paramValue = strings.Replace(paramValue, `"`, `\"`, -1)
 		return bytes.Replace(rt, []byte(paramVariable), []byte(paramValue), -1)
 	}
-	return bytes.Replace(rt, []byte(paramVariable), []byte(param.Value), -1)
+	return bytes.Replace(rt, []byte(paramVariable), []byte(paramValue), -1)
 }
 
 // UUID generates a Universally Unique IDentifier following RFC 4122.

--- a/pkg/template/resource_test.go
+++ b/pkg/template/resource_test.go
@@ -100,6 +100,28 @@ func Test_applyParamToResourceTemplate(t *testing.T) {
 			},
 			want: json.RawMessage(`{"foo": {"a":"b"}}`),
 		}, {
+			name: "escape newline in param val with JSON requires oldescape",
+			args: args{
+				param: triggersv1.Param{
+					Name:  "p1",
+					Value: `{"a":\n{"b":"c"}\n}`,
+				},
+				rt: json.RawMessage(`{"foo": "$(tt.params.p1)"}`),
+			},
+			oldEscape: true,
+			want:      json.RawMessage(`{"foo": "{\"a\":\n{\"b\":\"c\"}\n}"}`),
+		}, {
+			name: "escape newline in param val",
+			args: args{
+				param: triggersv1.Param{
+					Name: "p1",
+					Value: `test
+value`,
+				},
+				rt: json.RawMessage(`{"foo": "$(tt.params.p1)"}`),
+			},
+			want: json.RawMessage(`{"foo": "test\nvalue"}`),
+		}, {
 			name: "escape quotes in param val - old escaping",
 			args: args{
 				param: triggersv1.Param{


### PR DESCRIPTION
Closes #942

This PR resolves the bug by replacing all instances of the \n character
in triggerbinding params with \n, thus encoding into JSON as the bytes
92 110 rather than 10 or 13 10 depending on the system. This works in any
instance where the parameter is substituted as the JSON encoding will resolve
the parameter value after the byte array for the constructed rawMessage is
assembled. Therefore, anywhere that the newline character is in one of these
parameters, it will not encode appropriately in JSON.

This was determined based on the existing tests that use \n in the label fields.
Since the JSON encoder already operate successfully with those fields, we can look
at the resultant byte array when those tests are run and determine the appropriate
input that should be passed to the replace function in resource.go

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Resolves error that occurs when triggerbinding parameter has multiple lines
```
