### PR TITLE
Skip *heavy* validation on deletion 🙃

### DIFF
--- a/pkg/apis/triggers/v1alpha1/cluster_interceptor_validation.go
+++ b/pkg/apis/triggers/v1alpha1/cluster_interceptor_validation.go
@@ -24,6 +24,9 @@ import (
 
 // Validate ClusterInterceptor
 func (it *ClusterInterceptor) Validate(ctx context.Context) *apis.FieldError {
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return it.Spec.validate(ctx)
 }
 

--- a/pkg/apis/triggers/v1alpha1/cluster_interceptor_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/cluster_interceptor_validation_test.go
@@ -11,6 +11,27 @@ import (
 	"knative.dev/pkg/apis"
 )
 
+func TestClusterInterceptorValidate_OnDelete(t *testing.T) {
+	ci := triggersv1.ClusterInterceptor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "github",
+		},
+		Spec: triggersv1.ClusterInterceptorSpec{
+			ClientConfig: triggersv1.ClientConfig{
+				Service: &triggersv1.ServiceReference{
+					Namespace: "",
+					Name:      "github-svc",
+				},
+			},
+		},
+	}
+
+	err := ci.Validate(apis.WithinDelete(context.Background()))
+	if err != nil {
+		t.Errorf("ClusterInterceptor.Validate() on Delete expected no error, but got one, ClusterInterceptor: %v, error: %v", ci, err)
+	}
+}
+
 func TestClusterInterceptorValidate(t *testing.T) {
 	tests := []struct {
 		name               string

--- a/pkg/apis/triggers/v1alpha1/cluster_trigger_binding_validation.go
+++ b/pkg/apis/triggers/v1alpha1/cluster_trigger_binding_validation.go
@@ -27,5 +27,8 @@ func (ctb *ClusterTriggerBinding) Validate(ctx context.Context) *apis.FieldError
 	if err := validate.ObjectMetadata(ctb.GetObjectMeta()); err != nil {
 		return err.ViaField("metadata")
 	}
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return ctb.Spec.Validate(ctx)
 }

--- a/pkg/apis/triggers/v1alpha1/cluster_trigger_binding_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/cluster_trigger_binding_validation_test.go
@@ -22,7 +22,29 @@ import (
 
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 )
+
+func Test_ClusterTriggerBindingValidate_OnDelete(t *testing.T) {
+	tb := &v1alpha1.ClusterTriggerBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "name",
+		},
+		Spec: v1alpha1.TriggerBindingSpec{
+			Params: []v1alpha1.Param{{
+				Name:  "param1",
+				Value: "$(body.input1)",
+			}, {
+				Name:  "param2",
+				Value: "$(body.input2)",
+			}},
+		},
+	}
+	err := tb.Validate(apis.WithinDelete(context.Background()))
+	if err != nil {
+		t.Errorf("TriggerBinding.Validate() on Delete expected no error, but got one, TriggerBinding: %v, error: %v", tb, err)
+	}
+}
 
 func Test_ClusterTriggerBindingValidate(t *testing.T) {
 	tests := []struct {

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation.go
@@ -38,17 +38,15 @@ var (
 
 // Validate EventListener.
 func (e *EventListener) Validate(ctx context.Context) *apis.FieldError {
-	errs := e.validate(ctx)
-	errs = errs.Also(e.Spec.validate(ctx))
-	return errs
-}
-
-func (e *EventListener) validate(ctx context.Context) (errs *apis.FieldError) {
+	var errs *apis.FieldError
 	if len(e.ObjectMeta.Name) > 60 {
 		// Since `el-` is added as the prefix of EventListener services, the name of EventListener must be no more than 60 characters long.
 		errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("eventListener name '%s' must be no more than 60 characters long", e.ObjectMeta.Name), "metadata.name"))
 	}
-	return errs
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
+	return errs.Also(e.Spec.validate(ctx))
 }
 
 func (s *EventListenerSpec) validate(ctx context.Context) (errs *apis.FieldError) {

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
@@ -28,9 +28,30 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/ptr"
 )
+
+func Test_EventListenerValidate_OnDelete(t *testing.T) {
+	el := &v1alpha1.EventListener{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "namespace",
+		},
+		Spec: v1alpha1.EventListenerSpec{
+			Triggers: []v1alpha1.EventListenerTrigger{{
+				Template: &v1alpha1.EventListenerTemplate{
+					Ref: ptr.String(""),
+				},
+			}},
+		},
+	}
+	err := el.Validate(apis.WithinDelete(context.Background()))
+	if err != nil {
+		t.Errorf("EventListener.Validate() on Delete expected no error, but got one, EventListener: %v, error: %v", el, err)
+	}
+}
 
 func Test_EventListenerValidate(t *testing.T) {
 	tests := []struct {

--- a/pkg/apis/triggers/v1alpha1/trigger_binding_validation.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_binding_validation.go
@@ -27,6 +27,9 @@ import (
 
 // Validate TriggerBinding.
 func (tb *TriggerBinding) Validate(ctx context.Context) *apis.FieldError {
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return tb.Spec.Validate(ctx).ViaField("spec")
 }
 

--- a/pkg/apis/triggers/v1alpha1/trigger_binding_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_binding_validation_test.go
@@ -23,7 +23,30 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 )
+
+func Test_TriggerBindingValidate_OnDelete(t *testing.T) {
+	tb := &v1alpha1.TriggerBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "namespace",
+		},
+		Spec: v1alpha1.TriggerBindingSpec{
+			Params: []v1alpha1.Param{{
+				Name:  "param1",
+				Value: "$(body.input1)",
+			}, {
+				Name:  "param1",
+				Value: "$(body.input2)",
+			}},
+		},
+	}
+	err := tb.Validate(apis.WithinDelete(context.Background()))
+	if err != nil {
+		t.Errorf("TriggerBinding.Validate() on Delete expected no error, but got one, TriggerBinding: %v, error: %v", tb, err)
+	}
+}
 
 func Test_TriggerBindingValidate(t *testing.T) {
 	tests := []struct {

--- a/pkg/apis/triggers/v1alpha1/trigger_template_validation.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_template_validation.go
@@ -36,6 +36,9 @@ var paramsRegexp = regexp.MustCompile(`\$\(tt.params.(?P<var>[_a-zA-Z][_a-zA-Z0-
 // Validate validates a TriggerTemplate.
 func (t *TriggerTemplate) Validate(ctx context.Context) *apis.FieldError {
 	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return errs.Also(t.Spec.validate(ctx).ViaField("spec"))
 }
 

--- a/pkg/apis/triggers/v1alpha1/trigger_template_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_template_validation_test.go
@@ -89,6 +89,26 @@ func invalidParamResourceTemplate(t *testing.T) runtime.RawExtension {
 	})
 }
 
+func TestTriggerTemplate_Validate_OnDelete(t *testing.T) {
+	tt := &v1alpha1.TriggerTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tt",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.TriggerTemplateSpec{
+			Params: []v1alpha1.ParamSpec{{
+				Name:        "foo",
+				Description: "desc",
+				Default:     ptr.String("val"),
+			}},
+		},
+	}
+	err := tt.Validate(apis.WithinDelete(context.Background()))
+	if err != nil {
+		t.Errorf("TriggerTemplate.Validate() on Delete expected no error, but got one, TriggerTemplate: %v, error: %v", tt, err)
+	}
+}
+
 func TestTriggerTemplate_Validate(t *testing.T) {
 	tcs := []struct {
 		name     string

--- a/pkg/apis/triggers/v1alpha1/trigger_validation.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_validation.go
@@ -30,6 +30,9 @@ import (
 // Validate validates a Trigger
 func (t *Trigger) Validate(ctx context.Context) *apis.FieldError {
 	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return errs.Also(t.Spec.validate(ctx).ViaField("spec"))
 }
 

--- a/pkg/apis/triggers/v1alpha1/trigger_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_validation_test.go
@@ -24,8 +24,27 @@ import (
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	"github.com/tektoncd/triggers/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
 )
+
+func Test_TriggerValidate_OnDelete(t *testing.T) {
+	tr := &v1alpha1.Trigger{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "namespace",
+		},
+		Spec: v1alpha1.TriggerSpec{
+			// Binding with no spec is invalid, but shouldn't block the delete
+			Bindings: []*v1alpha1.TriggerSpecBinding{{Name: "", Kind: v1alpha1.NamespacedTriggerBindingKind, Ref: "", APIVersion: "v1alpha1"}},
+			Template: v1alpha1.TriggerSpecTemplate{Ref: ptr.String("tt")},
+		},
+	}
+	err := tr.Validate(apis.WithinDelete(context.Background()))
+	if err != nil {
+		t.Errorf("Trigger.Validate() on Delete expected no error, but got one, Trigger: %v, error: %v", tr, err)
+	}
+}
 
 func Test_TriggerValidate(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION

# Changes

When deleting an object, we don't need to pursue all the validation
that we do at creation. It reduces the work to be done as part of the
validation *and* allows invalid version of the resource (from previous
versions for example) to be deleted safely.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

The main reasoning for this change is to not face issues to reduce the situation where an upgrade makes object not deletable (because of *newly* invalid field). The example that happen upgrading from 0.10.x to 0.12.x make `EventListener` not deletable at all.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Skip *heavy* validation on deletion in the webhook
```
