### PR TITLE
Update docs for clusterroles packaged for eventlistener

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -71,11 +71,14 @@ See our [Tekton Triggers examples](https://github.com/tektoncd/triggers/tree/mas
 ## Specifying the Kubernetes service account
 
 You must specify a Kubernetes service account in the `serviceAccountName` field that the `EventListener` will use to instantiate Tekton objects.
-This account must have the following assigned:
-- A Kubernetes `Role` that permits the `get`, `list`, and `watch` verbs for each `Trigger` specified in the `EventListener`
-- A Kubernetes `ClusterRole` that permits read access to `ClusterTriggerBindings` objects
-- Permissions to create the Tekton resources specified in the associated `TriggerTemplate`, as shown in the following [example](../examples/rbac.yaml)
-- If you're using `namespaceSelectors` in your `EventListener`, a `ClusterRole` that permits read access to all `Trigger` objects on the cluster.ources across the cluster.
+
+Tekton Trigger creates 2 clusterroles while installing with necessary permissions required for an eventlistener. You can directly create bindings for your serviceaccount with the clusterroles.
+- A Kubernetes RoleBinding with `tekton-triggers-eventlistener-roles` clusterrole.
+- A Kubernetes ClusterRoleBinding with `tekton-triggers-eventlistener-clusterroles` clusterrole.
+  
+  You can checkout an example [here](../examples/rbac.yaml).
+- If you're using `namespaceSelectors` in your `EventListener`, you will have to create an additional `ClusterRoleBinding ` 
+  with `tekton-triggers-eventlistener-roles` clusterrole.
 
 ## Specifying `Triggers`
 


### PR DESCRIPTION
This update docs to use clusterroles packaged with triggers instead
of creating new roles for eventlistener.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
