### PR TITLE
Fixes namespac in clusterrolebinding  in getting-started

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -55,7 +55,8 @@ Configure your cluster as follows:
 2. Create the [`admin` user, role, and rolebinding](./rbac/admin-role.yaml) using the following command:
    
    ```
-   kubectl -n getting-started apply -f ./docs/getting-started/rbac/admin-role.yaml
+   kubectl -n getting-started apply -f ./docs/getting-started/rbac/admin-role.yaml \
+               -f ./docs/getting-started/rbac/clusterrolebinding.yaml
    ```
 3. (Optional) If you have already provisioned a cluster secret for a "Let's Encrypt" certificate,
    you must export it and then import it into your `getting-started` namespace. For example:

--- a/docs/getting-started/rbac/clusterrolebinding.yaml
+++ b/docs/getting-started/rbac/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-triggers-getting-started-clusterbinding
+subjects:
+- kind: ServiceAccount
+  name: tekton-triggers-example-sa
+  namespace: getting-started
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-triggers-example-clusterrole

--- a/docs/getting-started/rbac/webhook-role.yaml
+++ b/docs/getting-started/rbac/webhook-role.yaml
@@ -49,6 +49,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: tekton-triggers-createwebhook
+    namespace: getting-started
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
Previously we use to create ClusterRoleBinding with service account
in default ns as admin-role.yaml is symbolic link with examples/rbac.yaml,
this adds a new clusterrolebinding in docs/getting-started/rbac to
update the namespace.

Closes #990 

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
