### PR TITLE
Send EL response before Triggers finish processing 

### DIFF
--- a/cmd/eventlistenersink/main.go
+++ b/cmd/eventlistenersink/main.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	dynamicClientset "github.com/tektoncd/triggers/pkg/client/dynamic/clientset"
@@ -151,6 +152,7 @@ func main() {
 		Logger:                 logger,
 		Recorder:               recorder,
 		Auth:                   sink.DefaultAuthOverride{},
+		WGProcessTriggers:      &sync.WaitGroup{},
 		// Register all the listers we'll need
 		EventListenerLister:         factory.Triggers().V1beta1().EventListeners().Lister(),
 		TriggerLister:               factory.Triggers().V1beta1().Triggers().Lister(),

--- a/cmd/triggerrun/cmd/root.go
+++ b/cmd/triggerrun/cmd/root.go
@@ -28,6 +28,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"sync"
 
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/triggers/pkg/apis/triggers"
@@ -261,6 +262,7 @@ func newSink(config *rest.Config, sugerLogger *zap.SugaredLogger) sink.Sink {
 		KubeClientSet:          kubeClient,
 		HTTPClient:             http.DefaultClient,
 		Auth:                   sink.DefaultAuthOverride{},
+		WGProcessTriggers:      &sync.WaitGroup{},
 		DiscoveryClient:        sinkClients.DiscoveryClient,
 		DynamicClient:          dynamicCS,
 		Logger:                 sugerLogger,

--- a/cmd/triggerrun/cmd/root_test.go
+++ b/cmd/triggerrun/cmd/root_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http/httputil"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -233,8 +234,9 @@ func Test_processTriggerSpec(t *testing.T) {
 			logger := zaptest.NewLogger(t).Sugar()
 			kubeClient, triggerClient := getFakeTriggersClient(t, tt.args.resources)
 			s := sink.Sink{
-				KubeClientSet: kubeClient,
-				HTTPClient:    http.DefaultClient,
+				KubeClientSet:     kubeClient,
+				HTTPClient:        http.DefaultClient,
+				WGProcessTriggers: &sync.WaitGroup{},
 			}
 			got, err := processTriggerSpec(kubeClient, triggerClient, tt.args.t, tt.args.request, tt.args.event, eventID, logger, s)
 			if (err != nil) != tt.wantErr {

--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -370,8 +370,9 @@ metadata:
 
 ## Understanding `EventListener` response
 
-An `EventListener` responds with a `201 CREATED` HTTP response when at least one specified `Trigger` executes successfully.
-Otherwise, it responds with a `202 ACCEPTED` HTTP response. 
+An `EventListener` responds with a `202 ACCEPTED` HTTP response when the `EventListener`
+has been able to process the request and selected the appropriate triggers to process
+based off the `EventListener` configuration. 
 
 After detecting an event, the `EventListener` responds with the following message:
 

--- a/examples/bitbucket/README.md
+++ b/examples/bitbucket/README.md
@@ -28,7 +28,7 @@ Creates an EventListener that listens for Bitbucket webhook events.
    http://localhost:8080
    ```
 
-   The response status code should be `201 Created`
+   The response status code should be `202 Accepted`
 
    [`HMAC`](https://www.freeformatter.com/hmac-generator.html) tool used to create X-Hub-Signature.
 

--- a/examples/custom-resource/README.md
+++ b/examples/custom-resource/README.md
@@ -21,7 +21,7 @@ Creates an EventListener that listens for GitHub webhook events.
    http://<el_address>
    ```
 
-   The response status code is `201 Created`
+   The response status code should be `202 Accepted`
    
    [`HMAC`](https://www.freeformatter.com/hmac-generator.html) tool used to create X-Hub-Signature.
    

--- a/examples/eventlistener-tls-connection/README.md
+++ b/examples/eventlistener-tls-connection/README.md
@@ -64,7 +64,7 @@ This request will be processed by the owner of the root key to generate the cert
    https://<el-address> --cacert rootCA.crt --key client.key --cert client.crt
    ```
 
-   The response status code should be `201 Created`
+   The response status code should be `202 Accepted`
    
    [`HMAC`](https://www.freeformatter.com/hmac-generator.html) tool used to create X-Hub-Signature.
    

--- a/examples/github/README.md
+++ b/examples/github/README.md
@@ -29,7 +29,7 @@ Creates an EventListener that listens for GitHub webhook events.
    http://localhost:8080
    ```
 
-   The response status code should be `201 Created`
+   The response status code should be `202 Accepted`
 
    [`HMAC`](https://www.freeformatter.com/hmac-generator.html) tool used to create X-Hub-Signature.
 

--- a/examples/gitlab/README.md
+++ b/examples/gitlab/README.md
@@ -29,7 +29,7 @@ Creates an EventListener that listens for GitLab webhook events.
    http://localhost:8080
    ```
 
-   The response status code should be `201 Created`
+   The response status code should be `202 Accepted`
 
 1. You should see a new TaskRun that got created:
 

--- a/examples/selectors/label/README.md
+++ b/examples/selectors/label/README.md
@@ -31,7 +31,7 @@ Creates an EventListener that serve triggers selected via a label selector.
        -H 'Content-Type: application/json' \
        -d '{"head_commit":{"id":"28911bbb5a3e2ea034daf1f6be0a822d50e31e73"},"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git", "url":"https://github.com/tektoncd/triggers.git"}}' http://localhost:8000   ```
 
-   The response status code should be `201 Created`
+   The response status code should be `202 Accepted`
 
 4. You should see a single new Pipelinerun gets created, even though there are two triggers that would match the request data in the `foo` namespace
 

--- a/examples/selectors/namespace/README.md
+++ b/examples/selectors/namespace/README.md
@@ -31,7 +31,7 @@ Creates an EventListener that serve triggers in multiple namespaces.
        -H 'Content-Type: application/json' \
        -d '{"head_commit":{"id":"28911bbb5a3e2ea034daf1f6be0a822d50e31e73"},"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git", "url":"https://github.com/tektoncd/triggers.git"}}' http://localhost:8000   ```
 
-   The response status code should be `201 Created`
+   The response status code should be `202 Accepted`
 
 4. You should see a new Pipelinerun that got created:
 

--- a/examples/v1alpha1-task/README.md
+++ b/examples/v1alpha1-task/README.md
@@ -27,7 +27,7 @@ Creates an EventListener that creates a v1alpha1 TaskRun.
    http://localhost:8080
    ```
 
-   The response status code should be `201 Created`
+   The response status code should be `202 Accepted`
 
 1. You should see a new TaskRun that got created:
 

--- a/pkg/sink/metrics_test.go
+++ b/pkg/sink/metrics_test.go
@@ -3,6 +3,7 @@ package sink
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"testing"
 
 	"go.opencensus.io/stats/view"
@@ -67,7 +68,8 @@ func TestRecordResourceCreation(t *testing.T) {
 			}
 			r, _ := NewRecorder()
 			s := &Sink{
-				Recorder: r,
+				Recorder:          r,
+				WGProcessTriggers: &sync.WaitGroup{},
 			}
 			s.recordResourceCreation(test.resources)
 			rows, err := view.RetrieveData("triggered_resources")

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -19,7 +19,6 @@ package sink
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -28,9 +27,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -55,12 +51,10 @@ import (
 	"go.uber.org/zap/zaptest"
 	"go.uber.org/zap/zaptest/observer"
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	discoveryclient "k8s.io/client-go/discovery"
-	"k8s.io/client-go/dynamic"
+	"k8s.io/apimachinery/pkg/types"
 	fakedynamic "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
 	corev1lister "k8s.io/client-go/listers/core/v1"
@@ -154,6 +148,7 @@ func getSinkAssets(t *testing.T, resources test.Resources, elName string, webhoo
 		HTTPClient:                  httpClient,
 		Logger:                      logger.Sugar(),
 		Auth:                        DefaultAuthOverride{},
+		WGProcessTriggers:           &sync.WaitGroup{},
 		Recorder:                    recorder,
 		EventListenerLister:         eventlistenerinformer.Get(ctx).Lister(),
 		TriggerLister:               triggerinformer.Get(ctx).Lister(),
@@ -215,12 +210,12 @@ func toTaskRun(t *testing.T, actions []ktesting.Action) []pipelinev1.TaskRun {
 	return trs
 }
 
-// checkSinkResponse checks that the sink response status code is 201 and that
+// checkSinkResponse checks that the sink response status code is 202 and that
 // the body returns the EventListener, namespace, and eventID.
 func checkSinkResponse(t *testing.T, resp *http.Response, elName string) {
 	t.Helper()
-	if resp.StatusCode != http.StatusCreated {
-		t.Fatalf("expected response code 201 but got: %v", resp.Status)
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("expected response code 202 but got: %v", resp.Status)
 	}
 	var gotBody Response
 	if err := json.NewDecoder(resp.Body).Decode(&gotBody); err != nil {
@@ -916,6 +911,7 @@ func TestHandleEvent(t *testing.T) {
 				t.Fatalf("error sending request: %s", err)
 			}
 			checkSinkResponse(t, resp, elName)
+			sink.WGProcessTriggers.Wait()
 			// Check right resources were created.
 			got := toTaskRun(t, dynamicClient.Actions())
 
@@ -925,173 +921,6 @@ func TestHandleEvent(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want, got, cmpopts.SortSlices(compareTaskRuns)); diff != "" {
 				t.Errorf("Created resources mismatch (-want + got): %s", diff)
-			}
-		})
-	}
-}
-
-// Setup for TestHandleEvent_AuthOverride
-const userWithPermissions = "user-with-permissions"
-const userWithoutPermissions = "user-with-no-permissions"
-const userWithForbiddenAccess = "user-forbidden"
-
-var triggerAuthWG sync.WaitGroup
-
-type fakeAuth struct {
-}
-
-func (r fakeAuth) OverrideAuthentication(sa string, _ string, _ *zap.SugaredLogger, defaultDiscoverClient discoveryclient.ServerResourcesInterface,
-	defaultDynamicClient dynamic.Interface) (discoveryclient.ServerResourcesInterface, dynamic.Interface, error) {
-	dynamicClient := fakedynamic.NewSimpleDynamicClient(runtime.NewScheme())
-	dynamicSet := dynamicclientset.New(tekton.WithClient(dynamicClient))
-	switch sa {
-	case userWithoutPermissions:
-		dynamicClient.PrependReactor("*", "*", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
-			defer triggerAuthWG.Done()
-			return true, nil, kerrors.NewUnauthorized(sa + " unauthorized")
-		})
-	case userWithForbiddenAccess:
-		dynamicClient.PrependReactor("*", "*", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
-			defer triggerAuthWG.Done()
-			return true, nil, kerrors.NewForbidden(schema.GroupResource{}, sa, errors.New("action not Allowed"))
-		})
-	}
-	return defaultDiscoverClient, dynamicSet, nil
-}
-
-func TestHandleEvent_AuthOverride(t *testing.T) {
-	for _, testCase := range []struct {
-		userVal    string
-		statusCode int
-	}{{
-		userVal:    userWithoutPermissions,
-		statusCode: http.StatusUnauthorized,
-	}, {
-		userVal:    userWithPermissions,
-		statusCode: http.StatusCreated,
-	}, {
-		userVal:    userWithForbiddenAccess,
-		statusCode: http.StatusForbidden,
-	},
-	} {
-		t.Run(testCase.userVal, func(t *testing.T) {
-			eventBody := json.RawMessage(`{"head_commit": {"id": "testrevision"}, "repository": {"url": "testurl"}}`)
-			trigger := &triggersv1beta1.Trigger{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "git-clone-trigger",
-					Namespace: namespace,
-				},
-				Spec: triggersv1beta1.TriggerSpec{
-					ServiceAccountName: testCase.userVal,
-					Interceptors: []*triggersv1beta1.EventInterceptor{{
-						Ref: triggersv1beta1.InterceptorRef{Name: "github"},
-						Params: []triggersv1beta1.InterceptorParams{{
-							Name: "secretRef",
-							Value: test.ToV1JSON(t, &triggersv1beta1.SecretRef{
-								SecretKey:  "secretKey",
-								SecretName: "secret",
-							}),
-						}, {
-							Name:  "eventTypes",
-							Value: test.ToV1JSON(t, []string{"pull_request"}),
-						}},
-					}},
-					Bindings: []*triggersv1beta1.TriggerSpecBinding{{
-						Name:  "url",
-						Value: ptr.String("$(body.repository.url)"),
-					}},
-					Template: triggersv1beta1.TriggerSpecTemplate{
-						Spec: &triggersv1beta1.TriggerTemplateSpec{
-							Params: []triggersv1beta1.ParamSpec{
-								{Name: "url"},
-								{Name: "revision", Default: ptr.String("master")},
-								{Name: "name", Default: ptr.String("git-clone-test-run")},
-								{Name: "app", Default: ptr.String("triggers")},
-								{Name: "type", Default: ptr.String("bar")},
-							},
-							ResourceTemplates: []triggersv1beta1.TriggerResourceTemplate{{
-								RawExtension: trResourceTemplate(t),
-							}},
-						},
-					},
-				},
-			}
-			authSecret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testCase.userVal,
-					Namespace: testCase.userVal,
-					Annotations: map[string]string{
-						corev1.ServiceAccountNameKey: testCase.userVal,
-						corev1.ServiceAccountUIDKey:  testCase.userVal,
-					},
-				},
-				Type: corev1.SecretTypeServiceAccountToken,
-				Data: map[string][]byte{
-					corev1.ServiceAccountTokenKey: []byte(testCase.userVal),
-				},
-			}
-			authSA := &corev1.ServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testCase.userVal,
-					Namespace: testCase.userVal,
-				},
-				Secrets: []corev1.ObjectReference{{
-					Name:      testCase.userVal,
-					Namespace: testCase.userVal,
-				}},
-			}
-
-			el := &triggersv1beta1.EventListener{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "el",
-					Namespace: namespace,
-				},
-				Spec: triggersv1beta1.EventListenerSpec{
-					Triggers: []triggersv1beta1.EventListenerTrigger{{TriggerRef: "git-clone-trigger"}},
-				},
-			}
-			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "secret",
-					Namespace: namespace,
-				},
-				Data: map[string][]byte{
-					"secretKey": []byte("secret"),
-				},
-			}
-			resources := test.Resources{
-				ClusterInterceptors: []*triggersv1alpha1.ClusterInterceptor{github},
-				Triggers:            []*triggersv1beta1.Trigger{trigger},
-				EventListeners:      []*triggersv1beta1.EventListener{el},
-				Secrets:             []*corev1.Secret{secret, authSecret},
-				ServiceAccounts:     []*corev1.ServiceAccount{authSA},
-			}
-			sink, dynamicClient := getSinkAssets(t, resources, el.Name, nil)
-			sink.Auth = fakeAuth{}
-			ts := httptest.NewServer(http.HandlerFunc(sink.HandleEvent))
-			defer ts.Close()
-
-			triggerAuthWG.Add(1)
-			dynamicClient.PrependReactor("*", "*", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
-				defer triggerAuthWG.Done()
-				return false, nil, nil
-			})
-
-			req, err := http.NewRequest("POST", ts.URL, bytes.NewReader(eventBody))
-			if err != nil {
-				t.Fatalf("Error creating Post request: %s", err)
-			}
-			req.Header.Add("Content-Type", "application/json")
-			req.Header.Add("X-Github-Event", "pull_request")
-			req.Header.Add("X-Hub-Signature", test.HMACHeader(t, "secret", eventBody))
-
-			resp, err := http.DefaultClient.Do(req)
-			if err != nil {
-				t.Fatalf("Error sending Post request: %v", err)
-			}
-
-			if resp.StatusCode != testCase.statusCode {
-				t.Fatalf("response code doesn't match: expected %d vs. actual %d, entire status %v", testCase.statusCode, resp.StatusCode, resp.Status)
 			}
 		})
 	}

--- a/test/eventlistener_test.go
+++ b/test/eventlistener_test.go
@@ -49,7 +49,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
@@ -485,60 +484,6 @@ func TestEventListenerCreate(t *testing.T) {
 		if diff := cmp.Diff(wantPr.Spec, gotPr.Spec, cmp.Comparer(compareParamsWithLicenseJSON)); diff != "" {
 			t.Errorf("Diff instantiated ResourceTemplate spec %s: -want +got: %s", wantPr.Name, diff)
 		}
-	}
-
-	// Now let's override auth at the trigger level and make sure we get a permission problem
-
-	// create SA/secret with insufficient permissions to set at trigger level
-	userWithoutPermissions := "user-with-no-permissions"
-	triggerSA := &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      userWithoutPermissions,
-			Namespace: namespace,
-			UID:       types.UID(userWithoutPermissions),
-		},
-	}
-
-	_, err = c.KubeClient.CoreV1().ServiceAccounts(namespace).Create(context.Background(), triggerSA, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("Error creating trigger SA: %s", err.Error())
-	}
-
-	if err := WaitFor(func() (bool, error) {
-		el, err := c.TriggersClient.TriggersV1alpha1().EventListeners(namespace).Get(context.Background(), el.Name, metav1.GetOptions{})
-		if err != nil {
-			return false, nil
-		}
-		for i, trigger := range el.Spec.Triggers {
-			trigger.ServiceAccountName = userWithoutPermissions
-			el.Spec.Triggers[i] = trigger
-		}
-		_, err = c.TriggersClient.TriggersV1alpha1().EventListeners(namespace).Update(context.Background(), el, metav1.UpdateOptions{})
-		if err != nil {
-			return false, nil
-		}
-		return true, nil
-	}); err != nil {
-		t.Fatalf("Failed to update EventListener for trigger auth test: %s", err)
-	}
-
-	// Verify the EventListener is ready with the new update
-	if err := WaitFor(eventListenerReady(t, c, namespace, el.Name)); err != nil {
-		t.Fatalf("EventListener not ready after trigger auth update: %s", err)
-	}
-	// Send POST request to EventListener sink
-	req, err = http.NewRequest("POST", fmt.Sprintf("http://127.0.0.1:%s", portString), bytes.NewBuffer(eventBodyJSON))
-	if err != nil {
-		t.Fatalf("Error creating POST request for trigger auth: %s", err)
-	}
-	req.Header.Add("Content-Type", "application/json")
-	resp, err = http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("Error sending POST request for trigger auth: %s", err)
-	}
-
-	if resp.StatusCode != http.StatusUnauthorized && resp.StatusCode != http.StatusForbidden {
-		t.Errorf("sink did not return 401/403 response. Got status code: %d", resp.StatusCode)
 	}
 
 	// now set the trigger SA to the original one, should not get a 401/403


### PR DESCRIPTION


# Changes

**Note**: This is @jmcshane 's PR #1077 that I rebased.

In the current version of the product, the HTTP request to the EventListener
endpoint waits for all triggers to process to determine if a resource was
created. This is not in line with the suggestion by the source control
systems for webhook endpoints. This change updates the endpoint to respond
as soon as the triggers have been selected for processing.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
BREAKING CHANGE: With this change the EventListener will stop responding with `201 Created` status code when it creates resources. Instead it will always respond with a `202 Accepted` response code.
```
