### PR TITLE
Leverage `network.GetServiceHostname`

### DIFF
--- a/pkg/reconciler/eventlistener/eventlistener.go
+++ b/pkg/reconciler/eventlistener/eventlistener.go
@@ -55,6 +55,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/metrics"
+	"knative.dev/pkg/network"
 	"knative.dev/pkg/ptr"
 	pkgreconciler "knative.dev/pkg/reconciler"
 )
@@ -996,7 +997,7 @@ func wrapError(err1, err2 error) error {
 
 // listenerHostname returns the intended hostname for the EventListener service.
 func listenerHostname(name, namespace string, port int) string {
-	return fmt.Sprintf("%s.%s.svc.cluster.local:%d", name, namespace, port)
+	return network.GetServiceHostname(name, namespace) + fmt.Sprintf(":%d", port)
 }
 
 func defaultLoggingConfigMap() *corev1.ConfigMap {


### PR DESCRIPTION
Today triggers hard-codes `.svc.cluster.local`, but `cluster.local` is actually configurable, so this will break on certain clusters.

Knative has a helper function that looks up the appropriate suffix for the cluster and simply uses that.

Ref: https://github.com/knative/pkg/blob/3a2ae6db70971afbcaf1e1c3826cbc9a5d6c718e/network/domain.go#L40

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
