### PR TITLE
Adds curl test in e2e tests for examples

### DIFF
--- a/examples/v1alpha1/bitbucket/curl.sh
+++ b/examples/v1alpha1/bitbucket/curl.sh
@@ -1,0 +1,5 @@
+curl -v \
+-H 'X-Event-Key: repo:refs_changed' \
+-H 'X-Hub-Signature: sha1=b3fdaf5d1a47e57527764a233659c650a11abdd8' \
+-d '{"repository": {"links": {"clone": [{"href": "http://localhost:7990/scm/~test/helloworld.git", "name": "http"}, {"href": "ssh://git@localhost:7999/~test/helloworld.git", "name": "ssh"}]}}, "changes": [{"ref": {"displayId": "main"}}]}' \
+http://localhost:8080

--- a/examples/v1alpha1/embedded-trigger/curl.sh
+++ b/examples/v1alpha1/embedded-trigger/curl.sh
@@ -1,0 +1,10 @@
+curl -X POST \
+  http://localhost:8080 \
+  -H 'Content-Type: application/json' \
+  -H 'X-Hub-Signature: sha1=2da37dcb9404ff17b714ee7a505c384758ddeb7b' \
+  -d '{
+	"repository":
+	{
+		"url": "https://github.com/tektoncd/triggers.git"
+	}
+}'

--- a/examples/v1alpha1/github/curl.sh
+++ b/examples/v1alpha1/github/curl.sh
@@ -1,0 +1,6 @@
+curl -v \
+-H 'X-GitHub-Event: pull_request' \
+-H 'X-Hub-Signature: sha1=ba0cdc263b3492a74b601d240c27efe81c4720cb' \
+-H 'Content-Type: application/json' \
+-d '{"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git"}}' \
+http://localhost:8080

--- a/examples/v1alpha1/gitlab/curl.sh
+++ b/examples/v1alpha1/gitlab/curl.sh
@@ -1,0 +1,6 @@
+curl -v \
+-H 'X-GitLab-Token: 1234567' \
+-H 'X-Gitlab-Event: Push Hook' \
+-H 'Content-Type: application/json' \
+--data-binary "@examples/v1alpha1/gitlab/gitlab-push-event.json" \
+http://localhost:8080

--- a/examples/v1alpha1/label-selector/curl.sh
+++ b/examples/v1alpha1/label-selector/curl.sh
@@ -1,0 +1,6 @@
+curl -k -v \
+-H 'X-GitHub-Event: pull_request' \
+-H 'X-Hub-Signature: sha1=8d7c4d33686fd908394208a07d997b8f5bd70aa6' \
+-H 'Content-Type: application/json' \
+-d '{"head_commit":{"id":"28911bbb5a3e2ea034daf1f6be0a822d50e31e73"},"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git", "url":"https://github.com/tektoncd/triggers.git"}}' \
+http://localhost:8080

--- a/examples/v1alpha1/namespace-selector/curl.sh
+++ b/examples/v1alpha1/namespace-selector/curl.sh
@@ -1,0 +1,6 @@
+    curl -k -v \
+    -H 'X-GitHub-Event: pull_request' \
+    -H 'X-Hub-Signature: sha1=8d7c4d33686fd908394208a07d997b8f5bd70aa6' \
+    -H 'Content-Type: application/json' \
+    -d '{"head_commit":{"id":"28911bbb5a3e2ea034daf1f6be0a822d50e31e73"},"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git", "url":"https://github.com/tektoncd/triggers.git"}}' \
+    http://localhost:8080   

--- a/examples/v1alpha1/v1alpha1-task/curl.sh
+++ b/examples/v1alpha1/v1alpha1-task/curl.sh
@@ -1,0 +1,4 @@
+curl -v \
+   -H 'Content-Type: application/json' \
+   --data "{}" \
+   http://localhost:8080

--- a/examples/v1beta1/bitbucket/curl.sh
+++ b/examples/v1beta1/bitbucket/curl.sh
@@ -1,0 +1,5 @@
+curl -v \
+-H 'X-Event-Key: repo:refs_changed' \
+-H 'X-Hub-Signature: sha1=b3fdaf5d1a47e57527764a233659c650a11abdd8' \
+-d '{"repository": {"links": {"clone": [{"href": "http://localhost:7990/scm/~test/helloworld.git", "name": "http"}, {"href": "ssh://git@localhost:7999/~test/helloworld.git", "name": "ssh"}]}}, "changes": [{"ref": {"displayId": "main"}}]}' \
+http://localhost:8080

--- a/examples/v1beta1/embedded-trigger/curl.sh
+++ b/examples/v1beta1/embedded-trigger/curl.sh
@@ -1,0 +1,10 @@
+curl -X POST \
+  http://localhost:8080 \
+  -H 'Content-Type: application/json' \
+  -H 'X-Hub-Signature: sha1=2da37dcb9404ff17b714ee7a505c384758ddeb7b' \
+  -d '{
+	"repository":
+	{
+		"url": "https://github.com/tektoncd/triggers.git"
+	}
+}'

--- a/examples/v1beta1/github/curl.sh
+++ b/examples/v1beta1/github/curl.sh
@@ -1,0 +1,6 @@
+curl -v \
+-H 'X-GitHub-Event: pull_request' \
+-H 'X-Hub-Signature: sha1=ba0cdc263b3492a74b601d240c27efe81c4720cb' \
+-H 'Content-Type: application/json' \
+-d '{"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git"}}' \
+http://localhost:8080

--- a/examples/v1beta1/gitlab/curl.sh
+++ b/examples/v1beta1/gitlab/curl.sh
@@ -1,0 +1,6 @@
+curl -v \
+-H 'X-GitLab-Token: 1234567' \
+-H 'X-Gitlab-Event: Push Hook' \
+-H 'Content-Type: application/json' \
+--data-binary "@examples/v1beta1/gitlab/gitlab-push-event.json" \
+http://localhost:8080

--- a/examples/v1beta1/label-selector/curl.sh
+++ b/examples/v1beta1/label-selector/curl.sh
@@ -1,0 +1,6 @@
+curl -k -v \
+-H 'X-GitHub-Event: pull_request' \
+-H 'X-Hub-Signature: sha1=8d7c4d33686fd908394208a07d997b8f5bd70aa6' \
+-H 'Content-Type: application/json' \
+-d '{"head_commit":{"id":"28911bbb5a3e2ea034daf1f6be0a822d50e31e73"},"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git", "url":"https://github.com/tektoncd/triggers.git"}}' \
+http://localhost:8080

--- a/examples/v1beta1/namespace-selector/curl.sh
+++ b/examples/v1beta1/namespace-selector/curl.sh
@@ -1,0 +1,6 @@
+    curl -k -v \
+    -H 'X-GitHub-Event: pull_request' \
+    -H 'X-Hub-Signature: sha1=8d7c4d33686fd908394208a07d997b8f5bd70aa6' \
+    -H 'Content-Type: application/json' \
+    -d '{"head_commit":{"id":"28911bbb5a3e2ea034daf1f6be0a822d50e31e73"},"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git", "url":"https://github.com/tektoncd/triggers.git"}}' \
+    http://localhost:8080   

--- a/test/e2e-tests-examples.sh
+++ b/test/e2e-tests-examples.sh
@@ -23,20 +23,21 @@ source $(dirname $0)/e2e-common.sh
 set -u -e -o pipefail -x
 
 current_example=""
+current_example_version=""
 yaml_files=""
+port_forward_pid=""
 
 info() {
-  echo; echo "*** Example ${current_example}: $@ ***"; echo;
+  echo; echo "*** Example ${current_example_version}/${current_example}: $@ ***"; echo;
 }
 
 err() {
-  echo; echo "ERROR: Example ${current_example}: $@"; echo;
+  echo; echo "ERROR: Example ${current_example_version}/${current_example}: $@"; echo;
 }
 
 apply_files() {
   info "Applying Resources"
-  local version=$1
-  folder=${REPO_ROOT_DIR}/examples/${version}/${current_example}
+  folder=${REPO_ROOT_DIR}/examples/${current_example_version}/${current_example}
   yaml_files=$(find ${folder}/ -name *.yaml | sort) || {
     err "failed to find files"
     exit 1
@@ -53,17 +54,76 @@ check_eventlistener() {
   info "Waiting for EventListener to be available"
 
   elName=${current_example}-listener
-  kubectl wait --for=condition=Ready --timeout=20s eventlisteners/${elName} || {
+  kubectl wait --for=condition=Ready --timeout=20s eventlisteners/${elName}  || {
     err "eventlistener failed to get in running state"
     exit 1
   }
   kubectl get eventlisteners
 }
 
+ignoreExamples=( cron trigger-ref v1alpha1-task )
+
+port_forward_and_curl() {
+
+   if [[ $version == "v1beta1" ]]; then
+    info "ignoring for now"
+  fi
+
+  if [[ " ${ignoreExamples[@]} " =~ " ${current_example} " ]]; then
+    info 'ignoring for port forwarding'
+    return
+  fi
+
+  info "Port forwarding to execute curl command"
+
+  kubectl port-forward service/el-${current_example}-listener 8080 &
+  port_forward_pid=$!
+
+  # Wait a few seconds for forwarding to happen
+  sleep 3
+
+  response=$(bash ${REPO_ROOT_DIR}/examples/${current_example_version}/${current_example}/curl.sh)
+
+  echo; echo "response received: $response"; echo
+
+  eventID=$(jq -n "$response" | jq --raw-output '.eventID')
+
+  if [ -z "$eventID" ]
+  then
+     err "failed to get eventID"
+     exit 1
+  fi
+
+  tr=$(kubectl get taskruns -A -l triggers.tekton.dev/triggers-eventid=${eventID} -o name)
+  pr=$(kubectl get pipelineruns -A -l triggers.tekton.dev/triggers-eventid=${eventID} -o name)
+
+  if [ -z "$tr" ] && [ -z "$pr" ]
+  then
+     err "failed to create taskrun/pipelinerun"
+     exit 1
+  fi
+
+  if [ -z "$tr" ]
+  then
+    echo "PipelineRun created : $pr"
+  else
+    echo "Taskrun created : $tr"
+  fi
+
+  kill $port_forward_pid
+}
+
+create_example_pipeline() {
+  kubectl apply -f ${REPO_ROOT_DIR}/examples/example-pipeline.yaml || {
+      err "failed to apply example pipeline"
+      exit 1
+  }
+}
+
 trap "cleanup" EXIT SIGINT
 cleanup() {
   info "Cleaning up resources"
-
+  kill $port_forward_pid || true
   for y in ${yaml_files}; do
     kubectl delete -f ${y} --ignore-not-found || true
   done
@@ -75,20 +135,23 @@ cleanup() {
 main() {
   versions="v1alpha1 v1beta1"
   # List of examples test will run on
-  examples="bitbucket cron embedded-trigger github gitlab label-selector namespace-selector trigger-ref v1alpha1-task"
-
+  examples="bitbucket cron embedded-trigger github gitlab label-selector namespace-selector v1alpha1-task trigger-ref"
+  create_example_pipeline
   for v in ${versions}; do
+    current_example_version=${v}
     echo "Applying examples for version: ${v}"
     for e in ${examples}; do
       current_example=${e}
-      echo "*** Example ${current_example} ***";
-      apply_files ${v}
+      echo "*** Example ${current_example_version}/${current_example} ***";
+      apply_files
       check_eventlistener
+      port_forward_and_curl
       cleanup
       info "Test Successful"
     done
   done
+
+  echo; echo "*** Completed Examples Test Successfully ***"; echo;
 }
 
 main $@
-

--- a/test/e2e-tests-examples.sh
+++ b/test/e2e-tests-examples.sh
@@ -65,10 +65,6 @@ ignoreExamples=( cron trigger-ref v1alpha1-task )
 
 port_forward_and_curl() {
 
-   if [[ $version == "v1beta1" ]]; then
-    info "ignoring for now"
-  fi
-
   if [[ " ${ignoreExamples[@]} " =~ " ${current_example} " ]]; then
     info 'ignoring for port forwarding'
     return


### PR DESCRIPTION
In the present e2e test for examples this adds port forwading the
event listener and then doing a curl to test if a taskrun/pipelinerun
is created.

Ignored examples: `( cron trigger-ref v1alpha1-task )`

Part of #192 

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
