### PR TITLE
Take advantage of knative helpers.

### DIFF
--- a/pkg/apis/triggers/v1alpha1/event_listener_types.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_types.go
@@ -28,6 +28,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
 	"knative.dev/pkg/apis/duck/v1beta1"
+	"knative.dev/pkg/kmeta"
 )
 
 // Check that EventListener may be validated and defaulted.
@@ -51,6 +52,8 @@ type EventListener struct {
 	// +optional
 	Status EventListenerStatus `json:"status,omitempty"`
 }
+
+var _ kmeta.OwnerRefable = (*EventListener)(nil)
 
 // EventListenerSpec defines the desired state of the EventListener, represented
 // by a list of Triggers.
@@ -180,6 +183,11 @@ var eventListenerCondSet = apis.NewLivingConditionSet(
 	DeploymentExists,
 )
 
+// GetGroupVersionKind implements kmeta.OwnerRefable
+func (el *EventListener) GetGroupVersionKind() schema.GroupVersionKind {
+	return SchemeGroupVersion.WithKind("EventListener")
+}
+
 // GetCondition returns the Condition matching the given type.
 func (els *EventListenerStatus) GetCondition(t apis.ConditionType) *apis.Condition {
 	return eventListenerCondSet.Manage(els).GetCondition(t)
@@ -288,16 +296,6 @@ func (els *EventListenerStatus) InitializeConditions() {
 			Status: corev1.ConditionFalse,
 		})
 	}
-}
-
-// GetOwnerReference gets the EventListener as owner reference for any related
-// objects.
-func (el *EventListener) GetOwnerReference() *metav1.OwnerReference {
-	return metav1.NewControllerRef(el, schema.GroupVersionKind{
-		Group:   SchemeGroupVersion.Group,
-		Version: SchemeGroupVersion.Version,
-		Kind:    "EventListener",
-	})
 }
 
 // SetAddress sets the address (as part of Addressable contract) and marks the correct condition.

--- a/pkg/apis/triggers/v1beta1/event_listener_types.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_types.go
@@ -27,6 +27,7 @@ import (
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/apis/duck/v1beta1"
+	"knative.dev/pkg/kmeta"
 )
 
 // Check that EventListener may be validated and defaulted.
@@ -50,6 +51,8 @@ type EventListener struct {
 	// +optional
 	Status EventListenerStatus `json:"status,omitempty"`
 }
+
+var _ kmeta.OwnerRefable = (*EventListener)(nil)
 
 // EventListenerSpec defines the desired state of the EventListener, represented
 // by a list of Triggers.
@@ -191,6 +194,11 @@ var eventListenerCondSet = apis.NewLivingConditionSet(
 	DeploymentExists,
 )
 
+// GetGroupVersionKind implements kmeta.OwnerRefable
+func (el *EventListener) GetGroupVersionKind() schema.GroupVersionKind {
+	return SchemeGroupVersion.WithKind("EventListener")
+}
+
 // GetCondition returns the Condition matching the given type.
 func (els *EventListenerStatus) GetCondition(t apis.ConditionType) *apis.Condition {
 	return eventListenerCondSet.Manage(els).GetCondition(t)
@@ -299,16 +307,6 @@ func (els *EventListenerStatus) InitializeConditions() {
 			Status: corev1.ConditionFalse,
 		})
 	}
-}
-
-// GetOwnerReference gets the EventListener as owner reference for any related
-// objects.
-func (el *EventListener) GetOwnerReference() *metav1.OwnerReference {
-	return metav1.NewControllerRef(el, schema.GroupVersionKind{
-		Group:   SchemeGroupVersion.Group,
-		Version: SchemeGroupVersion.Version,
-		Kind:    "EventListener",
-	})
 }
 
 // SetAddress sets the address (as part of Addressable contract) and marks the correct condition.

--- a/pkg/dynamic/dynamic.go
+++ b/pkg/dynamic/dynamic.go
@@ -19,7 +19,7 @@ package dynamic
 import (
 	"context"
 
-	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	"github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/apis/duck"
@@ -53,7 +53,7 @@ func (t *listableTracker) watchOnDynamicObject(ctx context.Context, gvr schema.G
 		return err
 	}
 	shInformer.AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterControllerGVK(v1alpha1.SchemeGroupVersion.WithKind("EventListener")),
+		FilterFunc: controller.FilterController(&v1beta1.EventListener{}),
 		Handler:    controller.HandleAll(t.impl.EnqueueControllerOf),
 	})
 	return nil

--- a/pkg/reconciler/clusterinterceptor/controller.go
+++ b/pkg/reconciler/clusterinterceptor/controller.go
@@ -21,15 +21,12 @@ import (
 
 	clusterinterceptorinformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1alpha1/clusterinterceptor"
 	clusterinterceptorreconciler "github.com/tektoncd/triggers/pkg/client/injection/reconciler/triggers/v1alpha1/clusterinterceptor"
-	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
-	"knative.dev/pkg/logging"
 )
 
 func NewController() func(context.Context, configmap.Watcher) *controller.Impl {
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
-		logger := logging.FromContext(ctx)
 		clusterInterceptorInformer := clusterinterceptorinformer.Get(ctx)
 		reconciler := &Reconciler{}
 
@@ -39,12 +36,7 @@ func NewController() func(context.Context, configmap.Watcher) *controller.Impl {
 			}
 		})
 
-		logger.Info("Setting up event handlers")
-		clusterInterceptorInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-			AddFunc:    impl.Enqueue,
-			UpdateFunc: controller.PassNew(impl.Enqueue),
-			DeleteFunc: impl.Enqueue,
-		})
+		clusterInterceptorInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 		return impl
 	}

--- a/pkg/reconciler/eventlistener/eventlistener.go
+++ b/pkg/reconciler/eventlistener/eventlistener.go
@@ -553,7 +553,7 @@ func (r *Reconciler) reconcileCustomObject(ctx context.Context, el *v1beta1.Even
 	}
 	gvr, _ := meta.UnsafeGuessKindToResource(data.GetObjectKind().GroupVersionKind())
 
-	data.SetOwnerReferences([]metav1.OwnerReference{*el.GetOwnerReference()})
+	data.SetOwnerReferences([]metav1.OwnerReference{*kmeta.NewControllerRef(el)})
 
 	var watchError error
 	r.onlyOnce.Do(func() {
@@ -975,7 +975,7 @@ func generateObjectMeta(el *v1beta1.EventListener, staticResourceLabels map[stri
 	return metav1.ObjectMeta{
 		Namespace:       el.Namespace,
 		Name:            el.Status.Configuration.GeneratedResourceName,
-		OwnerReferences: []metav1.OwnerReference{*el.GetOwnerReference()},
+		OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(el)},
 		Labels:          kmeta.UnionMaps(el.Labels, GenerateResourceLabels(el.Name, staticResourceLabels)),
 		Annotations:     el.Annotations,
 	}

--- a/pkg/reconciler/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/eventlistener/eventlistener_test.go
@@ -189,7 +189,7 @@ func makeEL(ops ...func(el *v1beta1.EventListener)) *v1beta1.EventListener {
 // makeDeployment is a helper to build a Deployment that is created by an EventListener.
 // It generates a basic Deployment for the simplest EventListener and accepts functions for modification
 func makeDeployment(ops ...func(d *appsv1.Deployment)) *appsv1.Deployment {
-	ownerRefs := makeEL().GetOwnerReference()
+	ownerRefs := kmeta.NewControllerRef(makeEL())
 
 	d := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -413,7 +413,7 @@ var withTLSConfig = func(d *appsv1.Deployment) {
 // makeWithPod is a helper to build a Knative Service that is created by an EventListener.
 // It generates a basic Knative Service for the simplest EventListener and accepts functions for modification
 func makeWithPod(ops ...func(d *duckv1.WithPod)) *duckv1.WithPod {
-	ownerRefs := makeEL().GetOwnerReference()
+	ownerRefs := kmeta.NewControllerRef(makeEL())
 
 	d := duckv1.WithPod{
 		TypeMeta: metav1.TypeMeta{
@@ -499,7 +499,7 @@ func makeWithPod(ops ...func(d *duckv1.WithPod)) *duckv1.WithPod {
 // makeService is a helper to build a Service that is created by an EventListener.
 // It generates a basic Service for the simplest EventListener and accepts functions for modification.
 func makeService(ops ...func(*corev1.Service)) *corev1.Service {
-	ownerRefs := makeEL().GetOwnerReference()
+	ownerRefs := kmeta.NewControllerRef(makeEL())
 	s := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      generatedResourceName,


### PR DESCRIPTION
There are a few helpers that knative/pkg exposes, which triggers isn't taking full advantage of, which I noticed reviewing the code.

`controller.FilterController` is a strongly-typed alternative to `controller.FilterControllerG[V]K` which works for any `kmeta.OwnerRefable`.  Triggers followed the pattern Pipelines used to use with `GetOwnerReference`, which I removed in favor of `kmeta.NewControllerRef` when I made a similar change there during a similar cleanup.

There was also one place that `controller.HandleAll` wasn't being used, which now does.

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
