### PR TITLE
refactor: move list of allowed ResourceTemplate types to its own package

### DIFF
--- a/pkg/apis/triggers/config/allowed_types.go
+++ b/pkg/apis/triggers/config/allowed_types.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	pipelinev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+var Decoder runtime.Decoder
+
+// TODO(dibyom): We should have a way of configuring this instead of an init function?
+func init() {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(pipelinev1alpha1.AddToScheme(scheme))
+	utilruntime.Must(pipelinev1beta1.AddToScheme(scheme))
+	codec := serializer.NewCodecFactory(scheme)
+	Decoder = codec.UniversalDecoder(
+		pipelinev1alpha1.SchemeGroupVersion,
+		pipelinev1beta1.SchemeGroupVersion,
+	)
+}
+
+// EnsureAllowedType returns nil if the resourceTemplate has an apiVersion
+// and kind field set to one of the allowed ones.
+func EnsureAllowedType(rt runtime.RawExtension) error {
+	_, err := runtime.Decode(Decoder, rt.Raw)
+	return err
+}

--- a/pkg/apis/triggers/v1alpha1/trigger_template_types.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_template_types.go
@@ -82,10 +82,3 @@ type TriggerTemplateList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []TriggerTemplate `json:"items"`
 }
-
-// IsAllowedType returns true if the resourceTemplate has an apiVersion
-// and kind field set to one of the allowed ones.
-func (trt *TriggerResourceTemplate) IsAllowedType() error {
-	_, err := runtime.Decode(Decoder, trt.RawExtension.Raw)
-	return err
-}

--- a/pkg/apis/triggers/v1alpha1/trigger_template_validation.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_template_validation.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
+	"github.com/tektoncd/triggers/pkg/apis/triggers/config"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -53,7 +54,7 @@ func (s *TriggerTemplateSpec) validate(ctx context.Context) (errs *apis.FieldErr
 
 func validateResourceTemplates(templates []TriggerResourceTemplate) (errs *apis.FieldError) {
 	for i, trt := range templates {
-		if err := trt.IsAllowedType(); err != nil {
+		if err := config.EnsureAllowedType(trt.RawExtension); err != nil {
 			if runtime.IsMissingVersion(err) {
 				errs = errs.Also(apis.ErrMissingField(fmt.Sprintf("[%d].apiVersion", i)))
 			}


### PR DESCRIPTION
# Changes

This will help reduce the number of places we keep track of the list of
types that Triggers can create especially as we add the v1beta1 types.

Partially addresses #494 and part of the work needed for #1067

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
NONE
```