### PR TITLE
Switch reconciler & sink to using v1beta1 types

### DIFF
--- a/cmd/binding-eval/cmd/root.go
+++ b/cmd/binding-eval/cmd/root.go
@@ -28,7 +28,7 @@ import (
 	"sort"
 
 	"github.com/spf13/cobra"
-	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	"github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/pkg/template"
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -72,7 +72,7 @@ func evalBinding(w io.Writer, bindingPath, httpPath string) error {
 		return fmt.Errorf("error reading bindings: %w", err)
 	}
 
-	bindingParams := []v1alpha1.Param{}
+	bindingParams := []v1beta1.Param{}
 	for _, b := range bindings {
 		bindingParams = append(bindingParams, b.Spec.Params...)
 	}
@@ -99,16 +99,16 @@ func evalBinding(w io.Writer, bindingPath, httpPath string) error {
 	return nil
 }
 
-func readBindings(path string) ([]*v1alpha1.TriggerBinding, error) {
+func readBindings(path string) ([]*v1beta1.TriggerBinding, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("error reading binding file: %w", err)
 	}
 	defer f.Close()
 
-	var list []*v1alpha1.TriggerBinding
+	var list []*v1beta1.TriggerBinding
 	decoder := streaming.NewDecoder(f, scheme.Codecs.UniversalDecoder())
-	b := new(v1alpha1.TriggerBinding)
+	b := new(v1beta1.TriggerBinding)
 	for err == nil {
 		_, _, err = decoder.Decode(nil, b)
 		if err != nil {

--- a/cmd/eventlistenersink/main.go
+++ b/cmd/eventlistenersink/main.go
@@ -152,11 +152,11 @@ func main() {
 		Recorder:               recorder,
 		Auth:                   sink.DefaultAuthOverride{},
 		// Register all the listers we'll need
-		EventListenerLister:         factory.Triggers().V1alpha1().EventListeners().Lister(),
-		TriggerLister:               factory.Triggers().V1alpha1().Triggers().Lister(),
-		TriggerBindingLister:        factory.Triggers().V1alpha1().TriggerBindings().Lister(),
-		ClusterTriggerBindingLister: factory.Triggers().V1alpha1().ClusterTriggerBindings().Lister(),
-		TriggerTemplateLister:       factory.Triggers().V1alpha1().TriggerTemplates().Lister(),
+		EventListenerLister:         factory.Triggers().V1beta1().EventListeners().Lister(),
+		TriggerLister:               factory.Triggers().V1beta1().Triggers().Lister(),
+		TriggerBindingLister:        factory.Triggers().V1beta1().TriggerBindings().Lister(),
+		ClusterTriggerBindingLister: factory.Triggers().V1beta1().ClusterTriggerBindings().Lister(),
+		TriggerTemplateLister:       factory.Triggers().V1beta1().TriggerTemplates().Lister(),
 		ClusterInterceptorLister:    factory.Triggers().V1alpha1().ClusterInterceptors().Lister(),
 	}
 

--- a/cmd/triggerrun/cmd/root.go
+++ b/cmd/triggerrun/cmd/root.go
@@ -31,8 +31,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/triggers/pkg/apis/triggers"
-	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
-	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	triggersclientset "github.com/tektoncd/triggers/pkg/client/clientset/versioned"
 	dynamicClientset "github.com/tektoncd/triggers/pkg/client/dynamic/clientset"
 	"github.com/tektoncd/triggers/pkg/client/dynamic/clientset/tekton"
@@ -139,16 +138,16 @@ func trigger(triggerFile, httpPath, action, kubeconfig string, writer io.Writer)
 	return nil
 }
 
-func readTrigger(path string) ([]*v1alpha1.Trigger, error) {
+func readTrigger(path string) ([]*triggersv1.Trigger, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("error reading trigger file: %w", err)
 	}
 	defer f.Close()
 
-	var list []*v1alpha1.Trigger
+	var list []*triggersv1.Trigger
 	decoder := streaming.NewDecoder(f, scheme.Codecs.UniversalDecoder())
-	b := new(v1alpha1.Trigger)
+	b := new(triggersv1.Trigger)
 	for err == nil {
 		_, _, err = decoder.Decode(nil, b)
 		if err != nil {
@@ -213,13 +212,13 @@ func processTriggerSpec(kubeClient kubernetes.Interface, client triggersclientse
 
 	rt, err := template.ResolveTrigger(*tri,
 		func(name string) (*triggersv1.TriggerBinding, error) {
-			return client.TriggersV1alpha1().TriggerBindings(tri.Namespace).Get(context.Background(), name, metav1.GetOptions{})
+			return client.TriggersV1beta1().TriggerBindings(tri.Namespace).Get(context.Background(), name, metav1.GetOptions{})
 		},
 		func(name string) (*triggersv1.ClusterTriggerBinding, error) {
-			return client.TriggersV1alpha1().ClusterTriggerBindings().Get(context.Background(), name, metav1.GetOptions{})
+			return client.TriggersV1beta1().ClusterTriggerBindings().Get(context.Background(), name, metav1.GetOptions{})
 		},
 		func(name string) (*triggersv1.TriggerTemplate, error) {
-			return client.TriggersV1alpha1().TriggerTemplates(tri.Namespace).Get(context.Background(), name, metav1.GetOptions{})
+			return client.TriggersV1beta1().TriggerTemplates(tri.Namespace).Get(context.Background(), name, metav1.GetOptions{})
 		})
 	if err != nil {
 		log.Error("Failed to resolve Trigger: ", err)

--- a/cmd/triggerrun/cmd/root_test.go
+++ b/cmd/triggerrun/cmd/root_test.go
@@ -25,16 +25,14 @@ import (
 	"strings"
 	"testing"
 
-	"go.uber.org/zap/zaptest"
-
 	"github.com/google/go-cmp/cmp"
 	pipelinev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
-	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	triggersclientset "github.com/tektoncd/triggers/pkg/client/clientset/versioned"
 	"github.com/tektoncd/triggers/pkg/sink"
 	"github.com/tektoncd/triggers/test"
+	"go.uber.org/zap/zaptest"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -60,7 +58,7 @@ func TestReadTrigger(t *testing.T) {
 		t.Fatalf("failed to read trigger:%+v", err)
 	}
 
-	want := []*v1alpha1.Trigger{{
+	want := []*triggersv1.Trigger{{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "triggers.tekton.dev/v1alpha1",
 			Kind:       "Trigger",
@@ -68,11 +66,11 @@ func TestReadTrigger(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "trigger-run",
 		},
-		Spec: v1alpha1.TriggerSpec{
-			Bindings: []*v1alpha1.TriggerSpecBinding{
+		Spec: triggersv1.TriggerSpec{
+			Bindings: []*triggersv1.TriggerSpecBinding{
 				{Ref: "git-event-binding"},
 			},
-			Template: v1alpha1.TriggerSpecTemplate{
+			Template: triggersv1.TriggerSpecTemplate{
 				Ref: ptr.String("simple-pipeline-template"),
 			},
 		},
@@ -167,7 +165,7 @@ func Test_processTriggerSpec(t *testing.T) {
 		},
 	}
 
-	triggerBinding := v1alpha1.TriggerBinding{
+	triggerBinding := triggersv1.TriggerBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "git-event-binding",
 			Namespace: "default",
@@ -209,20 +207,20 @@ func Test_processTriggerSpec(t *testing.T) {
 	}{{
 		name: "testing-name",
 		args: args{
-			t: &v1alpha1.Trigger{
+			t: &triggersv1.Trigger{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "my-triggerRun",
 				},
-				Spec: v1alpha1.TriggerSpec{
-					Bindings: []*v1alpha1.TriggerSpecBinding{{Ref: "git-event-binding"}},                // These should be references to TriggerBindings defined below
-					Template: v1alpha1.TriggerSpecTemplate{Ref: ptr.String("simple-pipeline-template")}, // This should be a reference to a TriggerTemplate defined below
+				Spec: triggersv1.TriggerSpec{
+					Bindings: []*triggersv1.TriggerSpecBinding{{Ref: "git-event-binding"}},                // These should be references to TriggerBindings defined below
+					Template: triggersv1.TriggerSpecTemplate{Ref: ptr.String("simple-pipeline-template")}, // This should be a reference to a TriggerTemplate defined below
 				},
 			},
 			request: r,
 			event:   eventBody,
 			resources: test.Resources{
 				// Add any resources that we need to create with a fake client
-				TriggerBindings:  []*v1alpha1.TriggerBinding{&triggerBinding},
+				TriggerBindings:  []*triggersv1.TriggerBinding{&triggerBinding},
 				TriggerTemplates: []*triggersv1.TriggerTemplate{&triggerTemplate},
 			},
 		},

--- a/config/300-clustertriggerbinding.yaml
+++ b/config/300-clustertriggerbinding.yaml
@@ -35,8 +35,8 @@ spec:
     - tekton-triggers
   versions:
   - name: v1beta1
-    served: false
-    storage: false
+    served: true
+    storage: true
     schema:
       openAPIV3Schema:
         type: object
@@ -52,7 +52,7 @@ spec:
       status: {}
   - name: v1alpha1
     served: true
-    storage: true
+    storage: false
     schema:
       openAPIV3Schema:
         type: object

--- a/config/300-eventlistener.yaml
+++ b/config/300-eventlistener.yaml
@@ -35,8 +35,8 @@ spec:
     - tekton-triggers
   versions:
   - name: v1beta1
-    served: false
-    storage: false
+    served: true
+    storage: true
     # Opt into the status subresource so metadata.generation
     # starts to increment
     subresources:
@@ -71,7 +71,7 @@ spec:
 
   - name: v1alpha1
     served: true
-    storage: true
+    storage: false
     schema:
       openAPIV3Schema:
         type: object

--- a/config/300-trigger.yaml
+++ b/config/300-trigger.yaml
@@ -35,8 +35,8 @@ spec:
     - tekton-triggers
   versions:
   - name: v1beta1
-    served: false
-    storage: false
+    served: true
+    storage: true
     schema:
       openAPIV3Schema:
         type: object
@@ -52,7 +52,7 @@ spec:
       status: {}
   - name: v1alpha1
     served: true
-    storage: true
+    storage: false
     schema:
       openAPIV3Schema:
         type: object

--- a/config/300-triggerbinding.yaml
+++ b/config/300-triggerbinding.yaml
@@ -35,8 +35,8 @@ spec:
     - tekton-triggers
   versions:
   - name: v1beta1
-    served: false
-    storage: false
+    served: true
+    storage: true
     schema:
       openAPIV3Schema:
         type: object
@@ -55,7 +55,7 @@ spec:
 
   - name: v1alpha1
     served: true
-    storage: true
+    storage: false
     schema:
       openAPIV3Schema:
         type: object

--- a/config/300-triggertemplate.yaml
+++ b/config/300-triggertemplate.yaml
@@ -35,8 +35,8 @@ spec:
     - tekton-triggers
   versions:
   - name: v1beta1
-    served: false
-    storage: false
+    served: true
+    storage: true
     schema:
       openAPIV3Schema:
         type: object
@@ -54,7 +54,7 @@ spec:
       status: {}
   - name: v1alpha1
     served: true
-    storage: true
+    storage: false
     schema:
       openAPIV3Schema:
         type: object

--- a/pkg/apis/triggers/v1beta1/event_listener_types.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_types.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
-	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
 	"knative.dev/pkg/apis/duck/v1beta1"
 )
 
@@ -144,7 +143,7 @@ type EventListenerStatus struct {
 
 	// EventListener is Addressable. It currently exposes the service DNS
 	// address of the the EventListener sink
-	duckv1alpha1.AddressStatus `json:",inline"`
+	v1beta1.AddressStatus `json:",inline"`
 
 	// Configuration stores configuration for the EventListener service
 	Configuration EventListenerConfig `json:"configuration"`
@@ -315,7 +314,7 @@ func (el *EventListener) GetOwnerReference() *metav1.OwnerReference {
 // SetAddress sets the address (as part of Addressable contract) and marks the correct condition.
 func (els *EventListenerStatus) SetAddress(hostname string) {
 	if els.Address == nil {
-		els.Address = &duckv1alpha1.Addressable{}
+		els.Address = &v1beta1.Addressable{}
 	}
 	if hostname != "" {
 		els.Address.URL = &apis.URL{

--- a/pkg/interceptors/bitbucket/bitbucket.go
+++ b/pkg/interceptors/bitbucket/bitbucket.go
@@ -25,7 +25,7 @@ import (
 	corev1lister "k8s.io/client-go/listers/core/v1"
 
 	gh "github.com/google/go-github/v31/github"
-	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/pkg/interceptors"
 	"go.uber.org/zap"
 )

--- a/pkg/interceptors/bitbucket/bitbucket_test.go
+++ b/pkg/interceptors/bitbucket/bitbucket_test.go
@@ -21,11 +21,9 @@ import (
 	"net/http"
 	"testing"
 
-	"go.uber.org/zap/zaptest"
-
+	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/test"
-
-	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakeSecretInformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/fake"

--- a/pkg/interceptors/cel/cel.go
+++ b/pkg/interceptors/cel/cel.go
@@ -39,7 +39,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	corev1lister "k8s.io/client-go/listers/core/v1"
 
-	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 )
 
 var _ triggersv1.InterceptorInterface = (*Interceptor)(nil)

--- a/pkg/interceptors/cel/cel_test.go
+++ b/pkg/interceptors/cel/cel_test.go
@@ -34,12 +34,11 @@ import (
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/go-cmp/cmp"
+	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakeSecretInformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/fake"
 	rtesting "knative.dev/pkg/reconciler/testing"
-
-	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 )
 
 const testNS = "testing-ns"

--- a/pkg/interceptors/cel/triggers.go
+++ b/pkg/interceptors/cel/triggers.go
@@ -32,7 +32,7 @@ import (
 	"github.com/tektoncd/triggers/pkg/interceptors"
 	"sigs.k8s.io/yaml"
 
-	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 	corev1lister "k8s.io/client-go/listers/core/v1"
 )

--- a/pkg/interceptors/github/github.go
+++ b/pkg/interceptors/github/github.go
@@ -23,7 +23,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	gh "github.com/google/go-github/v31/github"
-	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/pkg/interceptors"
 	"go.uber.org/zap"
 	corev1lister "k8s.io/client-go/listers/core/v1"

--- a/pkg/interceptors/github/github_test.go
+++ b/pkg/interceptors/github/github_test.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 	"testing"
 
-	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/test"
 	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/interceptors/gitlab/gitlab.go
+++ b/pkg/interceptors/gitlab/gitlab.go
@@ -21,13 +21,11 @@ import (
 	"crypto/subtle"
 	"fmt"
 
+	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/pkg/interceptors"
+	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	corev1lister "k8s.io/client-go/listers/core/v1"
-
-	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
-
-	"go.uber.org/zap"
 )
 
 var _ triggersv1.InterceptorInterface = (*Interceptor)(nil)

--- a/pkg/interceptors/gitlab/gitlab_test.go
+++ b/pkg/interceptors/gitlab/gitlab_test.go
@@ -20,9 +20,8 @@ import (
 	"net/http"
 	"testing"
 
+	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"go.uber.org/zap/zaptest"
-
-	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakeSecretInformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/fake"

--- a/pkg/interceptors/interface.go
+++ b/pkg/interceptors/interface.go
@@ -1,0 +1,1 @@
+package interceptors

--- a/pkg/interceptors/webhook/webhook.go
+++ b/pkg/interceptors/webhook/webhook.go
@@ -27,8 +27,7 @@ import (
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/triggers/pkg/interceptors"
 
-	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
-	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 
 	"go.uber.org/zap"
 )
@@ -85,7 +84,7 @@ func (w *Interceptor) ExecuteTrigger(request *http.Request) (*http.Response, err
 }
 
 // getURI retrieves the ObjectReference to URI.
-func getURI(webhook *v1alpha1.WebhookInterceptor, ns string) (*url.URL, error) {
+func getURI(webhook *triggersv1.WebhookInterceptor, ns string) (*url.URL, error) {
 	// TODO: This should work for any Addressable.
 	// Use something like https://github.com/knative/eventing-contrib/blob/7c0fc5cfa8bd44da0767d9e7b250264ea6eb7d8d/pkg/controller/sinks/sinks.go#L32
 	switch {

--- a/pkg/interceptors/webhook/webhook_test.go
+++ b/pkg/interceptors/webhook/webhook_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	"github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis"
 )
@@ -68,7 +68,7 @@ func TestWebHookInterceptor(t *testing.T) {
 			Proxy: http.ProxyURL(interceptorURL),
 		},
 	}
-	webhook := &v1alpha1.WebhookInterceptor{
+	webhook := &v1beta1.WebhookInterceptor{
 		ObjectRef: &corev1.ObjectReference{
 			APIVersion: "v1",
 			Kind:       "Service",
@@ -127,7 +127,7 @@ func TestWebHookInterceptor_NotOK(t *testing.T) {
 			Proxy: http.ProxyURL(interceptorURL),
 		},
 	}
-	webhook := &v1alpha1.WebhookInterceptor{
+	webhook := &v1beta1.WebhookInterceptor{
 		ObjectRef: &corev1.ObjectReference{
 			APIVersion: "v1",
 			Kind:       "Service",
@@ -149,12 +149,12 @@ func TestGetURI(t *testing.T) {
 	var eventListenerNs = "default"
 	tcs := []struct {
 		name     string
-		ref      v1alpha1.WebhookInterceptor
+		ref      v1beta1.WebhookInterceptor
 		expected string
 		wantErr  bool
 	}{{
 		name: "namespace specified",
-		ref: v1alpha1.WebhookInterceptor{
+		ref: v1beta1.WebhookInterceptor{
 			ObjectRef: &corev1.ObjectReference{
 				Kind:       "Service",
 				Name:       "foo",
@@ -165,7 +165,7 @@ func TestGetURI(t *testing.T) {
 		wantErr:  false,
 	}, {
 		name: "no namespace",
-		ref: v1alpha1.WebhookInterceptor{
+		ref: v1beta1.WebhookInterceptor{
 			ObjectRef: &corev1.ObjectReference{
 				Kind:       "Service",
 				Name:       "foo",
@@ -175,7 +175,7 @@ func TestGetURI(t *testing.T) {
 		wantErr:  false,
 	}, {
 		name: "non services",
-		ref: v1alpha1.WebhookInterceptor{
+		ref: v1beta1.WebhookInterceptor{
 			ObjectRef: &corev1.ObjectReference{
 				Kind:       "Blah",
 				Name:       "foo",
@@ -185,7 +185,7 @@ func TestGetURI(t *testing.T) {
 		wantErr:  true,
 	}, {
 		name: "webhook interceptor with url",
-		ref: v1alpha1.WebhookInterceptor{
+		ref: v1beta1.WebhookInterceptor{
 			URL: apis.HTTP("foo.default.svc"),
 		},
 		expected: "http://foo.default.svc",

--- a/pkg/reconciler/eventlistener/controller.go
+++ b/pkg/reconciler/eventlistener/controller.go
@@ -19,10 +19,10 @@ package eventlistener
 import (
 	"context"
 
-	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	"github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	triggersclient "github.com/tektoncd/triggers/pkg/client/injection/client"
-	eventlistenerinformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1alpha1/eventlistener"
-	eventlistenerreconciler "github.com/tektoncd/triggers/pkg/client/injection/reconciler/triggers/v1alpha1/eventlistener"
+	eventlistenerinformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1beta1/eventlistener"
+	eventlistenerreconciler "github.com/tektoncd/triggers/pkg/client/injection/reconciler/triggers/v1beta1/eventlistener"
 	dynamicduck "github.com/tektoncd/triggers/pkg/dynamic"
 	"k8s.io/client-go/tools/cache"
 	duckinformer "knative.dev/pkg/client/injection/ducks/duck/v1/podspecable"
@@ -76,12 +76,12 @@ func NewController(config Config) func(context.Context, configmap.Watcher) *cont
 		})
 
 		deploymentInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-			FilterFunc: controller.FilterControllerGVK(v1alpha1.SchemeGroupVersion.WithKind("EventListener")),
+			FilterFunc: controller.FilterControllerGVK(v1beta1.SchemeGroupVersion.WithKind("EventListener")),
 			Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 		})
 
 		serviceInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-			FilterFunc: controller.FilterControllerGVK(v1alpha1.SchemeGroupVersion.WithKind("EventListener")),
+			FilterFunc: controller.FilterControllerGVK(v1beta1.SchemeGroupVersion.WithKind("EventListener")),
 			Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 		})
 

--- a/pkg/sink/sink.go
+++ b/pkg/sink/sink.go
@@ -26,9 +26,10 @@ import (
 	"net/http"
 
 	"github.com/tektoncd/triggers/pkg/apis/triggers"
-	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	triggersclientset "github.com/tektoncd/triggers/pkg/client/clientset/versioned"
-	listers "github.com/tektoncd/triggers/pkg/client/listers/triggers/v1alpha1"
+	listersv1alpha1 "github.com/tektoncd/triggers/pkg/client/listers/triggers/v1alpha1"
+	listers "github.com/tektoncd/triggers/pkg/client/listers/triggers/v1beta1"
 	"github.com/tektoncd/triggers/pkg/interceptors"
 	"github.com/tektoncd/triggers/pkg/interceptors/webhook"
 	"github.com/tektoncd/triggers/pkg/resources"
@@ -63,7 +64,7 @@ type Sink struct {
 	TriggerBindingLister        listers.TriggerBindingLister
 	ClusterTriggerBindingLister listers.ClusterTriggerBindingLister
 	TriggerTemplateLister       listers.TriggerTemplateLister
-	ClusterInterceptorLister    listers.ClusterInterceptorLister
+	ClusterInterceptorLister    listersv1alpha1.ClusterInterceptorLister
 }
 
 // Response defines the HTTP body that the Sink responds to events with.

--- a/pkg/sink/validate_payload_test.go
+++ b/pkg/sink/validate_payload_test.go
@@ -23,7 +23,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/template/event.go
+++ b/pkg/template/event.go
@@ -24,7 +24,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 )
 
 const (

--- a/pkg/template/event_test.go
+++ b/pkg/template/event_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/template/resource.go
+++ b/pkg/template/resource.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/template/resource_test.go
+++ b/pkg/template/resource_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/ptr"

--- a/test/controller.go
+++ b/test/controller.go
@@ -28,16 +28,17 @@ import (
 	fakeresourceclientset "github.com/tektoncd/pipeline/pkg/client/resource/clientset/versioned/fake"
 	fakeresourceclient "github.com/tektoncd/pipeline/pkg/client/resource/injection/client/fake"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	"github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	faketriggersclientset "github.com/tektoncd/triggers/pkg/client/clientset/versioned/fake"
 	dynamicclientset "github.com/tektoncd/triggers/pkg/client/dynamic/clientset"
 	"github.com/tektoncd/triggers/pkg/client/dynamic/clientset/tekton"
 	faketriggersclient "github.com/tektoncd/triggers/pkg/client/injection/client/fake"
 	fakeClusterInterceptorinformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1alpha1/clusterinterceptor/fake"
-	fakeclustertriggerbindinginformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1alpha1/clustertriggerbinding/fake"
-	fakeeventlistenerinformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1alpha1/eventlistener/fake"
-	faketriggerinformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1alpha1/trigger/fake"
-	faketriggerbindinginformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1alpha1/triggerbinding/fake"
-	faketriggertemplateinformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1alpha1/triggertemplate/fake"
+	fakeclustertriggerbindinginformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1beta1/clustertriggerbinding/fake"
+	fakeeventlistenerinformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1beta1/eventlistener/fake"
+	faketriggerinformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1beta1/trigger/fake"
+	faketriggerbindinginformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1beta1/triggerbinding/fake"
+	faketriggertemplateinformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1beta1/triggertemplate/fake"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -65,12 +66,12 @@ import (
 // to seed controllers with.
 type Resources struct {
 	Namespaces             []*corev1.Namespace
-	ClusterTriggerBindings []*v1alpha1.ClusterTriggerBinding
-	EventListeners         []*v1alpha1.EventListener
+	ClusterTriggerBindings []*v1beta1.ClusterTriggerBinding
+	EventListeners         []*v1beta1.EventListener
 	ClusterInterceptors    []*v1alpha1.ClusterInterceptor
-	TriggerBindings        []*v1alpha1.TriggerBinding
-	TriggerTemplates       []*v1alpha1.TriggerTemplate
-	Triggers               []*v1alpha1.Trigger
+	TriggerBindings        []*v1beta1.TriggerBinding
+	TriggerTemplates       []*v1beta1.TriggerTemplate
+	Triggers               []*v1beta1.Trigger
 	Deployments            []*appsv1.Deployment
 	Services               []*corev1.Service
 	ConfigMaps             []*corev1.ConfigMap
@@ -140,7 +141,7 @@ func SeedResources(t *testing.T, ctx context.Context, r Resources) Clients {
 		if err := ctbInformer.Informer().GetIndexer().Add(ctb); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := c.Triggers.TriggersV1alpha1().ClusterTriggerBindings().Create(context.Background(), ctb, metav1.CreateOptions{}); err != nil {
+		if _, err := c.Triggers.TriggersV1beta1().ClusterTriggerBindings().Create(context.Background(), ctb, metav1.CreateOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -148,7 +149,7 @@ func SeedResources(t *testing.T, ctx context.Context, r Resources) Clients {
 		if err := elInformer.Informer().GetIndexer().Add(el); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := c.Triggers.TriggersV1alpha1().EventListeners(el.Namespace).Create(context.Background(), el, metav1.CreateOptions{}); err != nil {
+		if _, err := c.Triggers.TriggersV1beta1().EventListeners(el.Namespace).Create(context.Background(), el, metav1.CreateOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -164,7 +165,7 @@ func SeedResources(t *testing.T, ctx context.Context, r Resources) Clients {
 		if err := tbInformer.Informer().GetIndexer().Add(tb); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := c.Triggers.TriggersV1alpha1().TriggerBindings(tb.Namespace).Create(context.Background(), tb, metav1.CreateOptions{}); err != nil {
+		if _, err := c.Triggers.TriggersV1beta1().TriggerBindings(tb.Namespace).Create(context.Background(), tb, metav1.CreateOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -172,7 +173,7 @@ func SeedResources(t *testing.T, ctx context.Context, r Resources) Clients {
 		if err := ttInformer.Informer().GetIndexer().Add(tt); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := c.Triggers.TriggersV1alpha1().TriggerTemplates(tt.Namespace).Create(context.Background(), tt, metav1.CreateOptions{}); err != nil {
+		if _, err := c.Triggers.TriggersV1beta1().TriggerTemplates(tt.Namespace).Create(context.Background(), tt, metav1.CreateOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -180,7 +181,7 @@ func SeedResources(t *testing.T, ctx context.Context, r Resources) Clients {
 		if err := trInformer.Informer().GetIndexer().Add(tr); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := c.Triggers.TriggersV1alpha1().Triggers(tr.Namespace).Create(context.Background(), tr, metav1.CreateOptions{}); err != nil {
+		if _, err := c.Triggers.TriggersV1beta1().Triggers(tr.Namespace).Create(context.Background(), tr, metav1.CreateOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -272,7 +273,7 @@ func SeedResources(t *testing.T, ctx context.Context, r Resources) Clients {
 func GetResourcesFromClients(c Clients) (*Resources, error) {
 	testResources := &Resources{}
 	// Add ClusterTriggerBindings
-	ctbList, err := c.Triggers.TriggersV1alpha1().ClusterTriggerBindings().List(context.Background(), metav1.ListOptions{})
+	ctbList, err := c.Triggers.TriggersV1beta1().ClusterTriggerBindings().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +288,7 @@ func GetResourcesFromClients(c Clients) (*Resources, error) {
 		// Add Namespace
 		testResources.Namespaces = append(testResources.Namespaces, ns.DeepCopy())
 		// Add EventListeners
-		elList, err := c.Triggers.TriggersV1alpha1().EventListeners(ns.Name).List(context.Background(), metav1.ListOptions{})
+		elList, err := c.Triggers.TriggersV1beta1().EventListeners(ns.Name).List(context.Background(), metav1.ListOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -295,7 +296,7 @@ func GetResourcesFromClients(c Clients) (*Resources, error) {
 			testResources.EventListeners = append(testResources.EventListeners, el.DeepCopy())
 		}
 		// Add TriggerBindings
-		tbList, err := c.Triggers.TriggersV1alpha1().TriggerBindings(ns.Name).List(context.Background(), metav1.ListOptions{})
+		tbList, err := c.Triggers.TriggersV1beta1().TriggerBindings(ns.Name).List(context.Background(), metav1.ListOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -303,7 +304,7 @@ func GetResourcesFromClients(c Clients) (*Resources, error) {
 			testResources.TriggerBindings = append(testResources.TriggerBindings, tb.DeepCopy())
 		}
 		// Add TriggerTemplates
-		ttList, err := c.Triggers.TriggersV1alpha1().TriggerTemplates(ns.Name).List(context.Background(), metav1.ListOptions{})
+		ttList, err := c.Triggers.TriggersV1beta1().TriggerTemplates(ns.Name).List(context.Background(), metav1.ListOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -343,7 +344,7 @@ func GetResourcesFromClients(c Clients) (*Resources, error) {
 			testResources.Secrets = append(testResources.Secrets, s.DeepCopy())
 		}
 		// Get Triggers
-		trList, err := c.Triggers.TriggersV1alpha1().Triggers(ns.Name).List(context.Background(), metav1.ListOptions{})
+		trList, err := c.Triggers.TriggersV1beta1().Triggers(ns.Name).List(context.Background(), metav1.ListOptions{})
 		if err != nil {
 			return nil, err
 		}

--- a/test/controller_test.go
+++ b/test/controller_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	"github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,59 +39,59 @@ func TestGetResourcesFromClients(t *testing.T) {
 			Name: "tekton-pipelines",
 		},
 	}
-	clusterTriggerBinding1 := &v1alpha1.ClusterTriggerBinding{
+	clusterTriggerBinding1 := &v1beta1.ClusterTriggerBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-clusterTriggerBinding1",
 		},
 	}
-	clusterTriggerBinding2 := &v1alpha1.ClusterTriggerBinding{
+	clusterTriggerBinding2 := &v1beta1.ClusterTriggerBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-clusterTriggerBinding2",
 		},
 	}
-	eventListener1 := &v1alpha1.EventListener{
+	eventListener1 := &v1beta1.EventListener{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "foo",
 			Name:      "my-eventlistener1",
 		},
 	}
-	eventListener2 := &v1alpha1.EventListener{
+	eventListener2 := &v1beta1.EventListener{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "foo",
 			Name:      "my-eventlistener2",
 		},
 	}
-	triggerBinding1 := &v1alpha1.TriggerBinding{
+	triggerBinding1 := &v1beta1.TriggerBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "foo",
 			Name:      "my-triggerBinding1",
 		},
 	}
-	triggerBinding2 := &v1alpha1.TriggerBinding{
+	triggerBinding2 := &v1beta1.TriggerBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "foo",
 			Name:      "my-triggerBinding2",
 		},
 	}
-	triggerTemplate1 := &v1alpha1.TriggerTemplate{
+	triggerTemplate1 := &v1beta1.TriggerTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "foo",
 			Name:      "my-triggerTemplate1",
 		},
 	}
-	triggerTemplate2 := &v1alpha1.TriggerTemplate{
+	triggerTemplate2 := &v1beta1.TriggerTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "foo",
 			Name:      "my-triggerTemplate2",
 		},
 	}
-	trigger1 := &v1alpha1.Trigger{
+	trigger1 := &v1beta1.Trigger{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "foo",
 			Name:      "my-trigger1",
 		},
 	}
-	trigger2 := &v1alpha1.Trigger{
+	trigger2 := &v1beta1.Trigger{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "foo",
 			Name:      "my-trigger2",
@@ -179,11 +179,11 @@ func TestGetResourcesFromClients(t *testing.T) {
 			name: "one resource each",
 			Resources: Resources{
 				Namespaces:             []*corev1.Namespace{nsFoo},
-				ClusterTriggerBindings: []*v1alpha1.ClusterTriggerBinding{clusterTriggerBinding1},
-				EventListeners:         []*v1alpha1.EventListener{eventListener1},
-				TriggerBindings:        []*v1alpha1.TriggerBinding{triggerBinding1},
-				TriggerTemplates:       []*v1alpha1.TriggerTemplate{triggerTemplate1},
-				Triggers:               []*v1alpha1.Trigger{trigger1},
+				ClusterTriggerBindings: []*v1beta1.ClusterTriggerBinding{clusterTriggerBinding1},
+				EventListeners:         []*v1beta1.EventListener{eventListener1},
+				TriggerBindings:        []*v1beta1.TriggerBinding{triggerBinding1},
+				TriggerTemplates:       []*v1beta1.TriggerTemplate{triggerTemplate1},
+				Triggers:               []*v1beta1.Trigger{trigger1},
 				Deployments:            []*appsv1.Deployment{deployment1},
 				Services:               []*corev1.Service{service1},
 				Pods:                   []*corev1.Pod{pod1},
@@ -194,11 +194,11 @@ func TestGetResourcesFromClients(t *testing.T) {
 			name: "two resources each",
 			Resources: Resources{
 				Namespaces:             []*corev1.Namespace{nsFoo, nsTektonPipelines},
-				ClusterTriggerBindings: []*v1alpha1.ClusterTriggerBinding{clusterTriggerBinding1, clusterTriggerBinding2},
-				EventListeners:         []*v1alpha1.EventListener{eventListener1, eventListener2},
-				TriggerBindings:        []*v1alpha1.TriggerBinding{triggerBinding1, triggerBinding2},
-				TriggerTemplates:       []*v1alpha1.TriggerTemplate{triggerTemplate1, triggerTemplate2},
-				Triggers:               []*v1alpha1.Trigger{trigger1, trigger2},
+				ClusterTriggerBindings: []*v1beta1.ClusterTriggerBinding{clusterTriggerBinding1, clusterTriggerBinding2},
+				EventListeners:         []*v1beta1.EventListener{eventListener1, eventListener2},
+				TriggerBindings:        []*v1beta1.TriggerBinding{triggerBinding1, triggerBinding2},
+				TriggerTemplates:       []*v1beta1.TriggerTemplate{triggerTemplate1, triggerTemplate2},
+				Triggers:               []*v1beta1.Trigger{trigger1, trigger2},
 				Deployments:            []*appsv1.Deployment{deployment1, deployment2},
 				Services:               []*corev1.Service{service1, service2},
 				Pods:                   []*corev1.Pod{pod1, pod2},
@@ -214,28 +214,28 @@ func TestGetResourcesFromClients(t *testing.T) {
 		{
 			name: "only clustertriggerbindings",
 			Resources: Resources{
-				ClusterTriggerBindings: []*v1alpha1.ClusterTriggerBinding{clusterTriggerBinding1, clusterTriggerBinding2},
+				ClusterTriggerBindings: []*v1beta1.ClusterTriggerBinding{clusterTriggerBinding1, clusterTriggerBinding2},
 			},
 		},
 		{
 			name: "only eventlisteners (and namespaces)",
 			Resources: Resources{
 				Namespaces:     []*corev1.Namespace{nsFoo, nsTektonPipelines},
-				EventListeners: []*v1alpha1.EventListener{eventListener1, eventListener2},
+				EventListeners: []*v1beta1.EventListener{eventListener1, eventListener2},
 			},
 		},
 		{
 			name: "only triggerBindings (and namespaces)",
 			Resources: Resources{
 				Namespaces:      []*corev1.Namespace{nsFoo, nsTektonPipelines},
-				TriggerBindings: []*v1alpha1.TriggerBinding{triggerBinding1, triggerBinding2},
+				TriggerBindings: []*v1beta1.TriggerBinding{triggerBinding1, triggerBinding2},
 			},
 		},
 		{
 			name: "only triggerTemplates (and namespaces)",
 			Resources: Resources{
 				Namespaces:       []*corev1.Namespace{nsFoo, nsTektonPipelines},
-				TriggerTemplates: []*v1alpha1.TriggerTemplate{triggerTemplate1, triggerTemplate2},
+				TriggerTemplates: []*v1beta1.TriggerTemplate{triggerTemplate1, triggerTemplate2},
 			},
 		},
 		{

--- a/test/params.go
+++ b/test/params.go
@@ -16,10 +16,10 @@ limitations under the License.
 
 package test
 
-import "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+import "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 
 // CompareParams can be used with comparison options such as `cmpopts.SortSlices`
 // so we can ignore the ordering of params.
-func CompareParams(x, y v1alpha1.Param) bool {
+func CompareParams(x, y v1beta1.Param) bool {
 	return x.Name < y.Name
 }


### PR DESCRIPTION
The reconciler and sink code now use v1beta1 Triggers types instead of v1alpha1
ones. The v1beta1 type has also been enabled as the storage type. This should
be a backwards compatible change. Users should still be able to use the
v1alpha1 types as they have before.

Part of #1067

Signed-off-by: Dibyo Mukherjee <dibyo@google.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
