### PR TITLE
Add a Ready StatusCondition for EventListener

### DIFF
--- a/pkg/apis/triggers/v1alpha1/event_listener_types_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_types_test.go
@@ -284,6 +284,20 @@ func TestSetConditionsForDynamicObjects(t *testing.T) {
 		Reason:  "Reason",
 		Message: "Message",
 	}})
+	expected := EventListenerStatus{
+		Status: duckv1.Status{
+			Conditions: []apis.Condition{{
+				Type:    apis.ConditionReady,
+				Status:  corev1.ConditionTrue,
+				Reason:  "Reason",
+				Message: "Message",
+			}},
+		},
+	}
+	if diff := cmp.Diff(expected, status, cmpopts.IgnoreTypes(
+		apis.Condition{}.LastTransitionTime.Inner.Time)); diff != "" {
+		t.Fatalf("SetConditionsForDynamicObjects() error. Diff (-want/+got) : %s", diff)
+	}
 }
 
 func TestEventListenerStatus_SetReadyCondition(t *testing.T) {

--- a/pkg/apis/triggers/v1alpha1/event_listener_types_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_types_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -101,6 +102,7 @@ func TestInitializeConditions(t *testing.T) {
 	var conditionTypes = []apis.ConditionType{
 		ServiceExists,
 		DeploymentExists,
+		apis.ConditionReady,
 	}
 	els := &EventListenerStatus{}
 	els.InitializeConditions()
@@ -282,4 +284,118 @@ func TestSetConditionsForDynamicObjects(t *testing.T) {
 		Reason:  "Reason",
 		Message: "Message",
 	}})
+}
+
+func TestEventListenerStatus_SetReadyCondition(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		initial *EventListenerStatus
+		want    *EventListenerStatus
+	}{{
+		name: "set Ready to true when all dependent conditions are true",
+		initial: &EventListenerStatus{
+			Status: duckv1.Status{
+				Conditions: []apis.Condition{{
+					Type:    DeploymentExists,
+					Status:  corev1.ConditionTrue,
+					Message: "Deployment Exists",
+				}, {
+					Type:    ServiceExists,
+					Status:  corev1.ConditionTrue,
+					Message: "Service Exists",
+				}, {
+					Type:    apis.ConditionType(appsv1.DeploymentProgressing),
+					Status:  corev1.ConditionTrue,
+					Message: `ReplicaSet "el-example-655bf689f" has successfully progressed.`,
+				}, {
+					Type:    apis.ConditionType(appsv1.DeploymentAvailable),
+					Status:  corev1.ConditionTrue,
+					Message: "Deployment has minimum availability.",
+				}},
+			},
+		},
+		want: &EventListenerStatus{
+			Status: duckv1.Status{
+				Conditions: []apis.Condition{{
+					Type:    DeploymentExists,
+					Status:  corev1.ConditionTrue,
+					Message: "Deployment Exists",
+				}, {
+					Type:    ServiceExists,
+					Status:  corev1.ConditionTrue,
+					Message: "Service Exists",
+				}, {
+					Type:    apis.ConditionType(appsv1.DeploymentProgressing),
+					Status:  corev1.ConditionTrue,
+					Message: `ReplicaSet "el-example-655bf689f" has successfully progressed.`,
+				}, {
+					Type:    apis.ConditionType(appsv1.DeploymentAvailable),
+					Status:  corev1.ConditionTrue,
+					Message: "Deployment has minimum availability.",
+				}, {
+					Type:    apis.ConditionReady,
+					Status:  corev1.ConditionTrue,
+					Message: "EventListener is ready",
+				}},
+			},
+		},
+	}, {
+		name: "set Ready to false when at least one dependent condition is false",
+		initial: &EventListenerStatus{
+			Status: duckv1.Status{
+				Conditions: []apis.Condition{{
+					Type:    DeploymentExists,
+					Status:  corev1.ConditionTrue,
+					Message: "Deployment Exists",
+				}, {
+					Type:    ServiceExists,
+					Status:  corev1.ConditionFalse,
+					Message: "Service does not exist",
+				}, {
+					Type:    apis.ConditionType(appsv1.DeploymentProgressing),
+					Status:  corev1.ConditionTrue,
+					Message: `ReplicaSet "el-example-655bf689f" has successfully progressed.`,
+				}, {
+					Type:    apis.ConditionType(appsv1.DeploymentAvailable),
+					Status:  corev1.ConditionTrue,
+					Message: "Deployment has minimum availability.",
+				}},
+			},
+		},
+		want: &EventListenerStatus{
+			Status: duckv1.Status{
+				Conditions: []apis.Condition{{
+					Type:    DeploymentExists,
+					Status:  corev1.ConditionTrue,
+					Message: "Deployment Exists",
+				}, {
+					Type:    ServiceExists,
+					Status:  corev1.ConditionFalse,
+					Message: "Service does not exist",
+				}, {
+					Type:    apis.ConditionType(appsv1.DeploymentProgressing),
+					Status:  corev1.ConditionTrue,
+					Message: `ReplicaSet "el-example-655bf689f" has successfully progressed.`,
+				}, {
+					Type:    apis.ConditionType(appsv1.DeploymentAvailable),
+					Status:  corev1.ConditionTrue,
+					Message: "Deployment has minimum availability.",
+				}, {
+					Type:    apis.ConditionReady,
+					Status:  corev1.ConditionFalse,
+					Message: "Condition Service has status: False with message: Service does not exist",
+				}},
+			},
+		},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.initial.SetReadyCondition()
+			if diff := cmp.Diff(tc.want, tc.initial, cmpopts.IgnoreTypes(
+				apis.Condition{}.LastTransitionTime.Inner.Time), cmpopts.SortSlices(func(x, y apis.Condition) bool {
+				return x.Type < y.Type
+			})); diff != "" {
+				t.Fatalf("SetReadyCondition() mismatch. -want/+got: %s", diff)
+			}
+		})
+	}
 }

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
@@ -124,7 +124,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, el *v1alpha1.EventListen
 	}
 	deploymentReconcileError := r.reconcileDeployment(ctx, logger, el)
 	serviceReconcileError := r.reconcileService(ctx, logger, el)
-
+	if el.Spec.Resources.CustomResource == nil {
+		el.Status.SetReadyCondition()
+	}
 	return wrapError(serviceReconcileError, deploymentReconcileError)
 }
 

--- a/test/e2e-tests-ingress.sh
+++ b/test/e2e-tests-ingress.sh
@@ -64,20 +64,6 @@ function wait_until_pod_started() {
   exit 1
 }
 
-# Parameters: $1 - EventListener name
-function get_eventlistener_service() {
-  echo "Getting ServiceName for EventListener $1"
-  for i in {1..150}; do  # timeout after 5 minutes
-    SERVICE_NAME=$(kubectl get eventlistener $1 -o=jsonpath='{.status.configuration.generatedName}')
-    if [[ -z "$SERVICE_NAME" ]]
-    then
-      sleep 2
-    else
-      break
-    fi
-  done
-}
-
 # Parameters: $1 - Service name
 function get_service_uid() {
   echo "Getting UID for Service $1"
@@ -134,7 +120,7 @@ DONE
 INGRESS_TASKRUN_NAME="create-ingress-taskrun"
 CERTIFICATE_KEY_PASSPHRASE="pass1"
 CERTIFICATE_SECRET_NAME="secret1"
-get_eventlistener_service ${EVENTLISTENER_NAME}
+SERVICE_NAME="el-${EVENTLISTENER_NAME}"
 get_service_uid ${SERVICE_NAME}
 EXTERNAL_DOMAIN="${SERVICE_NAME}.192.168.0.1.nip.io"
 


### PR DESCRIPTION
# Changes

The Ready Status is true when the other 4 status conditions - (Service,
Deployment, Progessing, and Available) are all true. The idea is that in the
future, Ready would be the one Condition users could  use to see if an
EventListener is ready to serve traffic or not.


Fixes #932

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
The EventListener Status now has a new Condition called Ready. Ready is set to True when the other status conditions are also true (i.e. the EventListener is ready to serve traffic). It is false if any of the other statuses are false.

DEPRECATION NOTICE: In the future, we plan to deprecate the other status conditions in favor of the Ready status condition.
```
