### PR TITLE
Adds readiness probe in core-interceptors deployment

### DIFF
--- a/cmd/interceptors/main.go
+++ b/cmd/interceptors/main.go
@@ -73,6 +73,7 @@ func main() {
 	}
 	mux := http.NewServeMux()
 	mux.Handle("/", service)
+	mux.HandleFunc("/ready", handler)
 
 	srv := &http.Server{
 		Addr: fmt.Sprintf(":%d", Port),
@@ -89,4 +90,8 @@ func main() {
 	if err := srv.ListenAndServe(); err != nil {
 		logger.Fatalf("failed to start interceptors service: %v", err)
 	}
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
 }

--- a/config/interceptors/core-interceptors-deployment.yaml
+++ b/config/interceptors/core-interceptors-deployment.yaml
@@ -65,6 +65,14 @@ spec:
           value: config-observability-triggers
         - name: METRICS_DOMAIN
           value: tekton.dev/triggers
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8082
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
         securityContext:
           allowPrivilegeEscalation: false
           # User 65532 is the distroless nonroot user ID


### PR DESCRIPTION
This adds readiness probe in the core interceptors
deployment.

Closes #1041 

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
