### PR TITLE
Fix metrics port expose issue for triggers eventlistener

### DIFF
--- a/config/controller-service.yaml
+++ b/config/controller-service.yaml
@@ -29,9 +29,9 @@ metadata:
 spec:
   ports:
   - name: http-metrics
-    port: 9090
+    port: 9000
     protocol: TCP
-    targetPort: 9090
+    targetPort: 9000
   selector:
     app.kubernetes.io/name: controller
     app.kubernetes.io/component: controller

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -75,6 +75,8 @@ spec:
           value: config-observability-triggers
         - name: METRICS_DOMAIN
           value: tekton.dev/triggers
+        - name: METRICS_PROMETHEUS_PORT
+          value: "9000"
         securityContext:
           allowPrivilegeEscalation: false
           # User 65532 is the distroless nonroot user ID

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -69,7 +69,7 @@ spec:
           value: tekton.dev/triggers
         ports:
         - name: metrics
-          containerPort: 9090
+          containerPort: 9000
         - name: profiling
           containerPort: 8008
         - name: https-webhook

--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -425,7 +425,7 @@ kubectl get pods --selector eventlistener=my-eventlistener
 
 ## Configuring metrics for `EventListeners`
 
-The following pipeline metrics are available on the `eventlistener` Service on port `9090`.
+The following pipeline metrics are available on the `eventlistener` Service on port `9000`.
 
 |  Name | Type | Labels/Tags | Status |
 | ---------- | ----------- | ----------- | ----------- |

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,7 +27,7 @@ NAME                          TYPE           CLUSTER-IP       EXTERNAL-IP   PORT
 el-listener                   ClusterIP      10.100.151.220   <none>        8080/TCP         48s  <--- this will receive the event
 tekton-pipelines-controller   ClusterIP      10.103.144.96    <none>        9090/TCP         8m34s
 tekton-pipelines-webhook      ClusterIP      10.96.198.4      <none>        443/TCP          8m34s
-tekton-triggers-controller    ClusterIP      10.102.221.96    <none>        9090/TCP         7m56s
+tekton-triggers-controller    ClusterIP      10.102.221.96    <none>        9000/TCP         7m56s
 tekton-triggers-webhook       ClusterIP      10.99.59.231     <none>        443/TCP          7m56s
 ```
 

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -65,8 +66,6 @@ const (
 	eventListenerServiceTLSPortName = "https-listener"
 	// eventListenerContainerPort defines the port exposed by the EventListener Container
 	eventListenerContainerPort = 8000
-	// eventListenerMetricsPort defines the port exposed by the EventListener metrics endpoint
-	eventListenerMetricsPort = 9090
 	// GeneratedResourcePrefix is the name prefix for resources generated in the
 	// EventListener reconciler
 	GeneratedResourcePrefix = "el"
@@ -274,7 +273,18 @@ func (r *Reconciler) reconcileDeployment(ctx context.Context, logger *zap.Sugare
 		return err
 	}
 
+	// METRICS_PROMETHEUS_PORT defines the port exposed by the EventListener metrics endpoint
+	// env METRICS_PROMETHEUS_PORT set by controller
+	metricsPort, err := strconv.ParseInt(os.Getenv("METRICS_PROMETHEUS_PORT"), 10, 64)
+	if err != nil {
+		logger.Error(err)
+		return err
+	}
 	container := getContainer(el, r.config, nil)
+	container.Ports = append(container.Ports, corev1.ContainerPort{
+		ContainerPort: int32(metricsPort),
+		Protocol:      corev1.ProtocolTCP,
+	})
 	container.VolumeMounts = []corev1.VolumeMount{{
 		Name:      "config-logging",
 		MountPath: "/etc/config-logging",
@@ -294,9 +304,15 @@ func (r *Reconciler) reconcileDeployment(ctx context.Context, logger *zap.Sugare
 		Name:  "METRICS_DOMAIN",
 		Value: triggersMetricsDomain,
 	})
+	// METRICS_PROMETHEUS_PORT defines the port exposed by the EventListener metrics endpoint
+	// env METRICS_PROMETHEUS_PORT set by controller
+	container.Env = append(container.Env, corev1.EnvVar{
+		Name:  "METRICS_PROMETHEUS_PORT",
+		Value: os.Getenv("METRICS_PROMETHEUS_PORT"),
+	})
 	container = addCertsForSecureConnection(container, r.config)
 
-	deployment := getDeployment(el, r.config)
+	deployment := getDeployment(el, container, r.config)
 
 	existingDeployment, err := r.deploymentLister.Deployments(el.Namespace).Get(el.Status.Configuration.GeneratedResourceName)
 	switch {
@@ -459,6 +475,12 @@ func (r *Reconciler) reconcileCustomObject(ctx context.Context, logger *zap.Suga
 	container.Env = append(container.Env, corev1.EnvVar{
 		Name:  "METRICS_DOMAIN",
 		Value: triggersMetricsDomain,
+	})
+	// METRICS_PROMETHEUS_PORT defines the port exposed by the EventListener metrics endpoint
+	// env METRICS_PROMETHEUS_PORT set by controller
+	container.Env = append(container.Env, corev1.EnvVar{
+		Name:  "METRICS_PROMETHEUS_PORT",
+		Value: os.Getenv("METRICS_PROMETHEUS_PORT"),
 	})
 
 	podlabels := mergeMaps(el.Labels, GenerateResourceLabels(el.Name, r.config.StaticResourceLabels))
@@ -659,7 +681,7 @@ func (r *Reconciler) reconcileCustomObject(ctx context.Context, logger *zap.Suga
 	return nil
 }
 
-func getDeployment(el *v1alpha1.EventListener, c Config) *appsv1.Deployment {
+func getDeployment(el *v1alpha1.EventListener, container corev1.Container, c Config) *appsv1.Deployment {
 	var (
 		tolerations                          []corev1.Toleration
 		nodeSelector, annotations, podlabels map[string]string
@@ -681,28 +703,6 @@ func getDeployment(el *v1alpha1.EventListener, c Config) *appsv1.Deployment {
 		},
 	}}
 
-	container := getContainer(el, c, nil)
-	container.VolumeMounts = []corev1.VolumeMount{{
-		Name:      "config-logging",
-		MountPath: "/etc/config-logging",
-	}}
-	container.Env = append(container.Env, corev1.EnvVar{
-		Name: "SYSTEM_NAMESPACE",
-		ValueFrom: &corev1.EnvVarSource{
-			FieldRef: &corev1.ObjectFieldSelector{
-				FieldPath: "metadata.namespace",
-			}},
-	})
-	container.Env = append(container.Env, corev1.EnvVar{
-		Name:  "CONFIG_OBSERVABILITY_NAME",
-		Value: metrics.ConfigMapName(),
-	})
-	container.Env = append(container.Env, corev1.EnvVar{
-		Name:  "METRICS_DOMAIN",
-		Value: triggersMetricsDomain,
-	})
-
-	container = addCertsForSecureConnection(container, c)
 	for _, v := range container.Env {
 		// If TLS related env are set then mount secret volume which will be used while starting the eventlistener.
 		if v.Name == "TLS_CERT" {
@@ -849,9 +849,6 @@ func getContainer(el *v1alpha1.EventListener, c Config, pod *duckv1.WithPod) cor
 		Image: *c.Image,
 		Ports: []corev1.ContainerPort{{
 			ContainerPort: int32(eventListenerContainerPort),
-			Protocol:      corev1.ProtocolTCP,
-		}, {
-			ContainerPort: int32(eventListenerMetricsPort),
 			Protocol:      corev1.ProtocolTCP,
 		}},
 		Resources: resources,

--- a/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/v1alpha1/eventlistener/eventlistener_test.go
@@ -206,7 +206,7 @@ func makeDeployment(ops ...func(d *appsv1.Deployment)) *appsv1.Deployment {
 							ContainerPort: int32(eventListenerContainerPort),
 							Protocol:      corev1.ProtocolTCP,
 						}, {
-							ContainerPort: int32(eventListenerMetricsPort),
+							ContainerPort: int32(9000),
 							Protocol:      corev1.ProtocolTCP,
 						}},
 						LivenessProbe: &corev1.Probe{
@@ -257,6 +257,9 @@ func makeDeployment(ops ...func(d *appsv1.Deployment)) *appsv1.Deployment {
 						}, {
 							Name:  "METRICS_DOMAIN",
 							Value: "tekton.dev/triggers",
+						}, {
+							Name:  "METRICS_PROMETHEUS_PORT",
+							Value: "9000",
 						}},
 					}},
 					Volumes: []corev1.Volume{{
@@ -298,7 +301,7 @@ var withTLSConfig = func(d *appsv1.Deployment) {
 			ContainerPort: int32(eventListenerContainerPort),
 			Protocol:      corev1.ProtocolTCP,
 		}, {
-			ContainerPort: int32(eventListenerMetricsPort),
+			ContainerPort: int32(9000),
 			Protocol:      corev1.ProtocolTCP,
 		}},
 		LivenessProbe: &corev1.Probe{
@@ -371,6 +374,9 @@ var withTLSConfig = func(d *appsv1.Deployment) {
 		}, {
 			Name:  "METRICS_DOMAIN",
 			Value: "tekton.dev/triggers",
+		}, {
+			Name:  "METRICS_PROMETHEUS_PORT",
+			Value: "9000",
 		}},
 	}}
 	d.Spec.Template.Spec.Volumes = []corev1.Volume{{
@@ -419,9 +425,6 @@ func makeWithPod(ops ...func(d *duckv1.WithPod)) *duckv1.WithPod {
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: int32(eventListenerContainerPort),
 							Protocol:      corev1.ProtocolTCP,
-						}, {
-							ContainerPort: int32(eventListenerMetricsPort),
-							Protocol:      corev1.ProtocolTCP,
 						}},
 						Args: []string{
 							"--el-name=" + eventListenerName,
@@ -447,6 +450,9 @@ func makeWithPod(ops ...func(d *duckv1.WithPod)) *duckv1.WithPod {
 						}, {
 							Name:  "METRICS_DOMAIN",
 							Value: "tekton.dev/triggers",
+						}, {
+							Name:  "METRICS_PROMETHEUS_PORT",
+							Value: "9000",
 						}},
 					}},
 					Volumes: []corev1.Volume{{
@@ -577,7 +583,11 @@ func withDeletionTimestamp(el *v1alpha1.EventListener) {
 }
 
 func TestReconcile(t *testing.T) {
-	err := os.Setenv("SYSTEM_NAMESPACE", "tekton-pipelines")
+	err := os.Setenv("METRICS_PROMETHEUS_PORT", "9000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.Setenv("SYSTEM_NAMESPACE", "tekton-pipelines")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -932,6 +942,9 @@ func TestReconcile(t *testing.T) {
 		}, {
 			Name:  "METRICS_DOMAIN",
 			Value: "tekton.dev/triggers",
+		}, {
+			Name:  "METRICS_PROMETHEUS_PORT",
+			Value: "9000",
 		}}
 	})
 


### PR DESCRIPTION
# Changes

Metrics related changes introduced as part of https://github.com/tektoncd/triggers/pull/1061 and because of those changes we are facing below issues when we create Knative Service using customeResources

1. when we apply [custom-resource](https://github.com/tektoncd/triggers/tree/main/examples/custom-resource) example  EL fail with below error
```
Warning  InternalError    15s (x14 over 56s)  EventListener  admission webhook "validation.webhook.serving.knative.dev" denied the request: validation failed: More than one container port is set: spec.template.spec.containers[0].ports
Only a single port is allowed
```
2. Knative Serving adds `queue-proxy` container along with EL container and Knative itself handles metrics on `9090` port for queue-proxy and because of that we face already bind error
```
{"severity":"ERROR","timestamp":"2021-05-11T09:28:00.588588485Z","logger":"queueproxy","caller":"queue/main.go:228","message":"Failed to bring up queue-proxy, shutting down.","commit":"813aa65","knative.dev/key":"dtest/el-github-knative-listener-00001","knative.dev/pod":"el-github-knative-listener-00001-deployment-fc8fb5cbc-xbqqv","error":"metrics server failed to listen: listen tcp :9090: bind: address already in use","stacktrace":"main.main\n\tknative.dev/serving/cmd/queue/main.go:228\nruntime.main\n\truntime/proc.go:204"}
```

The PR solves above issues and exposes metrics on `9000` port

Fixes https://github.com/tektoncd/triggers/issues/1090

/cc @jmcshane @dibyom 
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
Triggers exposes metrics on 9000 port 
```