### PR TITLE
Fix GitHub EL name in port forward command.

### DIFF
--- a/examples/v1alpha1/github/README.md
+++ b/examples/v1alpha1/github/README.md
@@ -13,7 +13,7 @@ Creates an EventListener that listens for GitHub webhook events.
 1. Port forward:
 
    ```bash
-   kubectl port-forward service/el-github-listener-interceptor 8080
+   kubectl port-forward service/el-github-listener 8080
    ```
 
 1. Test by sending the sample payload.


### PR DESCRIPTION
# Changes

Fix GitHub EL name in port forward command.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [N/A ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ N/A] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ N/A] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
NONE
```
