### PR TITLE
Try to proof that extensions keys are overriden using multiple webhooks

### DIFF
--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -1188,6 +1188,13 @@ func TestExecuteInterceptor_ExtensionChaining(t *testing.T) {
 					},
 				},
 			}, {
+				CEL: &triggersv1.CELInterceptor{
+					Overlays: []triggersv1.CELOverlay{{
+						Key:        "something",
+						Expression: "body.pull_request_url",
+					}},
+				},
+			}, {
 				Webhook: &triggersv1.WebhookInterceptor{
 					ObjectRef: &corev1.ObjectReference{
 						APIVersion: "v1",
@@ -1221,6 +1228,7 @@ func TestExecuteInterceptor_ExtensionChaining(t *testing.T) {
 				"pull_request_body": "key",
 				"pull_request_url":  "https://github.com/some/pr",
 			},
+			"something": "https://github.com/some/pr",
 		},
 	}
 	var gotBody map[string]interface{}
@@ -1247,6 +1255,7 @@ func TestExecuteInterceptor_ExtensionChaining(t *testing.T) {
 		"add_pr_body": map[string]interface{}{
 			"pull_request_url": "https://github.com/some/pr",
 		},
+		"something": "https://github.com/some/pr",
 	}
 
 	if diff := cmp.Diff(iresp.Extensions, wantExtensions); diff != "" {


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
