### PR TITLE
Forcing eventlistener sink to resolve eventlistener

### DIFF
--- a/cmd/eventlistenersink/main.go
+++ b/cmd/eventlistenersink/main.go
@@ -124,7 +124,7 @@ func main() {
 	}
 	err = r.WaitForEventListener(eventListenerBackoff)
 	if err != nil {
-		panic(err)
+		logger.Fatal(err)
 	}
 
 	// Listen and serve

--- a/cmd/eventlistenersink/main.go
+++ b/cmd/eventlistenersink/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/tektoncd/triggers/pkg/client/informers/externalversions"
 	triggerLogging "github.com/tektoncd/triggers/pkg/logging"
 	"github.com/tektoncd/triggers/pkg/sink"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -113,6 +114,17 @@ func main() {
 		TriggerBindingLister:        factory.Triggers().V1alpha1().TriggerBindings().Lister(),
 		ClusterTriggerBindingLister: factory.Triggers().V1alpha1().ClusterTriggerBindings().Lister(),
 		TriggerTemplateLister:       factory.Triggers().V1alpha1().TriggerTemplates().Lister(),
+	}
+	eventListenerBackoff := wait.Backoff{
+		Duration: 100 * time.Millisecond,
+		Factor:   2.5,
+		Jitter:   0.3,
+		Steps:    10,
+		Cap:      5 * time.Second,
+	}
+	err = r.WaitForEventListener(eventListenerBackoff)
+	if err != nil {
+		panic(err)
 	}
 
 	// Listen and serve


### PR DESCRIPTION
# Changes

This change forces the eventlistenersink process to be able to resolve
the EventListener before starting the HTTP server.

This means that the sink HTTP process (and readiness probe)
will not be listen until the EventListenerLister is able to resolve
the EventListener from the API server.

This is especially useful in startup cases, but can also assist
if the pod is started without permission to read the EventListener
object. In this situation, given this change, the eventlistener
pod will restart with a logged error message about lack of access to
that specific API resource.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Force eventlistener pod to resolve EventListener resource before startup
```
