### PR TITLE
Switch branch name from master to main

### DIFF
--- a/examples/cron/triggerbinding.yaml
+++ b/examples/cron/triggerbinding.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   params:
   - name: gitrevision
-    value: master
+    value: main
   - name: gitrepositoryurl
     value: https://github.com/tektoncd/triggers


### PR DESCRIPTION
# Changes

master branch doesn't exist in https://github.com/tektoncd/triggers repo. Main is the new name.

