### PR TITLE
Sync lister informers before serving traffic

### DIFF
--- a/pkg/sink/initialization.go
+++ b/pkg/sink/initialization.go
@@ -18,13 +18,10 @@ package sink
 
 import (
 	"flag"
-	"fmt"
 	"time"
 
 	triggersclientset "github.com/tektoncd/triggers/pkg/client/clientset/versioned"
 	"golang.org/x/xerrors"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/wait"
 	discoveryclient "k8s.io/client-go/discovery"
 	kubeclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -135,20 +132,4 @@ func ConfigureClients(clusterConfig *rest.Config) (Clients, error) {
 		RESTClient:      kubeClient.RESTClient(),
 		TriggersClient:  triggersClient,
 	}, nil
-}
-
-// WaitForEventListener waits for the Kubernetes eventlistener configuration
-func (r *Sink) WaitForEventListener(backoff wait.Backoff) error {
-
-	if err := wait.ExponentialBackoff(backoff, func() (bool, error) {
-		if _, err := r.EventListenerLister.EventListeners(r.EventListenerNamespace).Get(r.EventListenerName); errors.IsNotFound(err) {
-			return false, nil
-		} else if err != nil {
-			return false, err
-		}
-		return true, nil
-	}); err != nil {
-		return fmt.Errorf("Unable to retrieve EventListener %s in Namespace %s: %s", r.EventListenerName, r.EventListenerNamespace, err)
-	}
-	return nil
 }

--- a/pkg/sink/initialization_test.go
+++ b/pkg/sink/initialization_test.go
@@ -20,23 +20,7 @@ import (
 	"flag"
 	"strconv"
 	"testing"
-	"time"
-
-	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
-	eventlistenerinformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1alpha1/eventlistener"
-	"github.com/tektoncd/triggers/test"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-	rtesting "knative.dev/pkg/reconciler/testing"
 )
-
-var testBackoff = wait.Backoff{
-	Duration: 50 * time.Millisecond,
-	Factor:   1.0,
-	Jitter:   0.1,
-	Steps:    1,
-	Cap:      100 * time.Millisecond,
-}
 
 func Test_GetArgs(t *testing.T) {
 	if err := flag.Set(name, "elname"); err != nil {
@@ -115,49 +99,5 @@ func Test_GetArgs_error(t *testing.T) {
 				t.Errorf("GetArgs() did not return error when expected; sinkArgs: %v", sinkArgs)
 			}
 		})
-	}
-}
-
-func TestWaitForEventlistener(t *testing.T) {
-	eventListenerName := "my-eventlistener"
-	namespace := "my-namespace"
-	eventListener := &triggersv1.EventListener{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      eventListenerName,
-			Namespace: namespace,
-		},
-		Spec: triggersv1.EventListenerSpec{},
-	}
-	ctx, _ := rtesting.SetupFakeContext(t)
-	test.SeedResources(t, ctx, test.Resources{EventListeners: []*triggersv1.EventListener{eventListener}})
-	r := Sink{
-		EventListenerName:      eventListenerName,
-		EventListenerNamespace: namespace,
-		EventListenerLister:    eventlistenerinformer.Get(ctx).Lister(),
-	}
-
-	err := r.WaitForEventListener(testBackoff)
-	if err != nil {
-		t.Fatalf("Expected no error, received %s", err)
-	}
-}
-
-func TestWaitForEventlistener_Fatal(t *testing.T) {
-	eventListenerName := "my-eventlistener"
-	namespace := "my-namespace"
-	ctx, _ := rtesting.SetupFakeContext(t)
-	test.SeedResources(t, ctx, test.Resources{EventListeners: []*triggersv1.EventListener{}})
-	r := Sink{
-		EventListenerName:      eventListenerName,
-		EventListenerNamespace: namespace,
-		EventListenerLister:    eventlistenerinformer.Get(ctx).Lister(),
-	}
-	// will fail
-	err := r.WaitForEventListener(testBackoff)
-	if err == nil {
-		t.Fatalf("expected eventlistener wait to fail, instead succeeded")
-	}
-	if err.Error() != "Unable to retrieve EventListener my-eventlistener in Namespace my-namespace: timed out waiting for the condition" {
-		t.Fatalf("got incorrect error message, received: %s", err)
 	}
 }

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -55,7 +55,7 @@ function install_triggers_crd() {
   ko apply -f config/ || fail_test "Tekton Triggers installation failed"
 
   # Wait for the Interceptors CRD to be available before adding the core-interceptors
-  kubectl wait --for=condition=Established --timeout=30s crds/interceptors.triggers.tekton.dev
+  kubectl wait --for=condition=Established --timeout=30s crds/clusterinterceptors.triggers.tekton.dev
   ko apply -f config/interceptors || fail_test "Core interceptors installation failed"
 
   # Make sure that eveything is cleaned up in the current namespace.

--- a/test/eventlistener_scale_test.go
+++ b/test/eventlistener_scale_test.go
@@ -154,7 +154,7 @@ func createServiceAccount(t *testing.T, c *clients, namespace, name string) {
 			ObjectMeta: metav1.ObjectMeta{Name: "sa-clusterrole"},
 			Rules: []rbacv1.PolicyRule{{
 				APIGroups: []string{triggersv1.GroupName},
-				Resources: []string{"clustertriggerbindings"},
+				Resources: []string{"clustertriggerbindings", "clusterinterceptors"},
 				Verbs:     []string{"get", "list", "watch"},
 			}},
 		}, metav1.CreateOptions{},

--- a/test/eventlistener_test.go
+++ b/test/eventlistener_test.go
@@ -125,7 +125,6 @@ func impersonateRBAC(t *testing.T, sa, namespace string, kubeClient kubernetes.I
 
 func TestEventListenerCreate(t *testing.T) {
 	c, namespace := setup(t)
-	t.Parallel()
 	defer cleanup(t, c, namespace, "my-eventlistener")
 	knativetest.CleanupOnInterrupt(func() { cleanup(t, c, namespace, "my-eventlistener") }, t.Logf)
 


### PR DESCRIPTION
# Changes

Previously, we had a race where the EL would start serving traffic
before the lister caches were synced. This leads to the intermittent
resolution issues described in #896. #977 was an attempt to fix this for
the EventListener resource. This commit fixes it for all resource types
by first registering all the listers, and then syncing the cache before
serving traffic.

Tested by modifying the e2e test to run the intermittently failing test
10 times. Without this fix, it fails while with it it does not (See #1012).

Fixes #896

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
NONE
```
