### PR TITLE
Add details to Interceptor docs.

### DIFF
--- a/docs/clusterinterceptors.md
+++ b/docs/clusterinterceptors.md
@@ -56,5 +56,5 @@ The Kubernetes object running the custom business logic for your `ClusterInterce
 - Accepts an HTTP `POST` request that contains an [`InterceptorRequest`](https://pkg.go.dev/github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1#InterceptorRequest) 
   as a JSON body
 - Returns an HTTP 200 OK response that contains an [`InterceptorResponse`](https://pkg.go.dev/github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1#InterceptorResponse) 
-  as a JSON body
-- Returns a response other than HTTP 200 OK only if payload processing halts due to a catastrophic failure
+  as a JSON body. If the trigger processing should continue, the interceptor should set the `continue` field in the response to `true`. If the processing should be stopped, the interceptor should set the `continue` field to `false` and also provide additional information detailing the error in the `status` field.
+- Returns a response other than HTTP 200 OK only if payload processing halts due to a catastrophic failure. 

--- a/docs/interceptors.md
+++ b/docs/interceptors.md
@@ -462,12 +462,19 @@ spec:
 
 ### Chaining `Interceptors`
 
-**Note:** This section documents the current behavior for passing data between interceptors. New behavior is currently being implemented in [PR 271](https://github.com/tektoncd/triggers/issues/271).
-
 You can chain `Interceptors` with the following constraints:
 
-- CEL `Interceptors` do not modify the body of the event payload; instead, they add extra fields to the top-level `extensions` field.
+- `ClusterInterceptors` do not modify the body of the event payload; instead, they add extra fields to the top-level `extensions` field.
+
 - Webhook `Interceptors` can modify the body of the event payload, but cannot access the top-level `extensions` field.
+
+#### Chaining ClusterInterceptors
+
+Each ClusterInterceptor can return values in the InterceptorResponse within the `extensions` field. These values are then added to the `extensions` field of the InterceptorRequest that is sent to the next interceptor in the chain. 
+
+If two interceptors return an extensions field with the same name, the latter one will overwrite the one from the previous one i.e. if interceptors A and B both return `foo` in the Extensions field of the InterceptorResponse, the values written by B will overwrite the ones written by A. To prevent this, it is recommended that each cluster interceptor write to its own top level field i.e A returns `A.foo` and B return `B.foo` in the InterceptorResponse.
+
+#### Chaining Webhook Interceptors
 
 **Note:** We are working on changing the behavior of Webhook `Interceptors` to match that of CEL `Interceptors` so that both `Interceptor` types can share data via the top-level `extensions` field.
 


### PR DESCRIPTION
# Changes

This PR adds some additional details on interceptor documentation. 
1. It adds details on how interceptor authors should response when processing should be stopped, and 
2. It clarifies how chaining works with ClusterInterceptors

Fixes #1057 
Fixes #1056
Fixes #973 

/kind documentation

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
