### PR TITLE
Add EventListener UID to sink response, mark name/namespace as deprecated.

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -375,12 +375,24 @@ Otherwise, it responds with a `202 ACCEPTED` HTTP response.
 
 After detecting an event, the `EventListener` responds with the following message:
 
-```JSON
-{"eventListener":"listener","namespace":"default","eventID":"h2bb7"}
+```json
+{
+  "eventListener": "listener",
+  "namespace": "default",
+  "eventListenerUID": "ea71a6e4-9531-43a1-94fe-6136515d938c",
+  "eventID": "14a657c3-6816-45bf-b214-4afdaefc4ebd"
+}
 ```
-- `eventListener` - name of the target EventListener
-- `namespace` - namespace of the target EventListener
+
+- `eventListenerUID` - [UID](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids) of the target EventListener.
 - `eventID` - UID assigned to this event request
+
+### Deprecated Fields
+
+These fields are included in `EventListener` responses, but will be removed in a future release.
+
+- `eventListener` - name of the target EventListener. Use `eventListenerUID` instead.
+- `namespace` - namespace of the target EventListener. Use `eventListenerUID` instead.
 
 ## TLS HTTPS support in `EventListeners`
 

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -70,6 +71,7 @@ import (
 const (
 	eventID   = "12345"
 	namespace = "foo"
+	elUID     = "el-uid"
 )
 
 func init() {
@@ -221,9 +223,10 @@ func checkSinkResponse(t *testing.T, resp *http.Response, elName string) {
 		t.Fatalf("Error reading response body: %s", err)
 	}
 	wantBody := Response{
-		EventListener: elName,
-		Namespace:     namespace,
-		EventID:       eventID,
+		EventListener:    elName,
+		EventListenerUID: elUID,
+		Namespace:        namespace,
+		EventID:          eventID,
 	}
 	if diff := cmp.Diff(wantBody, gotBody); diff != "" {
 		t.Errorf("did not get expected response back -want,+got: %s", diff)
@@ -389,6 +392,7 @@ func TestHandleEvent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      eventListenerName,
 					Namespace: namespace,
+					UID:       types.UID(elUID),
 				},
 				Spec: triggersv1.EventListenerSpec{
 					Triggers: []triggersv1.EventListenerTrigger{{
@@ -452,6 +456,7 @@ func TestHandleEvent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      eventListenerName,
 					Namespace: namespace,
+					UID:       types.UID(elUID),
 				},
 				Spec: triggersv1.EventListenerSpec{
 					NamespaceSelector: triggersv1.NamespaceSelector{
@@ -521,6 +526,7 @@ func TestHandleEvent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      eventListenerName,
 					Namespace: namespace,
+					UID:       types.UID(elUID),
 				},
 				Spec: triggersv1.EventListenerSpec{
 					NamespaceSelector: triggersv1.NamespaceSelector{
@@ -594,6 +600,7 @@ func TestHandleEvent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      eventListenerName,
 					Namespace: namespace,
+					UID:       types.UID(elUID),
 				},
 				Spec: triggersv1.EventListenerSpec{
 					LabelSelector: &metav1.LabelSelector{
@@ -624,6 +631,7 @@ func TestHandleEvent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      eventListenerName,
 					Namespace: namespace,
+					UID:       types.UID(elUID),
 				},
 				Spec: triggersv1.EventListenerSpec{
 					Triggers: []triggersv1.EventListenerTrigger{{
@@ -651,6 +659,7 @@ func TestHandleEvent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      eventListenerName,
 					Namespace: namespace,
+					UID:       types.UID(elUID),
 				},
 				Spec: triggersv1.EventListenerSpec{
 					Triggers: []triggersv1.EventListenerTrigger{{
@@ -708,6 +717,7 @@ func TestHandleEvent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      eventListenerName,
 					Namespace: namespace,
+					UID:       types.UID(elUID),
 				},
 				Spec: triggersv1.EventListenerSpec{
 					Triggers: []triggersv1.EventListenerTrigger{{
@@ -762,6 +772,7 @@ func TestHandleEvent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      eventListenerName,
 					Namespace: namespace,
+					UID:       types.UID(elUID),
 				},
 				Spec: triggersv1.EventListenerSpec{
 					Triggers: []triggersv1.EventListenerTrigger{{
@@ -783,6 +794,7 @@ func TestHandleEvent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      eventListenerName,
 					Namespace: namespace,
+					UID:       types.UID(elUID),
 				},
 				Spec: triggersv1.EventListenerSpec{
 					NamespaceSelector: triggersv1.NamespaceSelector{
@@ -831,6 +843,7 @@ func TestHandleEvent(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      eventListenerName,
 					Namespace: namespace,
+					UID:       types.UID(elUID),
 				},
 				Spec: triggersv1.EventListenerSpec{
 					Triggers: []triggersv1.EventListenerTrigger{{

--- a/test/eventlistener_test.go
+++ b/test/eventlistener_test.go
@@ -450,8 +450,9 @@ func TestEventListenerCreate(t *testing.T) {
 		t.Errorf("sink did not return 2xx response. Got status code: %d", resp.StatusCode)
 	}
 	wantBody := sink.Response{
-		EventListener: "my-eventlistener",
-		Namespace:     namespace,
+		EventListener:    "my-eventlistener",
+		Namespace:        namespace,
+		EventListenerUID: string(el.GetUID()),
 	}
 	var gotBody sink.Response
 	if err := json.NewDecoder(resp.Body).Decode(&gotBody); err != nil {


### PR DESCRIPTION
# Changes

Add EventListener UID to sink response, mark name/namespace as deprecated.

The goal here is to provide a more opaque identifier to name/namespace,
which might contain PII in response. We will continue to support
name/namespace for the time being, but mark the fields as deprecated to
be removed in a later release.

This change also includes minor clean up to log annotations for common identifiers.

Part of #1070 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
- `eventListener` and `namespace` fields in EventListener response are now deprecated. Use `eventListenerUID` instead.
```
