### PR TITLE
Updates Interceptors to use Lister to access secrets

### DIFF
--- a/cmd/interceptors/main.go
+++ b/cmd/interceptors/main.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/tektoncd/triggers/pkg/interceptors/server"
 	"go.uber.org/zap"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	secretInformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
 	"knative.dev/pkg/injection"
@@ -52,10 +51,6 @@ func main() {
 	}
 
 	ctx, startInformer := injection.EnableInjectionOrDie(ctx, clusterConfig)
-	kubeClient, err := kubernetes.NewForConfig(clusterConfig)
-	if err != nil {
-		log.Fatalf("Failed to get the Kubernetes client set: %v", err)
-	}
 
 	zap, err := zap.NewProduction()
 	if err != nil {
@@ -70,7 +65,7 @@ func main() {
 	}()
 
 	secretLister := secretInformer.Get(ctx).Lister()
-	service, err := server.NewWithCoreInterceptors(secretLister, kubeClient, logger)
+	service, err := server.NewWithCoreInterceptors(secretLister, logger)
 	if err != nil {
 		log.Printf("failed to initialize core interceptors: %s", err)
 		return

--- a/pkg/interceptors/github/github.go
+++ b/pkg/interceptors/github/github.go
@@ -21,13 +21,12 @@ import (
 	"errors"
 
 	"google.golang.org/grpc/codes"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	gh "github.com/google/go-github/v31/github"
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	"github.com/tektoncd/triggers/pkg/interceptors"
 	"go.uber.org/zap"
-	"k8s.io/client-go/kubernetes"
+	corev1lister "k8s.io/client-go/listers/core/v1"
 )
 
 var _ triggersv1.InterceptorInterface = (*Interceptor)(nil)
@@ -36,14 +35,14 @@ var _ triggersv1.InterceptorInterface = (*Interceptor)(nil)
 var ErrInvalidContentType = errors.New("form parameter encoding not supported, please change the hook to send JSON payloads")
 
 type Interceptor struct {
-	KubeClientSet kubernetes.Interface
-	Logger        *zap.SugaredLogger
+	SecretLister corev1lister.SecretLister
+	Logger       *zap.SugaredLogger
 }
 
-func NewInterceptor(k kubernetes.Interface, l *zap.SugaredLogger) *Interceptor {
+func NewInterceptor(s corev1lister.SecretLister, l *zap.SugaredLogger) *Interceptor {
 	return &Interceptor{
-		Logger:        l,
-		KubeClientSet: k,
+		SecretLister: s,
+		Logger:       l,
 	}
 }
 
@@ -57,30 +56,8 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 	if err := interceptors.UnmarshalParams(r.InterceptorParams, &p); err != nil {
 		return interceptors.Failf(codes.InvalidArgument, "failed to parse interceptor params: %v", err)
 	}
-	// Validate secrets first before anything else, if set
-	if p.SecretRef != nil {
-		// Check the secret to see if it is empty
-		if p.SecretRef.SecretKey == "" {
-			return interceptors.Fail(codes.FailedPrecondition, "github interceptor secretRef.secretKey is empty")
-		}
-		header := headers.Get("X-Hub-Signature")
-		if header == "" {
-			return interceptors.Fail(codes.FailedPrecondition, "no X-Hub-Signature header set")
-		}
 
-		ns, _ := triggersv1.ParseTriggerID(r.Context.TriggerID)
-		secret, err := w.KubeClientSet.CoreV1().Secrets(ns).Get(ctx, p.SecretRef.SecretName, metav1.GetOptions{})
-		if err != nil {
-			return interceptors.Failf(codes.FailedPrecondition, "error getting secret: %v", err)
-		}
-		secretToken := secret.Data[p.SecretRef.SecretKey]
-
-		if err := gh.ValidateSignature(header, []byte(r.Body), secretToken); err != nil {
-			return interceptors.Fail(codes.FailedPrecondition, err.Error())
-		}
-	}
-
-	// Next see if the event type is in the allow-list
+	// Check if the event type is in the allow-list
 	if p.EventTypes != nil {
 		actualEvent := headers.Get("X-GitHub-Event")
 		isAllowed := false
@@ -92,6 +69,29 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 		}
 		if !isAllowed {
 			return interceptors.Failf(codes.FailedPrecondition, "event type %s is not allowed", actualEvent)
+		}
+	}
+
+	// Next validate secrets
+	if p.SecretRef != nil {
+		// Check the secret to see if it is empty
+		if p.SecretRef.SecretKey == "" {
+			return interceptors.Fail(codes.FailedPrecondition, "github interceptor secretRef.secretKey is empty")
+		}
+		header := headers.Get("X-Hub-Signature")
+		if header == "" {
+			return interceptors.Fail(codes.FailedPrecondition, "no X-Hub-Signature header set")
+		}
+
+		ns, _ := triggersv1.ParseTriggerID(r.Context.TriggerID)
+		secret, err := w.SecretLister.Secrets(ns).Get(p.SecretRef.SecretName)
+		if err != nil {
+			return interceptors.Failf(codes.FailedPrecondition, "error getting secret: %v", err)
+		}
+		secretToken := secret.Data[p.SecretRef.SecretKey]
+
+		if err := gh.ValidateSignature(header, []byte(r.Body), secretToken); err != nil {
+			return interceptors.Fail(codes.FailedPrecondition, err.Error())
 		}
 	}
 

--- a/pkg/interceptors/interceptors.go
+++ b/pkg/interceptors/interceptors.go
@@ -29,8 +29,7 @@ import (
 	"knative.dev/pkg/apis"
 
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
+	corev1lister "k8s.io/client-go/listers/core/v1"
 )
 
 const (
@@ -60,8 +59,7 @@ func getCache(req *http.Request) map[string]interface{} {
 //
 // As we may have many triggers that all use the same secret, we cache the secret values
 // in the request cache.
-// TODO: we don't really use the cache here. Instead use a secretLister?
-func GetSecretToken(req *http.Request, cs kubernetes.Interface, sr *triggersv1.SecretRef, triggerNS string) ([]byte, error) {
+func GetSecretToken(req *http.Request, sl corev1lister.SecretLister, sr *triggersv1.SecretRef, triggerNS string) ([]byte, error) {
 	var cache map[string]interface{}
 
 	cacheKey := path.Join("secret", triggerNS, sr.SecretName, sr.SecretKey)
@@ -72,7 +70,7 @@ func GetSecretToken(req *http.Request, cs kubernetes.Interface, sr *triggersv1.S
 		}
 	}
 
-	secret, err := cs.CoreV1().Secrets(triggerNS).Get(context.Background(), sr.SecretName, metav1.GetOptions{})
+	secret, err := sl.Secrets(triggerNS).Get(sr.SecretName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/interceptors/interceptors_test.go
+++ b/pkg/interceptors/interceptors_test.go
@@ -462,7 +462,7 @@ func TestExecute(t *testing.T) {
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			coreInterceptors, err := server.NewWithCoreInterceptors(nil, zaptest.NewLogger(t).Sugar())
+			coreInterceptors, err := server.NewWithCoreInterceptors(nil, nil, zaptest.NewLogger(t).Sugar())
 			if err != nil {
 				t.Fatalf("failed to initialize core interceptors: %v", err)
 			}
@@ -493,7 +493,7 @@ func TestExecute_Error(t *testing.T) {
 			"filter": `header.match("Content-Type", "application/json")`,
 		},
 	}
-	coreInterceptors, err := server.NewWithCoreInterceptors(nil, zaptest.NewLogger(t).Sugar())
+	coreInterceptors, err := server.NewWithCoreInterceptors(nil, nil, zaptest.NewLogger(t).Sugar())
 	if err != nil {
 		t.Fatalf("failed to initialize core interceptors: %v", err)
 	}

--- a/pkg/interceptors/server/server.go
+++ b/pkg/interceptors/server/server.go
@@ -30,7 +30,7 @@ type Server struct {
 func NewWithCoreInterceptors(sl corev1lister.SecretLister, k kubernetes.Interface, l *zap.SugaredLogger) (*Server, error) {
 
 	i := map[string]v1alpha1.InterceptorInterface{
-		"bitbucket": bitbucket.NewInterceptor(k, l),
+		"bitbucket": bitbucket.NewInterceptor(sl, l),
 		"cel":       cel.NewInterceptor(k, l),
 		"github":    github.NewInterceptor(sl, l),
 		"gitlab":    gitlab.NewInterceptor(sl, l),

--- a/pkg/interceptors/server/server.go
+++ b/pkg/interceptors/server/server.go
@@ -33,7 +33,7 @@ func NewWithCoreInterceptors(sl corev1lister.SecretLister, k kubernetes.Interfac
 		"bitbucket": bitbucket.NewInterceptor(k, l),
 		"cel":       cel.NewInterceptor(k, l),
 		"github":    github.NewInterceptor(sl, l),
-		"gitlab":    gitlab.NewInterceptor(k, l),
+		"gitlab":    gitlab.NewInterceptor(sl, l),
 	}
 
 	for k, v := range i {

--- a/pkg/interceptors/server/server.go
+++ b/pkg/interceptors/server/server.go
@@ -17,21 +17,19 @@ import (
 
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	"go.uber.org/zap"
-	"k8s.io/client-go/kubernetes"
 	corev1lister "k8s.io/client-go/listers/core/v1"
 )
 
 type Server struct {
-	KubeClient   kubernetes.Interface
 	Logger       *zap.SugaredLogger
 	interceptors map[string]v1alpha1.InterceptorInterface
 }
 
-func NewWithCoreInterceptors(sl corev1lister.SecretLister, k kubernetes.Interface, l *zap.SugaredLogger) (*Server, error) {
+func NewWithCoreInterceptors(sl corev1lister.SecretLister, l *zap.SugaredLogger) (*Server, error) {
 
 	i := map[string]v1alpha1.InterceptorInterface{
 		"bitbucket": bitbucket.NewInterceptor(sl, l),
-		"cel":       cel.NewInterceptor(k, l),
+		"cel":       cel.NewInterceptor(sl, l),
 		"github":    github.NewInterceptor(sl, l),
 		"gitlab":    gitlab.NewInterceptor(sl, l),
 	}
@@ -42,7 +40,6 @@ func NewWithCoreInterceptors(sl corev1lister.SecretLister, k kubernetes.Interfac
 		}
 	}
 	s := Server{
-		KubeClient:   k,
 		Logger:       l,
 		interceptors: i,
 	}

--- a/pkg/interceptors/server/server.go
+++ b/pkg/interceptors/server/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	"go.uber.org/zap"
 	"k8s.io/client-go/kubernetes"
+	corev1lister "k8s.io/client-go/listers/core/v1"
 )
 
 type Server struct {
@@ -26,11 +27,12 @@ type Server struct {
 	interceptors map[string]v1alpha1.InterceptorInterface
 }
 
-func NewWithCoreInterceptors(k kubernetes.Interface, l *zap.SugaredLogger) (*Server, error) {
+func NewWithCoreInterceptors(sl corev1lister.SecretLister, k kubernetes.Interface, l *zap.SugaredLogger) (*Server, error) {
+
 	i := map[string]v1alpha1.InterceptorInterface{
 		"bitbucket": bitbucket.NewInterceptor(k, l),
 		"cel":       cel.NewInterceptor(k, l),
-		"github":    github.NewInterceptor(k, l),
+		"github":    github.NewInterceptor(sl, l),
 		"gitlab":    gitlab.NewInterceptor(k, l),
 	}
 

--- a/pkg/interceptors/server/server_test.go
+++ b/pkg/interceptors/server/server_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	"go.uber.org/zap/zaptest"
-	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	fakeSecretInformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/fake"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
@@ -75,10 +74,9 @@ func TestServer_ServeHTTP(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			logger := zaptest.NewLogger(t)
 			ctx, _ := rtesting.SetupFakeContext(t)
-			kubeClient := fakekubeclient.Get(ctx)
 			secretLister := fakeSecretInformer.Get(ctx).Lister()
 
-			server, err := NewWithCoreInterceptors(secretLister, kubeClient, logger.Sugar())
+			server, err := NewWithCoreInterceptors(secretLister, logger.Sugar())
 			if err != nil {
 				t.Fatalf("error initializing core interceptors: %v", err)
 			}
@@ -136,10 +134,9 @@ func TestServer_ServeHTTP_Error(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			logger := zaptest.NewLogger(t)
 			ctx, _ := rtesting.SetupFakeContext(t)
-			kubeClient := fakekubeclient.Get(ctx)
 			secretLister := fakeSecretInformer.Get(ctx).Lister()
 
-			server, err := NewWithCoreInterceptors(secretLister, kubeClient, logger.Sugar())
+			server, err := NewWithCoreInterceptors(secretLister, logger.Sugar())
 			if err != nil {
 				t.Fatalf("error initializing core interceptors: %v", err)
 			}

--- a/pkg/interceptors/server/server_test.go
+++ b/pkg/interceptors/server/server_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	"go.uber.org/zap/zaptest"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
+	fakeSecretInformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/fake"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
@@ -75,8 +76,9 @@ func TestServer_ServeHTTP(t *testing.T) {
 			logger := zaptest.NewLogger(t)
 			ctx, _ := rtesting.SetupFakeContext(t)
 			kubeClient := fakekubeclient.Get(ctx)
+			secretLister := fakeSecretInformer.Get(ctx).Lister()
 
-			server, err := NewWithCoreInterceptors(kubeClient, logger.Sugar())
+			server, err := NewWithCoreInterceptors(secretLister, kubeClient, logger.Sugar())
 			if err != nil {
 				t.Fatalf("error initializing core interceptors: %v", err)
 			}
@@ -135,8 +137,9 @@ func TestServer_ServeHTTP_Error(t *testing.T) {
 			logger := zaptest.NewLogger(t)
 			ctx, _ := rtesting.SetupFakeContext(t)
 			kubeClient := fakekubeclient.Get(ctx)
+			secretLister := fakeSecretInformer.Get(ctx).Lister()
 
-			server, err := NewWithCoreInterceptors(kubeClient, logger.Sugar())
+			server, err := NewWithCoreInterceptors(secretLister, kubeClient, logger.Sugar())
 			if err != nil {
 				t.Fatalf("error initializing core interceptors: %v", err)
 			}

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -169,7 +169,7 @@ func getSinkAssets(t *testing.T, resources test.Resources, elName string, webhoo
 func setupInterceptors(t *testing.T, s corev1lister.SecretLister, k kubernetes.Interface, l *zap.SugaredLogger, webhookInterceptor http.Handler) *http.Client {
 	t.Helper()
 	// Setup a handler for core interceptors using httptest
-	coreInterceptors, err := server.NewWithCoreInterceptors(s, k, l)
+	coreInterceptors, err := server.NewWithCoreInterceptors(s, l)
 	if err != nil {
 		t.Fatalf("failed to initialize core interceptors: %v", err)
 	}


### PR DESCRIPTION
This updates all core interceptor to use lister to cache the secret
instead of using kubeclient, to prevent interceptor's calls to the API server
from being throttled.
This also moves the validation of event type before the secret validation
so that it reads the secret only when the event type matches.

Closes #1084

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
