### PR TITLE
Add separate interceptors file result to release pipeline

### DIFF
--- a/tekton/release-cheat-sheet.md
+++ b/tekton/release-cheat-sheet.md
@@ -136,11 +136,14 @@ the triggers repo, a terminal window and a text editor.
     ```bash
     # Test latest
     kubectl --context my-dev-cluster apply --filename https://storage.googleapis.com/tekton-releases/triggers/latest/release.yaml
+    kubectl --context my-dev-cluster apply --filename https://storage.googleapis.com/tekton-releases/triggers/latest/interceptors.yaml
     ```
 
     ```bash
     # Test backport
     kubectl --context my-dev-cluster apply --filename https://storage.googleapis.com/tekton-releases/triggers/previous/v0.12.1/release.yaml
+    # NOTE: Some older releases might not have a separate interceptors.yaml as they used to be bundled in release.yaml
+    kubectl --context my-dev-cluster apply --filename https://storage.googleapis.com/tekton-releases/triggers/previous/v0.12.1/interceptors.yaml
     ```
 
 1. Announce the release in Slack channels #general, #trigers and #announcements.

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -44,6 +44,12 @@ spec:
   - name: release-file-no-tag
     description: the URL of the release file
     value: $(tasks.report-bucket.results.release-no-tag)
+  - name: interceptors-file
+    description: the URL of the interceptors release file
+    value: $(tasks.report-bucket.results.interceptors)
+  - name: interceptors-file-no-tag
+    description: the URL of the interceptors release file
+    value: $(tasks.report-bucket.results.interceptors-no-tag)
   tasks:
   - name: git-clone
     taskRef:
@@ -177,9 +183,13 @@ spec:
       - name: versionTag
       results:
       - name: release
-        description: The full URL of the release file in the bucket
+        description: The full URL of the main release file in the bucket
       - name: release-no-tag
-        description: The full URL of the release file (no tag) in the bucket
+        description: The full URL of the main release file (no tag) in the bucket
+      - name: interceptors
+        description: The full URL of the interceptors release file in the bucket
+      - name: interceptors-no-tag
+        description: The full URL of the interceptors file (no tag) in the bucket
       steps:
       - name: create-results
         image: alpine
@@ -189,3 +199,5 @@ spec:
           BASE_URL=$(echo ${BASE_URL} | sed 's,gs://,https://storage.googleapis.com/,g')
           echo "${BASE_URL}/release.yaml" > $(results.release.path)
           echo "${BASE_URL}/release.notag.yaml" > $(results.release-no-tag.path)
+          echo "${BASE_URL}/interceptors.yaml" > $(results.interceptors.path)
+          echo "${BASE_URL}/interceptors.notag.yaml" > $(results.interceptors-no-tag.path)


### PR DESCRIPTION
Add separate `interceptors-file` result to release pipeline, as interceptors file
is now seprate release artifact. ref: https://github.com/tektoncd/triggers/pull/1007

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```