### PR TITLE
Added check for empty secret and provided a better error messsage

### DIFF
--- a/pkg/interceptors/bitbucket/bitbucket.go
+++ b/pkg/interceptors/bitbucket/bitbucket.go
@@ -54,6 +54,10 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 	headers := interceptors.Canonical(r.Header)
 	// Validate secrets first before anything else, if set
 	if p.SecretRef != nil {
+		// Check the secret to see if it is empty
+		if p.SecretRef.SecretKey == "" {
+			return interceptors.Fail(codes.FailedPrecondition, "bitbucket interceptor secretRef.secretKey is empty")
+		}
 		header := headers.Get("X-Hub-Signature")
 		if header == "" {
 			return interceptors.Fail(codes.InvalidArgument, "no X-Hub-Signature header set")

--- a/pkg/interceptors/bitbucket/bitbucket_test.go
+++ b/pkg/interceptors/bitbucket/bitbucket_test.go
@@ -49,7 +49,7 @@ func TestInterceptor_Process_ShouldContinue(t *testing.T) {
 	}{{
 		name:              "no secret",
 		interceptorParams: &triggersv1.BitbucketInterceptor{},
-		payload:           json.RawMessage(`{}`),
+		payload:           emptyJSONBody,
 		signature:         "foo",
 	}, {
 		name: "valid header for secret",
@@ -68,13 +68,13 @@ func TestInterceptor_Process_ShouldContinue(t *testing.T) {
 				"token": []byte(secretToken),
 			},
 		},
-		payload: json.RawMessage(`{}`),
+		payload: emptyJSONBody,
 	}, {
 		name: "matching event",
 		interceptorParams: &triggersv1.BitbucketInterceptor{
 			EventTypes: []string{"pr:opened", "repo:refs_changed"},
 		},
-		payload:   json.RawMessage(`{}`),
+		payload:   emptyJSONBody,
 		eventType: "repo:refs_changed",
 	}, {
 		name: "valid header for secret and matching event",
@@ -95,7 +95,7 @@ func TestInterceptor_Process_ShouldContinue(t *testing.T) {
 			},
 		},
 		eventType: "repo:refs_changed",
-		payload:   json.RawMessage(`{}`),
+		payload:   emptyJSONBody,
 	}, {
 		name:              "nil body does not panic",
 		interceptorParams: &triggersv1.BitbucketInterceptor{},
@@ -179,7 +179,7 @@ func TestInterceptor_Process_ShouldNotContinue(t *testing.T) {
 				"token": []byte("secrettoken"),
 			},
 		},
-		payload: json.RawMessage(`{}`),
+		payload: emptyJSONBody,
 	}, {
 		name: "no X-Hub-Signature header for secret",
 		interceptorParams: &triggersv1.BitbucketInterceptor{
@@ -196,13 +196,13 @@ func TestInterceptor_Process_ShouldNotContinue(t *testing.T) {
 				"token": []byte("secrettoken"),
 			},
 		},
-		payload: json.RawMessage(`{}`),
+		payload: emptyJSONBody,
 	}, {
 		name: "no matching event",
 		interceptorParams: &triggersv1.BitbucketInterceptor{
 			EventTypes: []string{"pr:opened", "repo:refs_changed"},
 		},
-		payload:   json.RawMessage(`{}`),
+		payload:   emptyJSONBody,
 		eventType: "event",
 	}, {
 		name: "invalid header for secret, but matching event",
@@ -223,7 +223,7 @@ func TestInterceptor_Process_ShouldNotContinue(t *testing.T) {
 			},
 		},
 		eventType: "pr:opened",
-		payload:   json.RawMessage(`{}`),
+		payload:   emptyJSONBody,
 	}, {
 		name: "valid header for secret, but no matching event",
 		interceptorParams: &triggersv1.BitbucketInterceptor{
@@ -243,7 +243,24 @@ func TestInterceptor_Process_ShouldNotContinue(t *testing.T) {
 			},
 		},
 		eventType: "event",
-		payload:   json.RawMessage(`{}`),
+		payload:   emptyJSONBody,
+	}, {
+		name: "empty secret",
+		interceptorParams: &triggersv1.BitbucketInterceptor{
+			SecretRef: &triggersv1.SecretRef{
+				SecretName: "mysecret",
+			},
+		},
+		signature: emptyBodyHMACSignature,
+		secret: &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "mysecret",
+			},
+			Data: map[string][]byte{
+				"token": []byte(secretToken),
+			},
+		},
+		payload: emptyJSONBody,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/interceptors/github/github.go
+++ b/pkg/interceptors/github/github.go
@@ -59,6 +59,10 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 	}
 	// Validate secrets first before anything else, if set
 	if p.SecretRef != nil {
+		// Check the secret to see if it is empty
+		if p.SecretRef.SecretKey == "" {
+			return interceptors.Fail(codes.FailedPrecondition, "github interceptor secretRef.secretKey is empty")
+		}
 		header := headers.Get("X-Hub-Signature")
 		if header == "" {
 			return interceptors.Fail(codes.FailedPrecondition, "no X-Hub-Signature header set")

--- a/pkg/interceptors/github/github_test.go
+++ b/pkg/interceptors/github/github_test.go
@@ -246,6 +246,23 @@ func TestInterceptor_ExecuteTrigger_ShouldNotContinue(t *testing.T) {
 		},
 		eventType: "MY_EVENT",
 		payload:   emptyJSONBody,
+	}, {
+		name: "empty secret",
+		interceptorParams: &triggersv1.GitHubInterceptor{
+			SecretRef: &triggersv1.SecretRef{
+				SecretName: "mysecret",
+			},
+		},
+		signature: emptyBodyHMACSignature,
+		secret: &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "mysecret",
+			},
+			Data: map[string][]byte{
+				"token": []byte(secretToken),
+			},
+		},
+		payload: emptyJSONBody,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/interceptors/gitlab/gitlab.go
+++ b/pkg/interceptors/gitlab/gitlab.go
@@ -54,6 +54,10 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 
 	headers := interceptors.Canonical(r.Header)
 	if p.SecretRef != nil {
+		// Check the secret to see if it is empty
+		if p.SecretRef.SecretKey == "" {
+			return interceptors.Fail(codes.FailedPrecondition, "gitlab interceptor secretRef.secretKey is empty")
+		}
 		header := headers.Get("X-GitLab-Token")
 		if header == "" {
 			return interceptors.Fail(codes.InvalidArgument, "no X-GitLab-Token header set")

--- a/pkg/interceptors/gitlab/gitlab_test.go
+++ b/pkg/interceptors/gitlab/gitlab_test.go
@@ -230,6 +230,21 @@ func TestInterceptor_ExecuteTrigger_ShouldNotContinue(t *testing.T) {
 				"token": []byte("secrettoken"),
 			},
 		},
+	}, {
+		name: "empty secret",
+		interceptorParams: &triggersv1.GitLabInterceptor{
+			SecretRef: &triggersv1.SecretRef{
+				SecretName: "mysecret",
+			},
+		},
+		secret: &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "mysecret",
+			},
+			Data: map[string][]byte{
+				"token": []byte("secrettoken"),
+			},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Changes

- Updated bitbucket interceptor to check for an empty secret and provided a better error message so that it doesn't result in "payload signature check failed"
- Updated bitbucket_tests to use emptyJSONBody instead of specifying an empty JSON body each time

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Updated bitbucket interceptor to check for empty secret and provided a better error message
```
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

Fixes #994 