### PR TITLE
fix: Cron task needs to post json body

### DIFF
--- a/examples/cron/cronjob.yaml
+++ b/examples/cron/cronjob.yaml
@@ -11,5 +11,5 @@ spec:
           containers:
           - name: hello
             image: curlimages/curl
-            args: ["curl", "-X", "POST" , "--data" ,"{}", "el-cron-listener.default.svc.cluster.local:8080" ]
+            args: ["curl", "-X", "POST", "--data", "{}", "el-cron-listener.default.svc.cluster.local:8080"]
           restartPolicy: Never

--- a/examples/cron/cronjob.yaml
+++ b/examples/cron/cronjob.yaml
@@ -10,9 +10,6 @@ spec:
         spec:
           containers:
           - name: hello
-            image: busybox
-            args:
-              - wget
-              - --spider
-              - el-cron-listener.default.svc.cluster.local:8080
+            image: curlimages/curl
+            args: ["curl", "-X", "POST" , "--data" ,"{}", "el-cron-listener.default.svc.cluster.local:8080" ]
           restartPolicy: Never


### PR DESCRIPTION
The event listener now expects a json payload
to be posted. Using wget results in an error. This PR uses the curl image to post an empty json payload.

fixes #986

# Changes