### PR TITLE
Add validation check for triggers

### DIFF
--- a/pkg/apis/triggers/v1alpha1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation.go
@@ -272,6 +272,10 @@ func (t *EventListenerTrigger) validate(ctx context.Context) (errs *apis.FieldEr
 		errs = errs.Also(apis.ErrMissingOneOf("template", "triggerRef"))
 	}
 
+	if t.TriggerRef != "" && (t.Template != nil || t.Bindings != nil || t.Interceptors != nil) {
+		errs = errs.Also(apis.ErrMultipleOneOf("triggerRef", "template or bindings or interceptors"))
+	}
+
 	// Validate optional Bindings
 	errs = errs.Also(triggerSpecBindingArray(t.Bindings).validate(ctx))
 	if t.Template != nil {

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
@@ -260,11 +260,6 @@ func Test_EventListenerValidate(t *testing.T) {
 			},
 			Spec: v1alpha1.EventListenerSpec{
 				Triggers: []v1alpha1.EventListenerTrigger{{
-					Bindings: []*v1alpha1.EventListenerBinding{{
-						Ref:        "tb",
-						Kind:       "TriggerBinding",
-						APIVersion: "v1alpha1",
-					}},
 					TriggerRef: "triggerref",
 				}},
 				Resources: v1alpha1.Resources{
@@ -695,6 +690,27 @@ func TestEventListenerValidate_error(t *testing.T) {
 				Resources: v1alpha1.Resources{
 					CustomResource: &v1alpha1.CustomResource{
 						RawExtension: getRawData(t),
+					},
+				},
+			},
+		},
+	}, {
+		name: "Specify TriggerTemplate along with TriggerRef",
+		el: &v1alpha1.EventListener{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					Template: &v1alpha1.EventListenerTemplate{
+						Ref: ptr.String("tt"),
+					},
+					TriggerRef: "triggerref",
+				}},
+				Resources: v1alpha1.Resources{
+					CustomResource: &v1alpha1.CustomResource{
+						RawExtension: getValidRawData(t),
 					},
 				},
 			},


### PR DESCRIPTION
# Changes

Added changes to do validation when user specify both `triggerRef`, `triggerTemplate` as part of eventlistener spec.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
User cannot specify both TriggerRef and (TriggerTemplate, TriggerBindings, Interceptors) as part of eventlistener spec.
```
