### PR TITLE
Added URL field to WebhookInterceptor

### DIFF
--- a/pkg/apis/triggers/v1alpha1/trigger_types.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_types.go
@@ -20,6 +20,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 )
 
 // TriggerSpec represents a connection between TriggerSpecBinding,
@@ -95,6 +96,8 @@ type WebhookInterceptor struct {
 	// name to use as the EventInterceptor. Either objectRef or url can be specified
 	// +optional
 	ObjectRef *corev1.ObjectReference `json:"objectRef,omitempty"`
+	// +optional
+	URL *apis.URL `json:"url,omitempty"`
 	// Header is a group of key-value pairs that can be appended to the
 	// interceptor request headers. This allows the interceptor to make
 	// decisions specific to an EventListenerTrigger.

--- a/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
@@ -1146,6 +1146,11 @@ func (in *WebhookInterceptor) DeepCopyInto(out *WebhookInterceptor) {
 		*out = new(v1.ObjectReference)
 		**out = **in
 	}
+	if in.URL != nil {
+		in, out := &in.URL, &out.URL
+		*out = new(apis.URL)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Header != nil {
 		in, out := &in.Header, &out.Header
 		*out = make([]v1beta1.Param, len(*in))

--- a/pkg/interceptors/webhook/webhook_test.go
+++ b/pkg/interceptors/webhook/webhook_test.go
@@ -30,6 +30,7 @@ import (
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
 )
 
 func TestWebHookInterceptor(t *testing.T) {
@@ -148,37 +149,47 @@ func TestGetURI(t *testing.T) {
 	var eventListenerNs = "default"
 	tcs := []struct {
 		name     string
-		ref      corev1.ObjectReference
+		ref      v1alpha1.WebhookInterceptor
 		expected string
 		wantErr  bool
 	}{{
 		name: "namespace specified",
-		ref: corev1.ObjectReference{
-			Kind:       "Service",
-			Name:       "foo",
-			APIVersion: "v1",
-			Namespace:  "bar",
-		},
+		ref: v1alpha1.WebhookInterceptor{
+			ObjectRef: &corev1.ObjectReference{
+				Kind:       "Service",
+				Name:       "foo",
+				APIVersion: "v1",
+				Namespace:  "bar",
+			}},
 		expected: "http://foo.bar.svc/",
 		wantErr:  false,
 	}, {
 		name: "no namespace",
-		ref: corev1.ObjectReference{
-			Kind:       "Service",
-			Name:       "foo",
-			APIVersion: "v1",
-		},
+		ref: v1alpha1.WebhookInterceptor{
+			ObjectRef: &corev1.ObjectReference{
+				Kind:       "Service",
+				Name:       "foo",
+				APIVersion: "v1",
+			}},
 		expected: "http://foo.default.svc/",
 		wantErr:  false,
 	}, {
 		name: "non services",
-		ref: corev1.ObjectReference{
-			Kind:       "Blah",
-			Name:       "foo",
-			APIVersion: "v1",
-		},
+		ref: v1alpha1.WebhookInterceptor{
+			ObjectRef: &corev1.ObjectReference{
+				Kind:       "Blah",
+				Name:       "foo",
+				APIVersion: "v1",
+			}},
 		expected: "",
 		wantErr:  true,
+	}, {
+		name: "webhook interceptor with url",
+		ref: v1alpha1.WebhookInterceptor{
+			URL: apis.HTTP("foo.default.svc"),
+		},
+		expected: "http://foo.default.svc",
+		wantErr:  false,
 	}}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
# Changes

Added URL field to WebhookInterceptor in trigger_types

Fixes #270 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Added URL field to WebhookInterceptor
```

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
