### PR TITLE
Use golang-build-legacy and golang-test-legacy.

### DIFF
--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -30,7 +30,7 @@ spec:
   tasks:
     - name: unit-tests
       taskRef:
-        name: golang-test
+        name: golang-test-legacy
       params:
         - name: package
           value: $(params.package)
@@ -40,7 +40,7 @@ spec:
             resource: source-repo
     - name: build
       taskRef:
-        name: golang-build
+        name: golang-build-legacy
       params:
         - name: package
           value: $(params.package)


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Theres are identical copies of the existing ones, designed to allow
pipeline and triggers to switch to them.

- This step uncouples the various projects so that we way then:
  switch pipeline and triggers one at the time to a publish
  task and release pipeline that use workspaces, no resources and thus
  the catalog version of golang-build and golang-test
- once the three projects are migrated, the legacy tasks will be
  removed

See tektoncd/plumbing#734

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```

/kind misc