### PR TITLE
Move off of deprecated `sharedmain` methods

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -50,7 +50,7 @@ var (
 )
 
 func main() {
-	cfg := sharedmain.ParseAndGetConfigOrDie()
+	cfg := injection.ParseAndGetRESTConfigOrDie()
 
 	c := eventlistener.Config{
 		Image:              image,

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection"
 	"knative.dev/pkg/injection/sharedmain"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/signals"
@@ -140,8 +141,8 @@ func main() {
 	// NOTE(afrittoli) - we should have the name "webhook-triggers"
 	// configurable. Once the change is done on knative/pkg side
 	// knative/eventing#4530 we can inherit it from it
-	sharedmain.WebhookMainWithConfig(ctx, "webhook-triggers",
-		sharedmain.ParseAndGetConfigOrDie(),
+	sharedmain.MainWithConfig(ctx, "webhook-triggers",
+		injection.ParseAndGetRESTConfigOrDie(),
 		certificates.NewController,
 		NewDefaultingAdmissionController,
 		NewValidationAdmissionController,


### PR DESCRIPTION
# Changes

This was uncovered by a test I'm adding to `knative.dev/pkg` that will let contributors know when their changes break `triggers`.

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
