### PR TITLE
docs: fix formatting of md so list display in HTML

### DIFF
--- a/docs/clusterinterceptors.md
+++ b/docs/clusterinterceptors.md
@@ -16,6 +16,7 @@ top-level `extensions` field to other [`Interceptors`](interceptors.md) and `Clu
 ## Structure of a `ClusterInterceptor`
 
 A `ClusterInterceptor` definition consists of the following fields:
+
 - Required:
   - [`apiVersion`][kubernetes-overview] - specifies the target API version, for example `triggers.tekton.dev/v1alpha1`
   - [`kind`][kubernetes-overview] - specifies that this Kubernetes resource is a `ClusterInterceptor` object
@@ -30,6 +31,7 @@ A `ClusterInterceptor` definition consists of the following fields:
 
 The `clientConfig` field specifies the client, such as an `EventListener` and how it communicates with the `ClusterInterceptor` to exchange
 event payload and other data. You can configure this field in one of the following ways:
+
 - Specify the `url` field and as its value a URL at which the corresponding Kubernetes service listens for incoming requests from this `ClusterInterceptor`
 - Specify the `service` field and within it reference the corresponding Kubernetes service that's listening for incoming requests from this `ClusterInterceptor`
 
@@ -52,6 +54,7 @@ spec:
 ## Configuring a Kubernetes Service for the `ClusterInterceptor`
 
 The Kubernetes object running the custom business logic for your `ClusterInterceptor` must meet the following criteria:
+
 - Fronted by a regular Kubernetes v1 Service listening on an HTTP port (default port is 80)
 - Accepts an HTTP `POST` request that contains an [`InterceptorRequest`](https://pkg.go.dev/github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1#InterceptorRequest) 
   as a JSON body


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

The lists dont currently render on the HTML page (https://tekton.dev/docs/triggers/clusterinterceptors/) due to the markdown processor being stricter than that used by GitHub. The additional spaces around the lists should allow them to be parsed into `<ul>` tags in the resulting HTML.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
