### PR TITLE
Add Status Tag to Event Count Metrics

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -446,7 +446,7 @@ The following pipeline metrics are available on the `eventlistener` Service on p
 |  Name | Type | Labels/Tags | Status |
 | ---------- | ----------- | :-: | ----------- |
 | `eventlistener_triggered_resources` | Counter | `kind`=&lt;kind&gt; | experimental |
-| `eventlistener_event_count` | Counter | - | experimental |
+| `eventlistener_event_count` | Counter | `status`=&lt;status&gt; | experimental |
 | `eventlistener_http_duration_seconds_[bucket, sum, count]` | Histogram | - | experimental |
 
 Several kinds of exporters can be configured for an `EventListener`, including Prometheus, Google Stackdriver, and many others.

--- a/pkg/sink/metrics.go
+++ b/pkg/sink/metrics.go
@@ -26,6 +26,11 @@ var (
 	triggeredResources = stats.Int64("triggered_resources", "Count of the number of triggered eventlistener resources", stats.UnitDimensionless)
 )
 
+const (
+	failTag    = "failed"
+	successTag = "succeeded"
+)
+
 // NewRecorder creates a new metrics recorder instance
 // to log the TaskRun related metrics
 func NewRecorder() (*Recorder, error) {
@@ -63,6 +68,7 @@ func NewRecorder() (*Recorder, error) {
 			Description: eventCount.Description(),
 			Measure:     eventCount,
 			Aggregation: view.Count(),
+			TagKeys:     []tag.Key{r.status},
 		},
 	)
 	if err != nil {
@@ -82,13 +88,13 @@ func (s *Sink) NewMetricsRecorderInterceptor() MetricsInterceptor {
 			endTime := time.Now()
 			elapsed := endTime.Sub(startTime)
 			// Log the consumed time
-			go s.recordMetrics(recorder, elapsed)
+			go s.recordDurationMetrics(recorder, elapsed)
 		}()
 		next(recorder, r)
 	}
 }
 
-func (s *Sink) recordMetrics(w *StatusRecorder, elapsed time.Duration) {
+func (s *Sink) recordDurationMetrics(w *StatusRecorder, elapsed time.Duration) {
 
 	duration := elapsed.Seconds()
 	s.Logger.Debugw("event listener request completed", "status", w.Status, "duration", duration)
@@ -102,6 +108,21 @@ func (s *Sink) recordMetrics(w *StatusRecorder, elapsed time.Duration) {
 	}
 
 	metrics.Record(ctx, elDuration.M(duration))
+}
+
+func (s *Sink) recordCountMetrics(status string) {
+
+	s.Logger.Debugw("event listener request", "status", status)
+	ctx, err := tag.New(
+		context.Background(),
+		tag.Insert(s.Recorder.status, status),
+	)
+
+	if err != nil {
+		s.Logger.Warnf("failed to create tag for metric event_count: %w", err)
+		return
+	}
+
 	metrics.Record(ctx, eventCount.M(1))
 }
 

--- a/pkg/sink/metrics_test.go
+++ b/pkg/sink/metrics_test.go
@@ -100,17 +100,15 @@ func TestRecordResourceCreation(t *testing.T) {
 	}
 }
 
-func TestRecordRecordMetrics(t *testing.T) {
+func TestRecordRecordDurationMetrics(t *testing.T) {
 	tests := []struct {
 		name             string
 		duration         time.Duration
 		expectedDuration float64
-		expectedCount    int64
 	}{{
 		name:             "Record Metrics",
 		duration:         7,
 		expectedDuration: 7e-09,
-		expectedCount:    1,
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -130,9 +128,44 @@ func TestRecordRecordMetrics(t *testing.T) {
 				Recorder: r,
 				Logger:   logger,
 			}
-			s.recordMetrics(&StatusRecorder{Status: 200}, test.duration)
+			s.recordDurationMetrics(&StatusRecorder{Status: 200}, test.duration)
 			metricstest.CheckDistributionData(t, "http_duration_seconds", nil, 1, test.expectedDuration, test.expectedDuration)
-			metricstest.CheckCountData(t, "event_count", nil, test.expectedCount)
+		})
+	}
+}
+
+func TestRecordRecordCountMetrics(t *testing.T) {
+	tests := []struct {
+		name          string
+		expectedTags  map[string]string
+		expectedCount int64
+	}{{
+		name: "Record Metrics",
+		expectedTags: map[string]string{
+			"status": failTag,
+		},
+		expectedCount: 1,
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defer metricstest.Unregister("event_count", "http_duration_seconds")
+			logger := zaptest.NewLogger(t).Sugar()
+			metrics.FlushExporter()
+			err := metrics.UpdateExporter(context.TODO(), metrics.ExporterOptions{
+				Domain:    "tekton.dev/triggers",
+				Component: "triggers",
+				ConfigMap: map[string]string{},
+			}, logger)
+			if err != nil {
+				t.Fatal(err)
+			}
+			r, _ := NewRecorder()
+			s := &Sink{
+				Recorder: r,
+				Logger:   logger,
+			}
+			s.recordCountMetrics(failTag)
+			metricstest.CheckCountData(t, "event_count", test.expectedTags, test.expectedCount)
 		})
 	}
 }

--- a/pkg/sink/validate_payload.go
+++ b/pkg/sink/validate_payload.go
@@ -29,6 +29,7 @@ func (r Sink) IsValidPayload(eventHandler http.Handler) http.Handler {
 		payload, err := ioutil.ReadAll(request.Body)
 		request.Body = ioutil.NopCloser(bytes.NewBuffer(payload))
 		if err != nil {
+			r.recordCountMetrics(failTag)
 			r.Logger.Errorf("Error reading event body: %s", err)
 			response.WriteHeader(http.StatusInternalServerError)
 			return
@@ -36,6 +37,7 @@ func (r Sink) IsValidPayload(eventHandler http.Handler) http.Handler {
 		var event map[string]interface{}
 		if err := json.Unmarshal([]byte(payload), &event); err != nil {
 			errMsg := fmt.Sprintf("Invalid event body format format: %s", err)
+			r.recordCountMetrics(failTag)
 			r.Logger.Error(errMsg)
 			response.WriteHeader(http.StatusBadRequest)
 			response.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
Added Status Tag to Event Count Metrics to denote failure or success in
processing event. Success only imply that event was handled
successfully, not that a triggered was successful.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes
```release-note
EventListener metrics `event_count` status which can determine whether received event failed before processing.
```