### PR TITLE
Add Metrics Port to EventListener service

### DIFF
--- a/pkg/reconciler/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/eventlistener/eventlistener_test.go
@@ -517,6 +517,13 @@ func makeService(ops ...func(*corev1.Service)) *corev1.Service {
 				TargetPort: intstr.IntOrString{
 					IntVal: int32(eventListenerContainerPort),
 				},
+			}, {
+				Name:     eventListenerMetricsPortName,
+				Protocol: corev1.ProtocolTCP,
+				Port:     int32(9000),
+				TargetPort: intstr.IntOrString{
+					IntVal: int32(eventListenerMetricsPort),
+				},
 			}},
 		},
 	}


### PR DESCRIPTION
Metrics port in service is needed by metering serices like prometheus
servicemonitor. It's already there for controller and webhook but not
EventListener which is created.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes


```release-note
Service Port for EventListener is accessible as http-metrics
```
