### PR TITLE
Add probes to custom resources(Knative Service)

### DIFF
--- a/pkg/reconciler/eventlistener/eventlistener.go
+++ b/pkg/reconciler/eventlistener/eventlistener.go
@@ -66,7 +66,7 @@ const (
 	// eventListenerServiceTLSPortName defines service TLS port name for EventListener Service
 	eventListenerServiceTLSPortName = "https-listener"
 	// eventListenerContainerPort defines the port exposed by the EventListener Container
-	eventListenerContainerPort = 8000
+	eventListenerContainerPort = 8080
 	// GeneratedResourcePrefix is the name prefix for resources generated in the
 	// EventListener reconciler
 	GeneratedResourcePrefix = "el"
@@ -486,6 +486,16 @@ func (r *Reconciler) reconcileCustomObject(ctx context.Context, logger *zap.Suga
 		Value: os.Getenv("METRICS_PROMETHEUS_PORT"),
 	})
 
+	container.ReadinessProbe = &corev1.Probe{
+		Handler: corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path:   "/live",
+				Scheme: corev1.URISchemeHTTP,
+			},
+		},
+		SuccessThreshold: 1,
+	}
+
 	podlabels := mergeMaps(el.Labels, GenerateResourceLabels(el.Name, r.config.StaticResourceLabels))
 
 	podlabels = mergeMaps(podlabels, customObjectData.Labels)
@@ -626,6 +636,10 @@ func (r *Reconciler) reconcileCustomObject(ctx context.Context, logger *zap.Suga
 			}
 			if !reflect.DeepEqual(existingObject.Spec.Template.Spec.Containers[0].Env, container.Env) {
 				existingObject.Spec.Template.Spec.Containers[0].Env = container.Env
+				updated = true
+			}
+			if !reflect.DeepEqual(existingObject.Spec.Template.Spec.Containers[0].ReadinessProbe, container.ReadinessProbe) {
+				existingObject.Spec.Template.Spec.Containers[0].ReadinessProbe = container.ReadinessProbe
 				updated = true
 			}
 			if !reflect.DeepEqual(existingObject.Spec.Template.Spec.Containers[0].VolumeMounts, originalObject.Spec.Template.Spec.Containers[0].VolumeMounts) {

--- a/pkg/reconciler/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/eventlistener/eventlistener_test.go
@@ -465,6 +465,15 @@ func makeWithPod(ops ...func(d *duckv1.WithPod)) *duckv1.WithPod {
 							Name:  "METRICS_PROMETHEUS_PORT",
 							Value: "9000",
 						}},
+						ReadinessProbe: &corev1.Probe{
+							Handler: corev1.Handler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path:   "/live",
+									Scheme: corev1.URISchemeHTTP,
+								},
+							},
+							SuccessThreshold: 1,
+						},
 					}},
 					Volumes: []corev1.Volume{{
 						Name: "config-logging",

--- a/test/eventlistener_test.go
+++ b/test/eventlistener_test.go
@@ -388,7 +388,7 @@ func TestEventListenerCreate(t *testing.T) {
 	}
 
 	// ElPort forward sink pod for http request
-	portString := strconv.Itoa(8000)
+	portString := strconv.Itoa(8080)
 	podName := sinkPods.Items[0].Name
 	stopChan, errChan := make(chan struct{}, 1), make(chan error, 1)
 


### PR DESCRIPTION
# Changes
Fixes: https://github.com/tektoncd/triggers/issues/1069

Added probes to custom object (Knative Service) so that pod receives request when it actually ready.

**Note:** Modified containerPort to `8080` because Readiness and Liveness Probe require port for  `HTTP` and Knative won't allow users to set the `port` instead by default use `8080` thats the reason modified `8000` to `8080` 
For more info: https://github.com/tektoncd/triggers/issues/1069#issuecomment-886672827

/cc @Fabian-K @dibyom 
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
1. Add Readiness and Liveness Probes for Knative service
2. EventListener pod runs on 8080 instead of 8000 port
```