### PR TITLE
Add SetSecuritycontext for EventListener in Controller.yaml

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -57,6 +57,7 @@ spec:
           "-stderrthreshold", "INFO",
           "-el-image", "ko://github.com/tektoncd/triggers/cmd/eventlistenersink",
           "-el-port", "8080",
+          "-el-security-context=true",
           "-el-readtimeout", "5",
           "-el-writetimeout", "40",
           "-el-idletimeout", "120",


### PR DESCRIPTION
Put it in the controller.yaml so that a user can refer release.yaml to configure this value instead of digging in the code.
Potentially enable us to run EL in OKD: #1172
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes


```release-note
SetSecuritycontext for EventListener in controller deployment can be configured now.
```