### PR TITLE
Remove Redundant Status Tag from EL Metrics

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -441,10 +441,10 @@ kubectl get pods --selector eventlistener=my-eventlistener
 The following pipeline metrics are available on the `eventlistener` Service on port `9000`.
 
 |  Name | Type | Labels/Tags | Status |
-| ---------- | ----------- | ----------- | ----------- |
+| ---------- | ----------- | :-: | ----------- |
 | `eventlistener_triggered_resources` | Counter | `kind`=&lt;kind&gt; | experimental |
-| `eventlistener_event_count` | Counter | `status`=&lt;status&gt; <br> | experimental |
-| `eventlistener_http_duration_seconds_[bucket, sum, count]` | Histogram | `status`=&lt;status&gt; <br> | experimental |
+| `eventlistener_event_count` | Counter | - | experimental |
+| `eventlistener_http_duration_seconds_[bucket, sum, count]` | Histogram | - | experimental |
 
 Several kinds of exporters can be configured for an `EventListener`, including Prometheus, Google Stackdriver, and many others.
 You can configure metrics using the [`config-observability-triggers` config map](../config/config-observability.yaml) in the `EventListener` namespaces.

--- a/pkg/sink/metrics.go
+++ b/pkg/sink/metrics.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
-	"strconv"
 	"time"
 
 	"go.opencensus.io/stats"
@@ -53,7 +52,6 @@ func NewRecorder() (*Recorder, error) {
 			Description: elDuration.Description(),
 			Measure:     elDuration,
 			Aggregation: elDistribution,
-			TagKeys:     []tag.Key{r.status},
 		},
 		&view.View{
 			Description: triggeredResources.Description(),
@@ -65,7 +63,6 @@ func NewRecorder() (*Recorder, error) {
 			Description: eventCount.Description(),
 			Measure:     eventCount,
 			Aggregation: view.Count(),
-			TagKeys:     []tag.Key{r.status},
 		},
 	)
 	if err != nil {
@@ -97,7 +94,6 @@ func (s *Sink) recordMetrics(w *StatusRecorder, elapsed time.Duration) {
 	s.Logger.Debugw("event listener request completed", "status", w.Status, "duration", duration)
 	ctx, err := tag.New(
 		context.Background(),
-		tag.Insert(s.Recorder.status, strconv.Itoa(w.Status)),
 	)
 
 	if err != nil {

--- a/pkg/sink/metrics_test.go
+++ b/pkg/sink/metrics_test.go
@@ -103,17 +103,11 @@ func TestRecordResourceCreation(t *testing.T) {
 func TestRecordRecordMetrics(t *testing.T) {
 	tests := []struct {
 		name             string
-		status           int
-		expectedTags     map[string]string
 		duration         time.Duration
 		expectedDuration float64
 		expectedCount    int64
 	}{{
-		name:   "Record Metrics",
-		status: 200,
-		expectedTags: map[string]string{
-			"status": "200",
-		},
+		name:             "Record Metrics",
 		duration:         7,
 		expectedDuration: 7e-09,
 		expectedCount:    1,
@@ -137,8 +131,8 @@ func TestRecordRecordMetrics(t *testing.T) {
 				Logger:   logger,
 			}
 			s.recordMetrics(&StatusRecorder{Status: 200}, test.duration)
-			metricstest.CheckDistributionData(t, "http_duration_seconds", test.expectedTags, 1, test.expectedDuration, test.expectedDuration)
-			metricstest.CheckCountData(t, "event_count", test.expectedTags, test.expectedCount)
+			metricstest.CheckDistributionData(t, "http_duration_seconds", nil, 1, test.expectedDuration, test.expectedDuration)
+			metricstest.CheckCountData(t, "event_count", nil, test.expectedCount)
 		})
 	}
 }


### PR DESCRIPTION
Removing the status tag from event_count and http_duration_seconds because it is always 200.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Remove Redundant Status Tag from EventListener Metrics. 
Breaking Change:
Status label has been removed from metric eventlistener_http_duration_seconds_*. Please remove querying base on status label.
```

