### PR TITLE
docs: fix formatting of code examples

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -476,10 +476,12 @@ see the [NGINX Ingress Controller Installation Guide](https://kubernetes.github.
    ```sh
    kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v0.34.1/deploy/static/provider/cloud/deploy.yaml
    ```
+   
 2. Obtain the name of your `EventListener` service:
    ```sh
     kubectl get el <EVENTLISTENR_NAME> -o=jsonpath='{.status.configuration.generatedName}{"\n"}'
    ```
+   
 3. Instantiate the `Ingress` object:
    ```yaml
    apiVersion: extensions/v1beta1
@@ -505,26 +507,29 @@ see the [NGINX Ingress Controller Installation Guide](https://kubernetes.github.
    ```   
    kubectl get ingress ingress-resource
    ``` 
-   
+
 5. Test the configuragion with `curl` or set up a GitHub Webhook that sends events to it.
 
 ## Exposing an `EventListener` using Openshift Route
 
 Below are instructions for configuring an OpenShift 4.2 cluster running API version `v1.14.6+32dc4a0`. For more information,
-see [Route Configuration]https://docs.openshift.com/container-platform/4.2/networking/routes/route-configuration.html).
+see [Route Configuration](https://docs.openshift.com/container-platform/4.2/networking/routes/route-configuration.html).
 
 1. Obtain the name of your `EventListener` service:
    ```sh
     oc get el <EVENTLISTENR_NAME> -o=jsonpath='{.status.configuration.generatedName}'
    ```
+
 2. Expose the `EventListener` service:
    ```sh
     oc expose svc/[el-listener] # REPLACE el-listener WITH YOUR SERVICE NAME FROM STEP 1
    ```
+
 3. Obtain the IP address of the exposed route:
    ```sh
     oc get route el-listener  -o=jsonpath='{.spec.host}' # REPLACE el-listener WITH YOUR SERVICE NAME FROM STEP 1
    ```
+   
 4. Test the configuragion with `curl` or set up a GitHub Webhook that sends events to it.
 
 ## Understanding the deployment of an `EventListener`
@@ -535,6 +540,7 @@ Below is a high-level walkthrough through the deployment of an `EventListener` u
    ```bash
    kubectl create -f https://github.com/tektoncd/triggers/tree/master/examples/github
    ```
+   
    Tekton Triggers creates a new `Deployment` and `Service` for the `EventListener`. using the `EventListener` definition,
    [`metadata.labels`](https://github.com/tektoncd/triggers/blob/master/docs/eventlisteners.md#labels), and pre-existing values
    such as container `Image`, `Name`, and `Port`. Tekton Triggers uses the `EventListener` name prefixed with `el-` to name the


### PR DESCRIPTION


# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Currently some of the examples don't render correctly when displayed on the docs website due to the markdown parser being stricter than GitHub's. e.g.

![CleanShot 2021-07-08 at 11 44 48](https://user-images.githubusercontent.com/4919969/124909054-ec4c6f80-dfe1-11eb-9641-8261a3cdf227.png)

This change should resolve those issues and have them display correctly both on GitHub and the website.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
NONE
```