### PR TITLE
Fix the cp command in the release publish task

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -92,7 +92,7 @@ spec:
       # Setup docker-auth
       DOCKER_CONFIG=~/.docker
       mkdir -p ${DOCKER_CONFIG}
-      cp /workspace/docker-config.json ${DOCKER_CONFIG}/
+      cp /workspace/docker-config.json ${DOCKER_CONFIG}/config.json
 
       # Change to directory with our .ko.yaml
       cd ${PROJECT_ROOT}
@@ -162,7 +162,7 @@ spec:
       # Setup docker-auth
       DOCKER_CONFIG=~/.docker
       mkdir -p ${DOCKER_CONFIG}
-      cp /workspace/docker-config.json ${DOCKER_CONFIG}/
+      cp /workspace/docker-config.json ${DOCKER_CONFIG}/config.json
 
       REGIONS="us eu asia"
 


### PR DESCRIPTION
# Changes

Before Tekton Pipelines v0.24.x, $HOME and workDir were implicitly set,
which rendered the cp command redundant and hid the issue.

Partially fixes tektoncd/plumbing#856

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```