### PR TITLE
Capitalization consistency for resourcetemplates

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -135,7 +135,7 @@ triggers:
       spec: 
         params:
           - name: "my-param-name"
-        resourceTemplates:
+        resourcetemplates:
         - apiVersion: "tekton.dev/v1beta1"
           kind: TaskRun
           metadata:

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -67,7 +67,7 @@ triggers:
       spec: 
         params:
           - name: "my-param-name"
-        resourceTemplates:
+        resourcetemplates:
         - apiVersion: "tekton.dev/v1beta1"
           kind: TaskRun
           metadata:

--- a/docs/triggertemplates.md
+++ b/docs/triggertemplates.md
@@ -98,7 +98,7 @@ A `TriggerTemplate` allows you to declare parameters supplied by the associated 
 * Tekton applies the value of the `default` field for each entry in the `params` array of your `TriggerTemplate` if it can't find a corresponding
   value in the associated `TriggerBinding` or cannot successfully extract the value from an HTTP header or body payload.
 
-* You can reference `tt.params` in the `resourceTemplates` section of your `TriggerTemplate` to make your `TriggerTemplate` reusable.
+* You can reference `tt.params` in the `resourcetemplates` section of your `TriggerTemplate` to make your `TriggerTemplate` reusable.
 
 * When you specify parameters in your resource template definitions, Tekton replaces the specified string with the parameter name, for example `$(tt.params.name)`.
   Therefore, simple string and number value replacements work fine directly in your YAML file. However, if a string has a numerical prefix, such as `123abcd`,

--- a/examples/eventlisteners/cel-eventlistener-interceptor.yaml
+++ b/examples/eventlisteners/cel-eventlistener-interceptor.yaml
@@ -23,7 +23,7 @@ spec:
         spec:
           params:
             - name: sha
-          resourceTemplates:
+          resourcetemplates:
             - apiVersion: tekton.dev/v1beta1
               kind: TaskRun
               metadata:

--- a/examples/eventlisteners/cel-eventlistener-multiple-overlays.yaml
+++ b/examples/eventlisteners/cel-eventlistener-multiple-overlays.yaml
@@ -26,7 +26,7 @@ spec:
           params:
             - name: sha
             - name: branch
-          resourceTemplates:
+          resourcetemplates:
             - apiVersion: tekton.dev/v1beta1
               kind: TaskRun
               metadata:


### PR DESCRIPTION
# Changes

Some of the documentation has the wrong capitalization for this spec. We should ensure
the fields are always accurate given the issues mentioned in #526

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Small documentation updates for API consistency
```

