### PR TITLE
Fix gitlab interceptor example

### DIFF
--- a/examples/gitlab/gitlab-push-listener.yaml
+++ b/examples/gitlab/gitlab-push-listener.yaml
@@ -7,18 +7,12 @@ spec:
   triggers:
     - name: gitlab-push-events-trigger
       interceptors:
-        - name: "verify-gitlab-payload"
-          ref:
-            name: "gitlab"
-            kind: ClusterInterceptor
-          params:
-            - name: secretRef
-              value:
-                secretName: "gitlab-secret"
-                secretKey: "secretToken"
-            - name: eventTypes
-              value:
-                - "Push Hook"
+      - gitlab:
+          eventTypes:
+          - Push Hook
+          secretRef:
+            secretName: "gitlab-secret"
+            secretKey: "secretToken"
       bindings:
         - name: gitrevision
           value: $(body.checkout_sha)


### PR DESCRIPTION
# Changes

The GitLab example was broken, probably due to the recent changes. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Fix GitLab interceptor example.
```
