### PR TITLE
Resolving cache sync issues

### DIFF
--- a/cmd/eventlistenersink/main.go
+++ b/cmd/eventlistenersink/main.go
@@ -121,7 +121,7 @@ func main() {
 	// Start and sync the informers before we start taking traffic
 	withTimeout, cancel := context.WithTimeout(ctx, cacheSyncTimeout)
 	defer cancel()
-	factory.Start(withTimeout.Done())
+	factory.Start(ctx.Done())
 	res := factory.WaitForCacheSync(withTimeout.Done())
 	for r, hasSynced := range res {
 		if !hasSynced {


### PR DESCRIPTION
# Changes

The factory stops syncing based on the context that is passed into the Start
function. We should wait for the cache sync with the short timeout, but the
factory should run for the lifetime of the eventlistener, hence the root
context object, with ctx.Done(), as it was before #1013


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Bugfix: Resolve cache sync issues introduced in v0.12.1
```

Closes #1026 
Closes #1036