### PR TITLE
Migrate from test builders to structs

### DIFF
--- a/pkg/apis/triggers/v1alpha1/cluster_trigger_binding_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/cluster_trigger_binding_validation_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
-	bldr "github.com/tektoncd/triggers/test/builder"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_ClusterTriggerBindingValidate(t *testing.T) {
@@ -30,23 +30,49 @@ func Test_ClusterTriggerBindingValidate(t *testing.T) {
 		tb   *v1alpha1.ClusterTriggerBinding
 	}{{
 		name: "empty",
-		tb:   bldr.ClusterTriggerBinding("name"),
+		tb: &v1alpha1.ClusterTriggerBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "name",
+			},
+		},
 	}, {
 		name: "multiple params",
-		tb: bldr.ClusterTriggerBinding("name",
-			bldr.ClusterTriggerBindingSpec(
-				bldr.TriggerBindingParam("param1", "$(body.input1)"),
-				bldr.TriggerBindingParam("param2", "$(body.input2)"),
-				bldr.TriggerBindingParam("param3", "$(body.input3)"),
-			)),
+		tb: &v1alpha1.ClusterTriggerBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "name",
+			},
+			Spec: v1alpha1.TriggerBindingSpec{
+				Params: []v1alpha1.Param{{
+					Name:  "param1",
+					Value: "$(body.input1)",
+				}, {
+					Name:  "param2",
+					Value: "$(body.input2)",
+				}, {
+					Name:  "param3",
+					Value: "$(body.input3)",
+				}},
+			},
+		},
 	}, {
 		name: "multiple params case sensitive",
-		tb: bldr.ClusterTriggerBinding("name",
-			bldr.ClusterTriggerBindingSpec(
-				bldr.TriggerBindingParam("param1", "$(body.input1)"),
-				bldr.TriggerBindingParam("PARAM1", "$(body.input2)"),
-				bldr.TriggerBindingParam("Param1", "$(body.input3)"),
-			)),
+		tb: &v1alpha1.ClusterTriggerBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "name",
+			},
+			Spec: v1alpha1.TriggerBindingSpec{
+				Params: []v1alpha1.Param{{
+					Name:  "param1",
+					Value: "$(body.input1)",
+				}, {
+					Name:  "PARAM1",
+					Value: "$(body.input2)",
+				}, {
+					Name:  "param3",
+					Value: "$(body.input3)",
+				}},
+			},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -63,12 +89,23 @@ func Test_ClusterTriggerBindingValidate_error(t *testing.T) {
 		tb   *v1alpha1.ClusterTriggerBinding
 	}{{
 		name: "duplicate params",
-		tb: bldr.ClusterTriggerBinding("name",
-			bldr.ClusterTriggerBindingSpec(
-				bldr.TriggerBindingParam("param1", "$(body.param1)"),
-				bldr.TriggerBindingParam("param1", "$(body.param1)"),
-				bldr.TriggerBindingParam("param3", "$(body.param1)"),
-			)),
+		tb: &v1alpha1.ClusterTriggerBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "name",
+			},
+			Spec: v1alpha1.TriggerBindingSpec{
+				Params: []v1alpha1.Param{{
+					Name:  "param1",
+					Value: "$(body.input1)",
+				}, {
+					Name:  "param1",
+					Value: "$(body.input2)",
+				}, {
+					Name:  "param3",
+					Value: "$(body.input3)",
+				}},
+			},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/triggers/v1alpha1/trigger_binding_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_binding_validation_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
-	bldr "github.com/tektoncd/triggers/test/builder"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_TriggerBindingValidate(t *testing.T) {
@@ -31,30 +31,69 @@ func Test_TriggerBindingValidate(t *testing.T) {
 		tb   *v1alpha1.TriggerBinding
 	}{{
 		name: "empty",
-		tb:   bldr.TriggerBinding("name", "namespace"),
+		tb: &v1alpha1.TriggerBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+		},
 	}, {
 		name: "multiple params",
-		tb: bldr.TriggerBinding("name", "namespace",
-			bldr.TriggerBindingSpec(
-				bldr.TriggerBindingParam("param1", "$(body.input1)"),
-				bldr.TriggerBindingParam("param2", "$(body.input2)"),
-				bldr.TriggerBindingParam("param3", "$(body.(input3))"),
-				bldr.TriggerBindingParam("param4", "static-input"),
-			)),
+		tb: &v1alpha1.TriggerBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Spec: v1alpha1.TriggerBindingSpec{
+				Params: []v1alpha1.Param{{
+					Name:  "param1",
+					Value: "$(body.input1)",
+				}, {
+					Name:  "param2",
+					Value: "$(body.input2)",
+				}, {
+					Name:  "param3",
+					Value: "$(body.(input3))",
+				}, {
+					Name:  "param4",
+					Value: "static-input",
+				}},
+			},
+		},
 	}, {
 		name: "multiple params case sensitive",
-		tb: bldr.TriggerBinding("name", "namespace",
-			bldr.TriggerBindingSpec(
-				bldr.TriggerBindingParam("param1", "$(body.input1)"),
-				bldr.TriggerBindingParam("PARAM1", "$(body.input2)"),
-				bldr.TriggerBindingParam("Param1", "$(body.input3)"),
-			)),
+		tb: &v1alpha1.TriggerBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Spec: v1alpha1.TriggerBindingSpec{
+				Params: []v1alpha1.Param{{
+					Name:  "param1",
+					Value: "$(body.input1)",
+				}, {
+					Name:  "PARAM1",
+					Value: "$(body.input2)",
+				}, {
+					Name:  "param3",
+					Value: "$(body.input3)",
+				}},
+			},
+		},
 	}, {
 		name: "multiple expressions in one body",
-		tb: bldr.TriggerBinding("name", "namespace",
-			bldr.TriggerBindingSpec(
-				bldr.TriggerBindingParam("param1", "$(body.input1)-$(body.input2)"),
-			)),
+		tb: &v1alpha1.TriggerBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Spec: v1alpha1.TriggerBindingSpec{
+				Params: []v1alpha1.Param{{
+					Name:  "param1",
+					Value: "$(body.input1)-$(body.input2)",
+				}},
+			},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -72,33 +111,72 @@ func Test_TriggerBindingValidate_error(t *testing.T) {
 		errMsg string
 	}{{
 		name: "duplicate params",
-		tb: bldr.TriggerBinding("name", "namespace",
-			bldr.TriggerBindingSpec(
-				bldr.TriggerBindingParam("param1", "$(body.param1)"),
-				bldr.TriggerBindingParam("param1", "$(body.param1)"),
-				bldr.TriggerBindingParam("param3", "$(body.param1)"),
-			)),
+		tb: &v1alpha1.TriggerBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Spec: v1alpha1.TriggerBindingSpec{
+				Params: []v1alpha1.Param{{
+					Name:  "param1",
+					Value: "$(body.input1)",
+				}, {
+					Name:  "param1",
+					Value: "$(body.input2)",
+				}, {
+					Name:  "param3",
+					Value: "$(body.input3)",
+				}},
+			},
+		},
 		errMsg: "expected exactly one, got both: spec.params[1].name",
 	}, {
 		name: "invalid parameter",
-		tb: bldr.TriggerBinding("name", "namespace",
-			bldr.TriggerBindingSpec(
-				bldr.TriggerBindingParam("param1", "$($(body.param1))"),
-			)),
+		tb: &v1alpha1.TriggerBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Spec: v1alpha1.TriggerBindingSpec{
+				Params: []v1alpha1.Param{{
+					Name:  "param1",
+					Value: "$($(body.param1))",
+				},
+				},
+			},
+		},
 		errMsg: "invalid value: $($(body.param1)): spec.params[0].value",
 	}, {
 		name: "invalid parameter further nested",
-		tb: bldr.TriggerBinding("name", "namespace",
-			bldr.TriggerBindingSpec(
-				bldr.TriggerBindingParam("param1", "$(body.test-$(body.param1))"),
-			)),
+		tb: &v1alpha1.TriggerBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Spec: v1alpha1.TriggerBindingSpec{
+				Params: []v1alpha1.Param{{
+					Name:  "param1",
+					Value: "$(body.test-$(body.param1))",
+				},
+				},
+			},
+		},
 		errMsg: "invalid value: $(body.test-$(body.param1)): spec.params[0].value",
 	}, {
 		name: "invalid parameter triple nested",
-		tb: bldr.TriggerBinding("name", "namespace",
-			bldr.TriggerBindingSpec(
-				bldr.TriggerBindingParam("param1", "$($($(body.param1)))"),
-			)),
+		tb: &v1alpha1.TriggerBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Spec: v1alpha1.TriggerBindingSpec{
+				Params: []v1alpha1.Param{{
+					Name:  "param1",
+					Value: "$($($(body.param1)))",
+				},
+				},
+			},
+		},
 		errMsg: "invalid value: $($($(body.param1))): spec.params[0].value",
 	}}
 	for _, tt := range tests {

--- a/pkg/apis/triggers/v1alpha1/trigger_template_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_template_validation_test.go
@@ -21,14 +21,12 @@ import (
 	"testing"
 
 	pipelinev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
-	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	"github.com/tektoncd/triggers/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/ptr"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
-	b "github.com/tektoncd/triggers/test/builder"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/pkg/apis"
 )
@@ -42,10 +40,10 @@ func simpleResourceTemplate(t *testing.T) runtime.RawExtension {
 	})
 }
 
-func v1beta1ResourceTemplate(t *testing.T) runtime.RawExtension {
-	return test.RawExtension(t, pipelinev1beta1.PipelineRun{
+func v1alpha1ResourceTemplate(t *testing.T) runtime.RawExtension {
+	return test.RawExtension(t, pipelinev1alpha1.PipelineRun{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "tekton.dev/v1beta1",
+			APIVersion: "tekton.dev/v1alpha1",
 			Kind:       "PipelineRun",
 		},
 	})
@@ -96,134 +94,293 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 		name     string
 		template *v1alpha1.TriggerTemplate
 		want     *apis.FieldError
-	}{
-		{
-			name: "invalid objectmetadata, name with dot",
-			template: b.TriggerTemplate("t.t", "foo", b.TriggerTemplateSpec(
-				b.TriggerTemplateParam("foo", "desc", "val"),
-				b.TriggerResourceTemplate(simpleResourceTemplate(t)))),
-			want: &apis.FieldError{
-				Message: "Invalid resource name: special character . must not be present",
-				Paths:   []string{"metadata.name"},
+	}{{
+		name: "invalid objectmetadata, name with dot",
+		template: &v1alpha1.TriggerTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "t.t",
+				Namespace: "foo",
+			},
+			Spec: v1alpha1.TriggerTemplateSpec{
+				Params: []v1alpha1.ParamSpec{{
+					Name:        "foo",
+					Description: "desc",
+					Default:     ptr.String("val"),
+				}},
+				ResourceTemplates: []v1alpha1.TriggerResourceTemplate{{
+					RawExtension: simpleResourceTemplate(t),
+				}},
 			},
 		},
-		{
-			name: "invalid objectmetadata, name too long",
-			template: b.TriggerTemplate(
-				"ttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt",
-				"foo", b.TriggerTemplateSpec(
-					b.TriggerTemplateParam("foo", "desc", "val"),
-					b.TriggerResourceTemplate(simpleResourceTemplate(t)))),
-			want: &apis.FieldError{
-				Message: "Invalid resource name: length must be no more than 63 characters",
-				Paths:   []string{"metadata.name"},
+		want: &apis.FieldError{
+			Message: "Invalid resource name: special character . must not be present",
+			Paths:   []string{"metadata.name"},
+		},
+	}, {
+		name: "invalid objectmetadata, name too long",
+		template: &v1alpha1.TriggerTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt",
+				Namespace: "foo",
+			},
+			Spec: v1alpha1.TriggerTemplateSpec{
+				Params: []v1alpha1.ParamSpec{{
+					Name:        "foo",
+					Description: "desc",
+					Default:     ptr.String("val"),
+				}},
+				ResourceTemplates: []v1alpha1.TriggerResourceTemplate{{
+					RawExtension: simpleResourceTemplate(t),
+				}},
 			},
 		},
-		{
-			name: "valid template",
-			template: b.TriggerTemplate("tt", "foo", b.TriggerTemplateSpec(
-				b.TriggerTemplateParam("foo", "desc", "val"),
-				b.TriggerResourceTemplate(simpleResourceTemplate(t)))),
-			want: nil,
-		}, {
-			name: "valid v1beta1 template",
-			template: b.TriggerTemplate("tt", "foo", b.TriggerTemplateSpec(
-				b.TriggerTemplateParam("foo", "desc", "val"),
-				b.TriggerResourceTemplate(v1beta1ResourceTemplate(t)))),
-			want: nil,
-		}, {
-			name: "missing resource template",
-			template: b.TriggerTemplate("tt", "foo", b.TriggerTemplateSpec(
-				b.TriggerTemplateParam("foo", "desc", "val"))),
-			want: &apis.FieldError{
-				Message: "missing field(s)",
-				Paths:   []string{"spec.resourcetemplates"},
+		want: &apis.FieldError{
+			Message: "Invalid resource name: length must be no more than 63 characters",
+			Paths:   []string{"metadata.name"},
+		},
+	}, {
+		name: "valid template",
+		template: &v1alpha1.TriggerTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tt",
+				Namespace: "foo",
 			},
-		}, {
-			name: "resource template missing kind",
-			template: b.TriggerTemplate("tt", "foo", b.TriggerTemplateSpec(
-				b.TriggerTemplateParam("foo", "desc", "val"),
-				b.TriggerResourceTemplate(test.RawExtension(t, pipelinev1alpha1.PipelineRun{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "tekton.dev/v1alpha1",
-					},
-				})))),
-			want: &apis.FieldError{
-				Message: "missing field(s)",
-				Paths:   []string{"spec.resourcetemplates[0].kind"},
+			Spec: v1alpha1.TriggerTemplateSpec{
+				Params: []v1alpha1.ParamSpec{{
+					Name:        "foo",
+					Description: "desc",
+					Default:     ptr.String("val"),
+				}},
+				ResourceTemplates: []v1alpha1.TriggerResourceTemplate{{
+					RawExtension: simpleResourceTemplate(t),
+				}},
 			},
-		}, {
-			name: "resource template missing apiVersion",
-			template: b.TriggerTemplate("tt", "foo", b.TriggerTemplateSpec(
-				b.TriggerTemplateParam("foo", "desc", "val"),
-				b.TriggerResourceTemplate(test.RawExtension(t, pipelinev1alpha1.PipelineRun{
-					TypeMeta: metav1.TypeMeta{
-						Kind: "PipelineRun",
-					},
-				})))),
-			want: &apis.FieldError{
-				Message: "missing field(s)",
-				Paths:   []string{"spec.resourcetemplates[0].apiVersion"},
+		},
+		want: nil,
+	}, {
+		name: "valid v1alpha1 template",
+		template: &v1alpha1.TriggerTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tt",
+				Namespace: "foo",
 			},
-		}, {
-			name: "resource template invalid apiVersion",
-			template: b.TriggerTemplate("tt", "foo", b.TriggerTemplateSpec(
-				b.TriggerTemplateParam("foo", "desc", "val"),
-				b.TriggerResourceTemplate(test.RawExtension(t, pipelinev1alpha1.PipelineRun{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "foobar",
-						Kind:       "pipelinerun",
-					},
-				})))),
-			want: &apis.FieldError{
-				Message: `invalid value: no kind "pipelinerun" is registered for version "foobar"`,
-				Paths:   []string{"spec.resourcetemplates[0]"},
+			Spec: v1alpha1.TriggerTemplateSpec{
+				Params: []v1alpha1.ParamSpec{{
+					Name:        "foo",
+					Description: "desc",
+					Default:     ptr.String("val"),
+				}},
+				ResourceTemplates: []v1alpha1.TriggerResourceTemplate{{
+					RawExtension: v1alpha1ResourceTemplate(t),
+				}},
 			},
-		}, {
-			name: "resource template invalid kind",
-			template: b.TriggerTemplate("tt", "foo", b.TriggerTemplateSpec(
-				b.TriggerTemplateParam("foo", "desc", "val"),
-				b.TriggerResourceTemplate(test.RawExtension(t, pipelinev1alpha1.PipelineRun{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "foo",
-						Kind:       "tekton.dev/v1alpha1",
-					},
-				})))),
-			want: &apis.FieldError{
-				Message: `invalid value: no kind "tekton.dev/v1alpha1" is registered for version "foo"`,
-				Paths:   []string{"spec.resourcetemplates[0]"},
+		},
+		want: nil,
+	}, {
+		name: "missing resource template",
+		template: &v1alpha1.TriggerTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tt",
+				Namespace: "foo",
 			},
-		}, {
-			name: "tt.params used in resource template are declared",
-			template: b.TriggerTemplate("tt", "foo", b.TriggerTemplateSpec(
-				b.TriggerTemplateParam("foo", "desc", "val"),
-				b.TriggerResourceTemplate(paramResourceTemplate(t)))),
-			want: nil,
-		}, {
-			name: "tt.params used in resource template are not declared",
-			template: b.TriggerTemplate("tt", "foo", b.TriggerTemplateSpec(
-				b.TriggerResourceTemplate(paramResourceTemplate(t)))),
-			want: &apis.FieldError{
-				Message: "invalid value: undeclared param '$(tt.params.foo)'",
-				Paths:   []string{"spec.resourcetemplates[0]"},
-				Details: "'$(tt.params.foo)' must be declared in spec.params",
+			Spec: v1alpha1.TriggerTemplateSpec{
+				Params: []v1alpha1.ParamSpec{{
+					Name:        "foo",
+					Description: "desc",
+					Default:     ptr.String("val"),
+				}},
 			},
-		}, {
-			name: "invalid params used in resource template are not declared",
-			template: b.TriggerTemplate("tt", "foo", b.TriggerTemplateSpec(
-				b.TriggerResourceTemplate(invalidParamResourceTemplate(t)))),
-			want: nil,
-		}, {
-			name: "invalid params used in resource template are declared",
-			template: b.TriggerTemplate("tt", "foo", b.TriggerTemplateSpec(
-				b.TriggerTemplateParam("foo", "desc", "val"),
-				b.TriggerResourceTemplate(invalidParamResourceTemplate(t)))),
-			want: nil,
-		}, {
-			name:     "no spec to triggertemplate",
-			template: b.TriggerTemplate("tt", "foo", b.TriggerTemplateSpec()),
-			want:     apis.ErrMissingField("spec", "spec.resourcetemplates"),
-		}}
+		},
+		want: &apis.FieldError{
+			Message: "missing field(s)",
+			Paths:   []string{"spec.resourcetemplates"},
+		},
+	}, {
+		name: "resource template missing kind",
+		template: &v1alpha1.TriggerTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tt",
+				Namespace: "foo",
+			},
+			Spec: v1alpha1.TriggerTemplateSpec{
+				Params: []v1alpha1.ParamSpec{{
+					Name:        "foo",
+					Description: "desc",
+					Default:     ptr.String("val"),
+				}},
+				ResourceTemplates: []v1alpha1.TriggerResourceTemplate{{
+					RawExtension: test.RawExtension(t, pipelinev1alpha1.PipelineRun{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "tekton.dev/v1alpha1",
+						},
+					}),
+				}},
+			},
+		},
+		want: &apis.FieldError{
+			Message: "missing field(s)",
+			Paths:   []string{"spec.resourcetemplates[0].kind"},
+		},
+	}, {
+		name: "resource template missing apiVersion",
+		template: &v1alpha1.TriggerTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tt",
+				Namespace: "foo",
+			},
+			Spec: v1alpha1.TriggerTemplateSpec{
+				Params: []v1alpha1.ParamSpec{{
+					Name:        "foo",
+					Description: "desc",
+					Default:     ptr.String("val"),
+				}},
+				ResourceTemplates: []v1alpha1.TriggerResourceTemplate{{
+					RawExtension: test.RawExtension(t, pipelinev1alpha1.PipelineRun{
+						TypeMeta: metav1.TypeMeta{
+							Kind: "PipelineRun",
+						},
+					}),
+				}},
+			},
+		},
+		want: &apis.FieldError{
+			Message: "missing field(s)",
+			Paths:   []string{"spec.resourcetemplates[0].apiVersion"},
+		},
+	}, {
+		name: "resource template invalid apiVersion",
+		template: &v1alpha1.TriggerTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tt",
+				Namespace: "foo",
+			},
+			Spec: v1alpha1.TriggerTemplateSpec{
+				Params: []v1alpha1.ParamSpec{{
+					Name:        "foo",
+					Description: "desc",
+					Default:     ptr.String("val"),
+				}},
+				ResourceTemplates: []v1alpha1.TriggerResourceTemplate{{
+					RawExtension: test.RawExtension(t, pipelinev1alpha1.PipelineRun{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "foobar",
+							Kind:       "pipelinerun",
+						},
+					}),
+				}},
+			},
+		},
+		want: &apis.FieldError{
+			Message: `invalid value: no kind "pipelinerun" is registered for version "foobar"`,
+			Paths:   []string{"spec.resourcetemplates[0]"},
+		},
+	}, {
+		name: "resource template invalid kind",
+		template: &v1alpha1.TriggerTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tt",
+				Namespace: "foo",
+			},
+			Spec: v1alpha1.TriggerTemplateSpec{
+				Params: []v1alpha1.ParamSpec{{
+					Name:        "foo",
+					Description: "desc",
+					Default:     ptr.String("val"),
+				}},
+				ResourceTemplates: []v1alpha1.TriggerResourceTemplate{{
+					RawExtension: test.RawExtension(t, pipelinev1alpha1.PipelineRun{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "foo",
+							Kind:       "tekton.dev/v1alpha1",
+						},
+					}),
+				}},
+			},
+		},
+		want: &apis.FieldError{
+			Message: `invalid value: no kind "tekton.dev/v1alpha1" is registered for version "foo"`,
+			Paths:   []string{"spec.resourcetemplates[0]"},
+		},
+	}, {
+		name: "tt.params used in resource template are declared",
+		template: &v1alpha1.TriggerTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tt",
+				Namespace: "foo",
+			},
+			Spec: v1alpha1.TriggerTemplateSpec{
+				Params: []v1alpha1.ParamSpec{{
+					Name:        "foo",
+					Description: "desc",
+					Default:     ptr.String("val"),
+				}},
+				ResourceTemplates: []v1alpha1.TriggerResourceTemplate{{
+					RawExtension: paramResourceTemplate(t),
+				}},
+			},
+		},
+		want: nil,
+	}, {
+		name: "tt.params used in resource template are not declared",
+		template: &v1alpha1.TriggerTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tt",
+				Namespace: "foo",
+			},
+			Spec: v1alpha1.TriggerTemplateSpec{
+				ResourceTemplates: []v1alpha1.TriggerResourceTemplate{{
+					RawExtension: paramResourceTemplate(t),
+				}},
+			},
+		},
+		want: &apis.FieldError{
+			Message: "invalid value: undeclared param '$(tt.params.foo)'",
+			Paths:   []string{"spec.resourcetemplates[0]"},
+			Details: "'$(tt.params.foo)' must be declared in spec.params",
+		},
+	}, {
+		name: "invalid params used in resource template are not declared",
+		template: &v1alpha1.TriggerTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tt",
+				Namespace: "foo",
+			},
+			Spec: v1alpha1.TriggerTemplateSpec{
+				ResourceTemplates: []v1alpha1.TriggerResourceTemplate{{
+					RawExtension: invalidParamResourceTemplate(t),
+				}},
+			},
+		},
+		want: nil,
+	}, {
+		name: "invalid params used in resource template are declared",
+		template: &v1alpha1.TriggerTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tt",
+				Namespace: "foo",
+			},
+			Spec: v1alpha1.TriggerTemplateSpec{
+				Params: []v1alpha1.ParamSpec{{
+					Name:        "foo",
+					Description: "desc",
+					Default:     ptr.String("val"),
+				}},
+				ResourceTemplates: []v1alpha1.TriggerResourceTemplate{{
+					RawExtension: invalidParamResourceTemplate(t),
+				}},
+			},
+		},
+		want: nil,
+	}, {
+		name: "no spec to triggertemplate",
+		template: &v1alpha1.TriggerTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tt",
+				Namespace: "foo",
+			},
+		},
+		want: apis.ErrMissingField("spec", "spec.resourcetemplates"),
+	}}
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/apis/triggers/v1alpha1/trigger_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_validation_test.go
@@ -23,10 +23,7 @@ import (
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	"github.com/tektoncd/triggers/test"
-	bldr "github.com/tektoncd/triggers/test/builder"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"knative.dev/pkg/ptr"
 )
 
@@ -36,32 +33,83 @@ func Test_TriggerValidate(t *testing.T) {
 		tr   *v1alpha1.Trigger
 	}{{
 		name: "Valid Trigger No TriggerBinding",
-		tr: bldr.Trigger("name", "namespace",
-			bldr.TriggerSpec(
-				bldr.TriggerSpecTemplate("tt", "v1alpha1"))),
+		tr: &v1alpha1.Trigger{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Spec: v1alpha1.TriggerSpec{
+				Template: v1alpha1.TriggerSpecTemplate{
+					Ref:        ptr.String("tt"),
+					APIVersion: "v1alpha1",
+				},
+			},
+		},
 	}, {
 		name: "Valid Trigger with TriggerBinding",
-		tr: bldr.Trigger("name", "namespace",
-			bldr.TriggerSpec(
-				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "TriggerBinding", "", "v1alpha1"),
-			)),
+		tr: &v1alpha1.Trigger{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Spec: v1alpha1.TriggerSpec{
+				Bindings: []*v1alpha1.TriggerSpecBinding{{
+					Ref:        "tb",
+					Kind:       v1alpha1.NamespacedTriggerBindingKind,
+					APIVersion: "v1alpha1",
+				}},
+				Template: v1alpha1.TriggerSpecTemplate{
+					Ref:        ptr.String("tt"),
+					APIVersion: "v1alpha1",
+				},
+			},
+		},
 	}, {
 		name: "Valid Trigger with ClusterTriggerBinding",
-		tr: bldr.Trigger("name", "namespace",
-			bldr.TriggerSpec(
-				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "ClusterTriggerBinding", "", "v1alpha1"),
-			)),
+		tr: &v1alpha1.Trigger{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Spec: v1alpha1.TriggerSpec{
+				Bindings: []*v1alpha1.TriggerSpecBinding{{
+					Ref:        "tb",
+					Kind:       v1alpha1.ClusterTriggerBindingKind,
+					APIVersion: "v1alpha1",
+				}},
+				Template: v1alpha1.TriggerSpecTemplate{
+					Ref:        ptr.String("tt"),
+					APIVersion: "v1alpha1",
+				},
+			},
+		},
 	}, {
 		name: "Valid Trigger with multiple TriggerBindings",
-		tr: bldr.Trigger("name", "namespace",
-			bldr.TriggerSpec(
-				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "ClusterTriggerBinding", "", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "TriggerBinding", "", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb3", "", "", "v1alpha1"),
-			)),
+		tr: &v1alpha1.Trigger{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Spec: v1alpha1.TriggerSpec{
+				Bindings: []*v1alpha1.TriggerSpecBinding{{
+					Ref:        "tb",
+					Kind:       v1alpha1.NamespacedTriggerBindingKind,
+					APIVersion: "v1alpha1",
+				}, {
+					Ref:        "tb",
+					Kind:       v1alpha1.ClusterTriggerBindingKind,
+					APIVersion: "v1alpha1",
+				}, {
+					Ref:        "tb2",
+					Kind:       v1alpha1.NamespacedTriggerBindingKind,
+					APIVersion: "v1alpha1",
+				}},
+				Template: v1alpha1.TriggerSpecTemplate{
+					Ref:        ptr.String("tt"),
+					APIVersion: "v1alpha1",
+				},
+			},
+		},
 	}, {
 		name: "Trigger with new embedded TriggerBindings",
 		tr: &v1alpha1.Trigger{
@@ -85,57 +133,53 @@ func Test_TriggerValidate(t *testing.T) {
 		},
 	}, {
 		name: "Valid Trigger Interceptor",
-		tr: bldr.Trigger("name", "namespace",
-			bldr.TriggerSpec(
-				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "", "", "v1alpha1"),
-				bldr.TriggerSpecInterceptor("svc", "v1", "Service", "namespace"),
-			)),
-	}, {
-		name: "Valid Trigger Interceptor With Header",
-		tr: bldr.Trigger("name", "namespace",
-			bldr.TriggerSpec(
-				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "", "", "v1alpha1"),
-				bldr.TriggerSpecInterceptor("svc", "v1", "Service", "namespace",
-					bldr.TriggerSpecInterceptorParam("Valid-Header-Key", "valid value"),
-				),
-			)),
-	}, {
-		name: "Valid Trigger Interceptor With Headers",
-		tr: bldr.Trigger("name", "namespace",
-			bldr.TriggerSpec(
-				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "", "", "v1alpha1"),
-				bldr.TriggerSpecInterceptor("svc", "v1", "Service", "namespace",
-					bldr.TriggerSpecInterceptorParam("Valid-Header-Key1", "valid value1"),
-					bldr.TriggerSpecInterceptorParam("Valid-Header-Key1", "valid value2"),
-					bldr.TriggerSpecInterceptorParam("Valid-Header-Key2", "valid value"),
-				),
-			)),
-	}, {
-		name: "Valid Trigger with CEL interceptor",
-		tr: bldr.Trigger("name", "namespace",
-			bldr.TriggerSpec(
-				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "", "", "v1alpha1"),
-				bldr.TriggerSpecCELInterceptor("body.value == 'test'"),
-			)),
+		tr: &v1alpha1.Trigger{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Spec: v1alpha1.TriggerSpec{
+				Interceptors: []*v1alpha1.TriggerInterceptor{{
+					Ref: v1alpha1.InterceptorRef{
+						Name:       "cel",
+						Kind:       v1alpha1.ClusterInterceptorKind,
+						APIVersion: "v1alpha1",
+					},
+					Params: []v1alpha1.InterceptorParams{{
+						Name:  "filter",
+						Value: test.ToV1JSON(t, "body.value == test"),
+					}, {
+						Name: "overlays",
+						Value: test.ToV1JSON(t, []v1alpha1.CELOverlay{{
+							Key:        "value",
+							Expression: "testing",
+						}}),
+					}},
+				}},
+				Bindings: []*v1alpha1.TriggerSpecBinding{{
+					Ref:        "tb",
+					Kind:       v1alpha1.ClusterTriggerBindingKind,
+					APIVersion: "v1alpha1",
+				}},
+				Template: v1alpha1.TriggerSpecTemplate{
+					Ref:        ptr.String("tt"),
+					APIVersion: "v1alpha1",
+				},
+			},
+		},
 	}, {
 		name: "Valid Trigger with no trigger name",
-		tr: bldr.Trigger("name", "namespace",
-			bldr.TriggerSpec(
-				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "", "", "v1alpha1"),
-			)),
-	}, {
-		name: "Valid Trigger with CEL overlays",
-		tr: bldr.Trigger("name", "namespace",
-			bldr.TriggerSpec(
-				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "", "", "v1alpha1"),
-				bldr.TriggerSpecCELInterceptor("", bldr.TriggerSpecCELOverlay("body.value", "'testing'")),
-			)),
+		tr: &v1alpha1.Trigger{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "namespace",
+			},
+			Spec: v1alpha1.TriggerSpec{
+				Template: v1alpha1.TriggerSpecTemplate{
+					Ref:        ptr.String("tt"),
+					APIVersion: "v1alpha1",
+				},
+			},
+		},
 	}, {
 		name: "Trigger with embedded Template",
 		tr: &v1alpha1.Trigger{
@@ -190,7 +234,12 @@ func TestTriggerValidate_error(t *testing.T) {
 		tr   *v1alpha1.Trigger
 	}{{
 		name: "TriggerBinding with no spec",
-		tr:   bldr.Trigger("name", "namespace"),
+		tr: &v1alpha1.Trigger{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+		},
 	}, {
 		name: "Bindings missing ref",
 		tr: &v1alpha1.Trigger{
@@ -276,146 +325,24 @@ func TestTriggerValidate_error(t *testing.T) {
 			},
 		},
 	}, {
-		name: "Interceptor Name only",
-		tr: bldr.Trigger("name", "namespace",
-			bldr.TriggerSpec(
-				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "", "tb", "v1alpha1"),
-				bldr.TriggerSpecInterceptor("svc", "", "", ""),
-			)),
-	}, {
-		name: "Interceptor Missing ObjectRef",
-		tr: &v1alpha1.Trigger{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
-			Spec: v1alpha1.TriggerSpec{
-				Bindings:     []*v1alpha1.TriggerSpecBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb", APIVersion: "v1alpha1"}},
-				Template:     v1alpha1.TriggerSpecTemplate{Ref: ptr.String("tt"), APIVersion: "v1alpha1"},
-				Interceptors: []*v1alpha1.TriggerInterceptor{{}},
-			},
-		},
-	}, {
-		name: "Interceptor Empty ObjectRef",
-		tr: &v1alpha1.Trigger{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
-			Spec: v1alpha1.TriggerSpec{
-				Bindings: []*v1alpha1.TriggerSpecBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb", APIVersion: "v1alpha1"}},
-				Template: v1alpha1.TriggerSpecTemplate{Ref: ptr.String("tt"), APIVersion: "v1alpha1"},
-				Interceptors: []*v1alpha1.TriggerInterceptor{{
-					Webhook: &v1alpha1.WebhookInterceptor{
-						ObjectRef: &corev1.ObjectReference{
-							Name: "",
-						},
-					},
-				}},
-			},
-		},
-	}, {
 		name: "Valid Trigger with invalid TriggerBinding",
-		tr: bldr.Trigger("name", "namespace",
-			bldr.TriggerSpec(
-				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "NamespaceTriggerBinding", "tb", "v1alpha1"),
-			)),
-	}, {
-		name: "Interceptor Wrong APIVersion",
-		tr: bldr.Trigger("name", "namespace",
-			bldr.TriggerSpec(
-				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "", "tb", "v1alpha1"),
-				bldr.TriggerSpecInterceptor("foo", "v3", "Service", ""),
-			)),
-	}, {
-		name: "Interceptor Wrong Kind",
-		tr: bldr.Trigger("name", "namespace",
-			bldr.TriggerSpec(
-				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "", "tb", "v1alpha1"),
-				bldr.TriggerSpecInterceptor("foo", "v1", "Deployment", ""),
-			)),
-	}, {
-		name: "Interceptor Non-Canonical Header",
-		tr: bldr.Trigger("name", "namespace",
-			bldr.TriggerSpec(
-				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "", "tb", "v1alpha1"),
-				bldr.TriggerSpecInterceptor("foo", "v1", "Deployment", "",
-					bldr.TriggerSpecInterceptorParam("non-canonical-header-key", "valid value"),
-				),
-			)),
-	}, {
-		name: "Interceptor Empty Header Name",
-		tr: bldr.Trigger("name", "namespace",
-			bldr.TriggerSpec(
-				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "", "tb", "v1alpha1"),
-				bldr.TriggerSpecInterceptor("foo", "v1", "Deployment", "",
-					bldr.TriggerSpecInterceptorParam("", "valid value"),
-				),
-			)),
-	}, {
-		name: "Interceptor Empty Header Value",
-		tr: bldr.Trigger("name", "namespace",
-			bldr.TriggerSpec(
-				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "", "tb", "v1alpha1"),
-				bldr.TriggerSpecInterceptor("foo", "v1", "Deployment", "",
-					bldr.TriggerSpecInterceptorParam("Valid-Header-Key", ""),
-				),
-			)),
-	}, {
-		name: "Multiple interceptors set",
 		tr: &v1alpha1.Trigger{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "name",
 				Namespace: "namespace",
 			},
 			Spec: v1alpha1.TriggerSpec{
-				Bindings: []*v1alpha1.TriggerSpecBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
-				Template: v1alpha1.TriggerSpecTemplate{Ref: ptr.String("tt")},
-				Interceptors: []*v1alpha1.TriggerInterceptor{{
-					DeprecatedGitHub:    &v1alpha1.GitHubInterceptor{},
-					DeprecatedGitLab:    &v1alpha1.GitLabInterceptor{},
-					DeprecatedBitbucket: &v1alpha1.BitbucketInterceptor{},
+				Bindings: []*v1alpha1.TriggerSpecBinding{{
+					Ref:        "tb",
+					Kind:       "BADBINDINGKIND",
+					APIVersion: "v1alpha1",
 				}},
+				Template: v1alpha1.TriggerSpecTemplate{
+					Ref:        ptr.String("tt"),
+					APIVersion: "v1alpha1",
+				},
 			},
 		},
-	}, {
-		name: "CEL interceptor with no filter or overlays",
-		tr: &v1alpha1.Trigger{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
-			Spec: v1alpha1.TriggerSpec{
-				Bindings: []*v1alpha1.TriggerSpecBinding{{Name: "tb", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "tb"}},
-				Template: v1alpha1.TriggerSpecTemplate{Ref: ptr.String("tt")},
-				Interceptors: []*v1alpha1.TriggerInterceptor{{
-					DeprecatedCEL: &v1alpha1.CELInterceptor{},
-				}},
-			},
-		},
-	}, {
-		name: "CEL interceptor with bad filter expression",
-		tr: bldr.Trigger("name", "namespace",
-			bldr.TriggerSpec(
-				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "", "tb", "v1alpha1"),
-				bldr.TriggerSpecCELInterceptor("body.value == 'test')"),
-			)),
-	}, {
-		name: "CEL interceptor with bad overlay expression",
-		tr: bldr.Trigger("name", "namespace",
-			bldr.TriggerSpec(
-				bldr.TriggerSpecTemplate("tt", "v1alpha1"),
-				bldr.TriggerSpecBinding("tb", "", "tb", "v1alpha1"),
-				bldr.TriggerSpecCELInterceptor("", bldr.TriggerSpecCELOverlay("body.value", "'testing')")),
-			)),
 	}, {
 		name: "Trigger template with both ref and spec",
 		tr: &v1alpha1.Trigger{
@@ -432,7 +359,7 @@ func TestTriggerValidate_error(t *testing.T) {
 			},
 		},
 	}, {
-		name: "Trigger template with both name and spec", // TODO(#FIXME): Remove when name field is removed
+		name: "Trigger template with both name and spec",
 		tr: &v1alpha1.Trigger{
 			ObjectMeta: metav1.ObjectMeta{Name: "name"},
 			Spec: v1alpha1.TriggerSpec{

--- a/pkg/template/resource_test.go
+++ b/pkg/template/resource_test.go
@@ -26,7 +26,6 @@ import (
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	"github.com/tektoncd/triggers/test"
-	bldr "github.com/tektoncd/triggers/test/builder"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/ptr"
 )
@@ -692,19 +691,39 @@ func TestMergeBindingParams(t *testing.T) {
 	}{{
 		name:            "empty bindings",
 		clusterBindings: []*triggersv1.ClusterTriggerBinding{},
-		bindings: []*triggersv1.TriggerBinding{
-			bldr.TriggerBinding("", "", bldr.TriggerBindingSpec()),
-			bldr.TriggerBinding("", "", bldr.TriggerBindingSpec()),
+		bindings: []*triggersv1.TriggerBinding{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "",
+				Namespace: "",
+			},
+			Spec: triggersv1.TriggerBindingSpec{},
+		}, {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "",
+				Namespace: "",
+			},
+			Spec: triggersv1.TriggerBindingSpec{},
+		},
 		},
 		want: []triggersv1.Param{},
 	}, {
 		name:            "single binding with multiple params",
 		clusterBindings: []*triggersv1.ClusterTriggerBinding{},
-		bindings: []*triggersv1.TriggerBinding{
-			bldr.TriggerBinding("", "", bldr.TriggerBindingSpec(
-				bldr.TriggerBindingParam("param1", "value1"),
-				bldr.TriggerBindingParam("param2", "value2"),
-			)),
+		bindings: []*triggersv1.TriggerBinding{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "",
+				Namespace: "",
+			},
+			Spec: triggersv1.TriggerBindingSpec{
+				Params: []triggersv1.Param{{
+					Name:  "param1",
+					Value: "value1",
+				}, {
+					Name:  "param2",
+					Value: "value2",
+				}},
+			},
+		},
 		},
 		want: []triggersv1.Param{{
 			Name:  "param1",
@@ -715,12 +734,20 @@ func TestMergeBindingParams(t *testing.T) {
 		}},
 	}, {
 		name: "single cluster type binding with multiple params",
-		clusterBindings: []*triggersv1.ClusterTriggerBinding{
-			bldr.ClusterTriggerBinding("", bldr.ClusterTriggerBindingSpec(
-				bldr.TriggerBindingParam("param1", "value1"),
-				bldr.TriggerBindingParam("param2", "value2"),
-			)),
-		},
+		clusterBindings: []*triggersv1.ClusterTriggerBinding{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ctb",
+			},
+			Spec: triggersv1.TriggerBindingSpec{
+				Params: []triggersv1.Param{{
+					Name:  "param1",
+					Value: "value1",
+				}, {
+					Name:  "param2",
+					Value: "value2",
+				}},
+			},
+		}},
 		bindings: []*triggersv1.TriggerBinding{},
 		want: []triggersv1.Param{{
 			Name:  "param1",
@@ -731,22 +758,49 @@ func TestMergeBindingParams(t *testing.T) {
 		}},
 	}, {
 		name: "multiple bindings each with multiple params",
-		clusterBindings: []*triggersv1.ClusterTriggerBinding{
-			bldr.ClusterTriggerBinding("", bldr.ClusterTriggerBindingSpec(
-				bldr.TriggerBindingParam("param5", "value1"),
-				bldr.TriggerBindingParam("param6", "value2"),
-			)),
-		},
-		bindings: []*triggersv1.TriggerBinding{
-			bldr.TriggerBinding("", "", bldr.TriggerBindingSpec(
-				bldr.TriggerBindingParam("param1", "value1"),
-				bldr.TriggerBindingParam("param2", "value2"),
-			)),
-			bldr.TriggerBinding("", "", bldr.TriggerBindingSpec(
-				bldr.TriggerBindingParam("param3", "value3"),
-				bldr.TriggerBindingParam("param4", "value4"),
-			)),
-		},
+		clusterBindings: []*triggersv1.ClusterTriggerBinding{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ctb",
+			},
+			Spec: triggersv1.TriggerBindingSpec{
+				Params: []triggersv1.Param{{
+					Name:  "param5",
+					Value: "value1",
+				}, {
+					Name:  "param6",
+					Value: "value2",
+				}},
+			},
+		}},
+		bindings: []*triggersv1.TriggerBinding{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tb",
+				Namespace: "ns",
+			},
+			Spec: triggersv1.TriggerBindingSpec{
+				Params: []triggersv1.Param{{
+					Name:  "param1",
+					Value: "value1",
+				}, {
+					Name:  "param2",
+					Value: "value2",
+				}},
+			},
+		}, {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "",
+				Namespace: "",
+			},
+			Spec: triggersv1.TriggerBindingSpec{
+				Params: []triggersv1.Param{{
+					Name:  "param3",
+					Value: "value3",
+				}, {
+					Name:  "param4",
+					Value: "value4",
+				}},
+			},
+		}},
 		want: []triggersv1.Param{{
 			Name:  "param1",
 			Value: "value1",
@@ -769,24 +823,52 @@ func TestMergeBindingParams(t *testing.T) {
 	}, {
 		name:            "multiple bindings with duplicate params",
 		clusterBindings: []*triggersv1.ClusterTriggerBinding{},
-		bindings: []*triggersv1.TriggerBinding{
-			bldr.TriggerBinding("", "", bldr.TriggerBindingSpec(
-				bldr.TriggerBindingParam("param1", "value1"),
-			)),
-			bldr.TriggerBinding("", "", bldr.TriggerBindingSpec(
-				bldr.TriggerBindingParam("param1", "value3"),
-				bldr.TriggerBindingParam("param4", "value4"),
-			)),
+		bindings: []*triggersv1.TriggerBinding{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tb",
+				Namespace: "ns",
+			},
+			Spec: triggersv1.TriggerBindingSpec{
+				Params: []triggersv1.Param{{
+					Name:  "param1",
+					Value: "value1",
+				}},
+			},
+		}, {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tb",
+				Namespace: "ns",
+			},
+			Spec: triggersv1.TriggerBindingSpec{
+				Params: []triggersv1.Param{{
+					Name:  "param1",
+					Value: "value1",
+				}, {
+					Name:  "param4",
+					Value: "value4",
+				}},
+			},
+		},
 		},
 		wantErr: true,
 	}, {
 		name:            "single binding with duplicate params",
 		clusterBindings: []*triggersv1.ClusterTriggerBinding{},
-		bindings: []*triggersv1.TriggerBinding{
-			bldr.TriggerBinding("", "", bldr.TriggerBindingSpec(
-				bldr.TriggerBindingParam("param1", "value1"),
-				bldr.TriggerBindingParam("param1", "value3"),
-			)),
+		bindings: []*triggersv1.TriggerBinding{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tb",
+				Namespace: "ns",
+			},
+			Spec: triggersv1.TriggerBindingSpec{
+				Params: []triggersv1.Param{{
+					Name:  "param1",
+					Value: "value1",
+				}, {
+					Name:  "param1",
+					Value: "value3",
+				}},
+			},
+		},
 		},
 		wantErr: true,
 	}}


### PR DESCRIPTION
# Changes

This is helpful as we migrate to the v1beta1 types since we won't have
to maintain separate test builders for v1beta1 types.

Ref #1067, #735


/kind cleanup
/release-note-none

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
