### PR TITLE
Update examples readme to use valid port 8000

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -54,14 +54,14 @@ parameters.
 
 4. Send a payload to the listener
 
-Assuming we have a listener available at `localhost:8080` (and port-forwarded
+Assuming we have a listener available at `localhost:8000` (and port-forwarded
 for this example, with
-`kubectl port-forward $(kubectl get pod -o=name -l eventlistener=listener) 8080`),
+`kubectl port-forward $(kubectl get pod -o=name -l eventlistener=listener) 8000`),
 run the following command in your shell of choice or using Postman:
 
 ```bash
 curl -X POST \
-  http://localhost:8080 \
+  http://localhost:8000 \
   -H 'Content-Type: application/json' \
   -H 'X-Hub-Signature: sha1=2da37dcb9404ff17b714ee7a505c384758ddeb7b' \
   -d '{

--- a/examples/bitbucket/README.md
+++ b/examples/bitbucket/README.md
@@ -15,7 +15,7 @@ Creates an EventListener that listens for Bitbucket webhook events.
    ```bash
    kubectl port-forward \
     "$(kubectl get pod --selector=eventlistener=bitbucket-listener -oname)" \
-     8080
+     8000
    ```
 
    **Note**: Instead of port forwarding, you can set the
@@ -29,7 +29,7 @@ Creates an EventListener that listens for Bitbucket webhook events.
    -H 'X-Event-Key: repo:refs_changed' \
    -H 'X-Hub-Signature: sha1=544dde67b85743361b0321c9cc55f84472a608dd' \
    -d '{"repository": {"links": {"clone": [{"href": "http://localhost:7990/scm/~test/helloworld.git", "name": "http"}, {"href": "ssh://git@localhost:7999/~test/helloworld.git", "name": "ssh"}]}}, "changes": [{"ref": {"displayId": "main"}}]}' \
-   http://localhost:8080
+   http://localhost:8000
    ```
 
    The response status code should be `201 Created`

--- a/examples/github/README.md
+++ b/examples/github/README.md
@@ -15,7 +15,7 @@ Creates an EventListener that listens for GitHub webhook events.
    ```bash
    kubectl port-forward \
     "$(kubectl get pod --selector=eventlistener=github-listener-interceptor -oname)" \
-     8080
+     8000
    ```
 
    **Note**: Instead of port forwarding, you can set the
@@ -30,7 +30,7 @@ Creates an EventListener that listens for GitHub webhook events.
    -H 'X-Hub-Signature: sha1=ba0cdc263b3492a74b601d240c27efe81c4720cb' \
    -H 'Content-Type: application/json' \
    -d '{"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git"}}' \
-   http://localhost:8080
+   http://localhost:8000
    ```
 
    The response status code should be `201 Created`

--- a/examples/gitlab/README.md
+++ b/examples/gitlab/README.md
@@ -15,7 +15,7 @@ Creates an EventListener that listens for GitLab webhook events.
    ```bash
    kubectl port-forward \
     "$(kubectl get pod --selector=eventlistener=gitlab-listener -oname)" \
-     8080
+     8000
    ```
 
    **Note**: Instead of port forwarding, you can set the
@@ -30,7 +30,7 @@ Creates an EventListener that listens for GitLab webhook events.
    -H 'X-Gitlab-Event: Push Hook' \
    -H 'Content-Type: application/json' \
    --data-binary "@examples/gitlab/gitlab-push-event.json" \
-   http://localhost:8080
+   http://localhost:8000
    ```
 
    The response status code should be `201 Created`

--- a/examples/v1alpha1-task/README.md
+++ b/examples/v1alpha1-task/README.md
@@ -15,7 +15,7 @@ Creates an EventListener that creates a v1alpha1 TaskRun.
    ```shell script
    kubectl port-forward \
     "$(kubectl get pod --selector=eventlistener=v1alpha1-task-listener -oname)" \
-     8080
+     8000
    ```
 
    **Note**: Instead of port forwarding, you can set the
@@ -28,7 +28,7 @@ Creates an EventListener that creates a v1alpha1 TaskRun.
    curl -v \
    -H 'Content-Type: application/json' \
    --data "{}" \
-   http://localhost:8080
+   http://localhost:8000
    ```
 
    The response status code should be `201 Created`


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
Updated examples readme to use correct port 8000
Because as part of PR https://github.com/tektoncd/triggers/pull/887 EL container runs on 8000 instead of 8080 and kubectl port-forward looks for container port
```
