### PR TITLE
Add link between cluster interceptor docs and interceptor docs

### DIFF
--- a/docs/clusterinterceptors.md
+++ b/docs/clusterinterceptors.md
@@ -11,7 +11,7 @@ Tekton Triggers ships with the `ClusterInterceptor` Custom Resource Definition (
 A `ClusterInterceptor` specifies an external Kubernetes v1 Service running custom business logic that receives the event payload from the
 `EventListener` via an HTTP request and returns a processed version of the payload along with an HTTP 200 response. The `ClusterInterceptor` can also
 halt processing if the event payload does not meet criteria you have configured as well as add extra fields that are accessible in the `EventListener's`
-top-level `extensions` field to other `Interceptors` and `ClusterInterceptors` chained with it and the associated `TriggerBinding`.
+top-level `extensions` field to other [`Interceptors`](interceptors.md) and `ClusterInterceptors` chained with it and the associated `TriggerBinding`.
 
 ## Structure of a `ClusterInterceptor`
 


### PR DESCRIPTION
# Changes

I wonder if in the long run it might make sense to merge these pages - hard to understand from just the cluster interceptor docs what the interceptors are about. But for now at least linking to the context.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
