### PR TITLE
Fix container name in Deployment for interceptors

### DIFF
--- a/config/interceptors.yaml
+++ b/config/interceptors.yaml
@@ -48,7 +48,7 @@ spec:
     spec:
       serviceAccountName: tekton-triggers-core-interceptors
       containers:
-      - name: tekton-triggers-controller
+      - name: tekton-triggers-core-interceptors
         image: "ko://github.com/tektoncd/triggers/cmd/interceptors"
         args: [
           "-logtostderr",


### PR DESCRIPTION
Container name is controller, it should be core-interceptors. We use container name for image replacement logic in operator.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes


```release-note
Change container name for interceptors to core-interceptors from controller.
```
