### PR TITLE
Provide error for invalid bindings

### DIFF
--- a/pkg/apis/triggers/v1alpha1/trigger_binding_validation.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_binding_validation.go
@@ -18,6 +18,8 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/apis"
@@ -25,22 +27,62 @@ import (
 
 // Validate TriggerBinding.
 func (tb *TriggerBinding) Validate(ctx context.Context) *apis.FieldError {
-	return tb.Spec.Validate(ctx)
+	return tb.Spec.Validate(ctx).ViaField("spec")
 }
 
 // Validate TriggerBindingSpec.
 func (s *TriggerBindingSpec) Validate(ctx context.Context) *apis.FieldError {
-	return validateParams(s.Params)
+	return validateParams(s.Params).ViaField("params")
 }
 
 func validateParams(params []Param) *apis.FieldError {
 	// Ensure there aren't multiple params with the same name.
 	seen := sets.NewString()
-	for _, param := range params {
+	for i, param := range params {
 		if seen.Has(param.Name) {
-			return apis.ErrMultipleOneOf("spec.params")
+			return apis.ErrMultipleOneOf(fmt.Sprintf("[%d].name", i))
 		}
 		seen.Insert(param.Name)
+		errs := validateParamValue(param.Value).ViaField(fmt.Sprintf("[%d]", i))
+		if errs != nil {
+			return errs
+		}
 	}
 	return nil
+}
+
+func validateParamValue(in string) *apis.FieldError {
+	if !strings.Contains(in, "$(") {
+		return nil
+	}
+	// Splits string on $( to find potential Tekton expressions
+	maybeExpressions := strings.Split(in, "$(")
+	terminated := true
+	for _, e := range maybeExpressions[1:] { // Split always returns at least one element
+		// Iterate until we find the first unbalanced )
+		numOpenBrackets := 0
+		if !terminated {
+			return apis.ErrInvalidValue(in, "value")
+		}
+		terminated = false
+		for _, ch := range e {
+			switch ch {
+			case '(':
+				numOpenBrackets++
+			case ')':
+				numOpenBrackets--
+				if numOpenBrackets < 0 {
+					terminated = true
+				}
+			default:
+				continue
+			}
+			if numOpenBrackets < 0 {
+				terminated = true
+				break
+			}
+		}
+	}
+	return nil
+
 }


### PR DESCRIPTION
# Changes

TriggerBinding values do not yet have any validation on their values, but we have situations, as
discussed in #385, where the binding value is somewhat nonsensical. In templates, it is possible that
a nesting situation may take place within a TaskRun script, but for a binding parameter value it makes
sense to avoid these types of situations.

This PR currently only avoids the situations where expressions are directly nested, meaning
dollar-parens immediately followed by dollar-parens. This would not detect a situation where they are
separated by some characters

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
TriggerBinding error on invalid Tekton template values
```
