### PR TITLE
Use v1 API for RoleBinding 🦝

### DIFF
--- a/test/ingress/200-ingress-clusterrolebinding.yaml
+++ b/test/ingress/200-ingress-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: ingress
@@ -8,5 +8,5 @@ subjects:
     namespace: default
 roleRef:
   kind: ClusterRole
-  name: ingress 
+  name: ingress
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION


# Changes

Starting in 1.17, using `RoleBinding` with
rbac.authorization.k8s.io/v1beta1 is deprecated and will be removed in
1.22. Let's use `v1` API instead.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>

/cc @tektoncd/triggers-maintainers 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Using `rbac.authorization.k8s.io/v1` instead of `rbac.authorization.k8s.io/v1beta1` for `RoleBinding` as it is being deprecated starting in 1.17.
```