### PR TITLE
Removes the replicas field

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -24,6 +24,7 @@ or more [`Interceptors`](./interceptors.md).
 - [Specifying a `PodTemplate`](#specifying-a-podtemplate)
 - [Specifying `Resources`](#specifying-resources)
   - [Specifying a `kubernetesResource` object](#specifying-a-kubernetesresource-object)
+    - [Specifying `Replicas`](#specifying-replicas)
   - [Specifying a `CustomResource` object](#specifying-a-customresource-object)
     - [Contract for the `CustomResource` object](#contract-for-the-customresource-object)
 - [Specifying `Interceptors`](#specifying-interceptors)
@@ -58,7 +59,6 @@ An `EventListener` definition consists of the following fields:
     - [`serviceAccountName`](#specifiying-the-kubernetes-service-account) - Specifies the `ServiceAccount` the `EventListener` will use to instantiate Tekton resources
 - Optional:
   - [`triggers`](#specifying-triggers) - specifies a list of `Triggers` to execute upon event detection
-  - [`replicas`](#specifying-a-kubernetesresource-object) - specifies the number of `EventListener` pods to create (only for `kubernetesResource` objects)
   - [`podTemplate`](#specifying-a-podtemplate) - specifies the `PodTemplate` for your `EventListener` pod
   - [`resources`](#specifying-resources) - specifies the resources that will be available to the event listening service
   - [`namespaceSelector`](#constraining-eventlisteners-to-specific-namespaces) - specifies the namespace for the `EventListener`; this is where the `EventListener` looks for the 
@@ -235,12 +235,12 @@ spec:
               effect: NoSchedule
 ```
 
+#### Specifying `Replicas`
+
 You can optionally use the `replicas` field to instruct Tekton Triggers to deploy more than one instance of your `EventListener` in individual Kubernetes Pods.
 If you do not specify this value, the default number of instances (and thus, the number of respective Pods) per `EventListener` is 1. If you set a value for the `replicas` field
 while creating or upgrading the `EventListener's` YAML file, that value overrides any value you set manually later as as well as a value set by any other deployment
 mechanism, such as HPA.
-
-**Note:** The `spec.replicas` field is now the `spec.resources.kubernetesResource.replicas` field.
 
 ### Specifying a `CustomResource` object
 

--- a/go.sum
+++ b/go.sum
@@ -375,7 +375,6 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -669,7 +668,6 @@ github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/common v0.6.0/go.mod h1:eBmuwkDJBwy6iBfxCBob6t6dR6ENT/y+J+Zk0j9GMYc=
 github.com/prometheus/common v0.7.0/go.mod h1:DjGbpBbp5NYNiECxcL/VnbXCCaQpKd3tt26CguLLsqA=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
-github.com/prometheus/common v0.15.0 h1:4fgOnadei3EZvgRwxJ7RMpG1k1pOZth5Pc13tyspaKM=
 github.com/prometheus/common v0.15.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
 github.com/prometheus/common v0.19.0 h1:Itb4+NjG9wRdkAWgVucbM/adyIXxEhbw0866e0uZE6A=
 github.com/prometheus/common v0.19.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
@@ -748,7 +746,6 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tektoncd/pipeline v0.24.1 h1:c+Odgmf8dkUVRdQ5NVbOliwFB8608kM9i+18t5QDO+g=
 github.com/tektoncd/pipeline v0.24.1/go.mod h1:ChFD/vfu14VOtCVlLWdtlvOwXfBfVotULoNV6yz+CKY=
-github.com/tektoncd/plumbing v0.0.0-20210420200944-17170d5e7bc9 h1:ZLPo8/vilaxvpdvvdd9ZgIhhQJPkHyS5GeKK8UH4/Yo=
 github.com/tektoncd/plumbing v0.0.0-20210420200944-17170d5e7bc9/go.mod h1:WTWwsg91xgm+jPOKoyKVK/yRYxnVDlUYeDlypB1lDdQ=
 github.com/tektoncd/plumbing v0.0.0-20210514044347-f8a9689d5bd5 h1:tY3t38AFNwlSWALhulEHryANpQ53Hfjp9jM5zl8ImSQ=
 github.com/tektoncd/plumbing v0.0.0-20210514044347-f8a9689d5bd5/go.mod h1:WTWwsg91xgm+jPOKoyKVK/yRYxnVDlUYeDlypB1lDdQ=

--- a/pkg/apis/triggers/v1alpha1/event_listener_defaults.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_defaults.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"knative.dev/pkg/logging"
-	"knative.dev/pkg/ptr"
 )
 
 // SetDefaults sets the defaults on the object.
@@ -46,8 +45,6 @@ func (el *EventListener) SetDefaults(ctx context.Context) {
 			}
 		}
 		el.Spec.updatePodTemplate()
-		// To be removed in a later release #1020
-		el.Spec.updateReplicas()
 	}
 }
 
@@ -68,24 +65,5 @@ func (spec *EventListenerSpec) updatePodTemplate() {
 			spec.DeprecatedPodTemplate.Tolerations = nil
 		}
 		spec.DeprecatedPodTemplate = nil
-	}
-}
-
-// To be Removed in a later release #1020
-func (spec *EventListenerSpec) updateReplicas() {
-	if spec.DeprecatedReplicas != nil {
-		if *spec.DeprecatedReplicas == 0 {
-			if spec.Resources.KubernetesResource == nil {
-				spec.Resources.KubernetesResource = &KubernetesResource{}
-			}
-			spec.Resources.KubernetesResource.Replicas = ptr.Int32(1)
-			spec.DeprecatedReplicas = nil
-		} else if *spec.DeprecatedReplicas > 0 {
-			if spec.Resources.KubernetesResource == nil {
-				spec.Resources.KubernetesResource = &KubernetesResource{}
-			}
-			spec.Resources.KubernetesResource.Replicas = spec.DeprecatedReplicas
-			spec.DeprecatedReplicas = nil
-		}
 	}
 }

--- a/pkg/apis/triggers/v1alpha1/event_listener_defaults_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_defaults_test.go
@@ -76,23 +76,6 @@ func TestEventListenerSetDefaults(t *testing.T) {
 			},
 		},
 	}, {
-		name: "set replicas to 1 if provided deprecated replicas is 0 as part of eventlistener spec",
-		in: &v1alpha1.EventListener{
-			Spec: v1alpha1.EventListenerSpec{
-				DeprecatedReplicas: ptr.Int32(0),
-			},
-		},
-		wc: v1alpha1.WithUpgradeViaDefaulting,
-		want: &v1alpha1.EventListener{
-			Spec: v1alpha1.EventListenerSpec{
-				Resources: v1alpha1.Resources{
-					KubernetesResource: &v1alpha1.KubernetesResource{
-						Replicas: ptr.Int32(1),
-					},
-				},
-			},
-		},
-	}, {
 		name: "set replicas to 1 if provided replicas is 0 as part of eventlistener kubernetesResources",
 		in: &v1alpha1.EventListener{
 			Spec: v1alpha1.EventListenerSpec{
@@ -166,23 +149,6 @@ func TestEventListenerSetDefaults(t *testing.T) {
 						Replicas: ptr.Int32(2),
 					},
 				},
-			},
-		},
-		wc: v1alpha1.WithUpgradeViaDefaulting,
-		want: &v1alpha1.EventListener{
-			Spec: v1alpha1.EventListenerSpec{
-				Resources: v1alpha1.Resources{
-					KubernetesResource: &v1alpha1.KubernetesResource{
-						Replicas: ptr.Int32(2),
-					},
-				},
-			},
-		},
-	}, {
-		name: "different value for deprecated replicas other than 0",
-		in: &v1alpha1.EventListener{
-			Spec: v1alpha1.EventListenerSpec{
-				DeprecatedReplicas: ptr.Int32(2),
 			},
 		},
 		wc: v1alpha1.WithUpgradeViaDefaulting,

--- a/pkg/apis/triggers/v1alpha1/event_listener_types.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_types.go
@@ -55,14 +55,12 @@ type EventListener struct {
 // EventListenerSpec defines the desired state of the EventListener, represented
 // by a list of Triggers.
 type EventListenerSpec struct {
-	ServiceAccountName string                 `json:"serviceAccountName,omitempty"`
-	Triggers           []EventListenerTrigger `json:"triggers"`
-	// To be removed in a later release #1020
-	DeprecatedReplicas    *int32                `json:"replicas,omitempty"`
-	DeprecatedPodTemplate *PodTemplate          `json:"podTemplate,omitempty"`
-	NamespaceSelector     NamespaceSelector     `json:"namespaceSelector,omitempty"`
-	LabelSelector         *metav1.LabelSelector `json:"labelSelector,omitempty"`
-	Resources             Resources             `json:"resources,omitempty"`
+	ServiceAccountName    string                 `json:"serviceAccountName,omitempty"`
+	Triggers              []EventListenerTrigger `json:"triggers"`
+	DeprecatedPodTemplate *PodTemplate           `json:"podTemplate,omitempty"`
+	NamespaceSelector     NamespaceSelector      `json:"namespaceSelector,omitempty"`
+	LabelSelector         *metav1.LabelSelector  `json:"labelSelector,omitempty"`
+	Resources             Resources              `json:"resources,omitempty"`
 }
 
 type Resources struct {

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation.go
@@ -54,13 +54,6 @@ func (s *EventListenerSpec) validate(ctx context.Context) (errs *apis.FieldError
 		errs = errs.Also(trigger.validate(ctx).ViaField(fmt.Sprintf("spec.triggers[%d]", i)))
 	}
 
-	// To be removed in a later release #1020
-	if s.DeprecatedReplicas != nil {
-		if *s.DeprecatedReplicas < 0 {
-			errs = errs.Also(apis.ErrInvalidValue(*s.DeprecatedReplicas, "spec.replicas"))
-		}
-	}
-
 	// Both Kubernetes and Custom resource can't be present at the same time
 	if s.Resources.KubernetesResource != nil && s.Resources.CustomResource != nil {
 		return apis.ErrMultipleOneOf("spec.resources.kubernetesResource", "spec.resources.customResource")

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
@@ -947,27 +947,6 @@ func TestEventListenerValidate_error(t *testing.T) {
 			},
 		},
 	}, {
-		name: "user specify invalid deprecated replicas",
-		el: &v1alpha1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
-			Spec: v1alpha1.EventListenerSpec{
-				Triggers: []v1alpha1.EventListenerTrigger{{
-					Template: &v1alpha1.EventListenerTemplate{
-						Ref: ptr.String("tt"),
-					},
-				}},
-				DeprecatedReplicas: ptr.Int32(-1),
-				Resources: v1alpha1.Resources{
-					KubernetesResource: &v1alpha1.KubernetesResource{
-						Replicas: ptr.Int32(-1),
-					},
-				},
-			},
-		},
-	}, {
 		name: "user specify invalid replicas",
 		el: &v1alpha1.EventListener{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go
@@ -378,11 +378,6 @@ func (in *EventListenerSpec) DeepCopyInto(out *EventListenerSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.DeprecatedReplicas != nil {
-		in, out := &in.DeprecatedReplicas, &out.DeprecatedReplicas
-		*out = new(int32)
-		**out = **in
-	}
 	if in.DeprecatedPodTemplate != nil {
 		in, out := &in.DeprecatedPodTemplate, &out.DeprecatedPodTemplate
 		*out = new(PodTemplate)

--- a/test/builder/eventlistener.go
+++ b/test/builder/eventlistener.go
@@ -96,13 +96,6 @@ func EventListenerServiceAccount(saName string) EventListenerSpecOp {
 	}
 }
 
-// EventListenerReplicas sets the specified Replicas of the EventListener.
-func EventListenerReplicas(replicas int32) EventListenerSpecOp {
-	return func(spec *v1alpha1.EventListenerSpec) {
-		spec.DeprecatedReplicas = &replicas
-	}
-}
-
 // EventListenerTrigger adds an EventListenerTrigger to the EventListenerSpec Triggers.
 // Any number of EventListenerTriggerOp modifiers can be passed to create/modify it.
 func EventListenerTrigger(ttName, apiVersion string, ops ...EventListenerTriggerOp) EventListenerSpecOp {


### PR DESCRIPTION
This remove the deprecated field replicas from spec in eventlistener.

Issue #1020

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
