### PR TITLE
Add ConfigMap which can contain triggers info

### DIFF
--- a/config/200-role.yaml
+++ b/config/200-role.yaml
@@ -69,3 +69,23 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "watch"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tekton-triggers-info
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers
+rules:
+    # All system:authenticated users needs to have access
+    # of the triggers-info ConfigMap even if they don't
+    # have access to the other resources present in the
+    # installed namespace.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["triggers-info"]
+    verbs: ["get"]

--- a/config/201-rolebinding.yaml
+++ b/config/201-rolebinding.yaml
@@ -66,3 +66,24 @@ roleRef:
   kind: Role
   name: tekton-triggers-core-interceptors
   apiGroup: rbac.authorization.k8s.io
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-triggers-info
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers
+subjects:
+    # Giving all system:authenticated users the access of the
+    # ConfigMap which contains version information.
+  - kind: Group
+    name: system:authenticated
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tekton-triggers-info

--- a/config/config-info.yaml
+++ b/config/config-info.yaml
@@ -1,0 +1,29 @@
+# Copyright 2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: triggers-info
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-triggers
+data:
+  # Contains triggers version which can be queried by external
+  # tools such as CLI. Elevated permissions are already given to
+  # this ConfigMap such that even if we don't have access to
+  # other resources in the namespace we still can have access to
+  # this ConfigMap.
+  version: "devel"


### PR DESCRIPTION
# Changes

As of now we fetch version of triggers through labels present on the
deployments which is read by tools such as `tkn cli` and display the
version. This version may not be displayed to users if they don't have
permission to view the deployment.

In this commit we are adding
1. A `ConfigMap` which contains version information.
2. RBAC which will give appropriate permissions to view the ConfigMap
irrespective of whether user is has permission to view other objects in
that namespace or not.

This is covered as part of [TEP-0041](https://github.com/tektoncd/community/blob/main/teps/0041-tekton-component-versioning.md)

/kind feature

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [X] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Add ConfigMap which will contains Triggers info such as version and some RBAC rules which will give access to this ConfigMap to all the system:authenticated users.
```