### PR TITLE
Declares named metrics ports

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -77,6 +77,9 @@ spec:
           value: tekton.dev/triggers
         - name: METRICS_PROMETHEUS_PORT
           value: "9000"
+        ports:
+        - name: metrics
+          containerPort: 9000
         securityContext:
           allowPrivilegeEscalation: false
           # User 65532 is the distroless nonroot user ID

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -69,7 +69,7 @@ spec:
           value: tekton.dev/triggers
         ports:
         - name: metrics
-          containerPort: 9000
+          containerPort: 9090
         - name: profiling
           containerPort: 8008
         - name: https-webhook


### PR DESCRIPTION
# Changes

Adds `metrics` port to controller deployment and fixes the port number for the same name for webhook.

Named ports are useful for prometheus-operator [podMetricsEndpoints](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#podmetricsendpoint).

The port number for webhook wasn't the actual port number for the released image.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```

