### PR TITLE
doc: template inside a Trigger is not optional

### DIFF
--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -27,7 +27,7 @@ the following fields:
   - [`spec`][kubernetes-overview] - Specifies the configuration information for
     your Trigger resource object. The spec include:
     - [`bindings`] - (Optional) A list of bindings to use. Can either be a reference to existing `TriggerBinding` resources or embedded name/value pairs.
-    - [`template`] - (Optional) Either a reference to a TriggerTemplate object or an embedded TriggerTemplate spec.
+    - [`template`] - Either a reference to a TriggerTemplate object or an embedded TriggerTemplate spec.
     - [`interceptors`](./eventlisteners.md#interceptors) - (Optional) list of interceptors to use
     - [`serviceAccountName`] - (Optional) Specifies the ServiceAccount provided to EventListener by Trigger to create resources
 


### PR DESCRIPTION
# Changes

/kind documentation 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
NONE
```