### PR TITLE
Next pass refactoring EventListener reconciler towards best-practices.

### DIFF
--- a/pkg/reconciler/eventlistener/eventlistener.go
+++ b/pkg/reconciler/eventlistener/eventlistener.go
@@ -42,6 +42,7 @@ import (
 	appsv1lister "k8s.io/client-go/listers/apps/v1"
 	corev1lister "k8s.io/client-go/listers/core/v1"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/metrics"
 	pkgreconciler "knative.dev/pkg/reconciler"
@@ -168,6 +169,10 @@ func (r *Reconciler) reconcileService(ctx context.Context, el *v1beta1.EventList
 				service.Spec.Ports[i].NodePort = existingService.Spec.Ports[i].NodePort
 			}
 		}
+		// Preserve user-added annotations.
+		if len(existingService.Annotations) > 0 {
+			service.Annotations = kmeta.UnionMaps(service.Annotations, existingService.Annotations)
+		}
 
 		if !equality.Semantic.DeepEqual(existingService.Spec, service.Spec) ||
 			!equality.Semantic.DeepEqual(existingService.Labels, service.Labels) ||
@@ -260,6 +265,10 @@ func (r *Reconciler) reconcileDeployment(ctx context.Context, el *v1beta1.EventL
 		// (or manually themselves) scale the underlying deployment.
 		if deployment.Spec.Replicas == nil {
 			deployment.Spec.Replicas = existingDeployment.Spec.Replicas
+		}
+		// Preserve user-added annotations.
+		if len(existingDeployment.Annotations) > 0 {
+			deployment.Annotations = kmeta.UnionMaps(deployment.Annotations, existingDeployment.Annotations)
 		}
 
 		if !equality.Semantic.DeepEqual(existingDeployment.Spec, deployment.Spec) ||

--- a/pkg/reconciler/eventlistener/eventlistener.go
+++ b/pkg/reconciler/eventlistener/eventlistener.go
@@ -18,15 +18,11 @@ package eventlistener
 
 import (
 	"context"
-	"encoding/json"
 	stdError "errors"
 	"fmt"
-	"reflect"
 	"strings"
 	"sync"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/contexts"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	triggersclientset "github.com/tektoncd/triggers/pkg/client/clientset/versioned"
@@ -36,18 +32,16 @@ import (
 	"github.com/tektoncd/triggers/pkg/reconciler/eventlistener/resources"
 	"golang.org/x/xerrors"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	appsv1lister "k8s.io/client-go/listers/apps/v1"
 	corev1lister "k8s.io/client-go/listers/core/v1"
 	"knative.dev/pkg/apis"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
-	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/metrics"
 	pkgreconciler "knative.dev/pkg/reconciler"
@@ -152,57 +146,44 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, el *v1beta1.EventListener
 	return nil
 }
 
-func reconcileObjectMeta(existing *metav1.ObjectMeta, desired metav1.ObjectMeta) (updated bool) {
-	if !reflect.DeepEqual(existing.Labels, desired.Labels) {
-		updated = true
-		existing.Labels = desired.Labels
-	}
-
-	// TODO(dibyom): We should exclude propagation of some annotations such as `kubernetes.io/last-applied-revision`
-	if !reflect.DeepEqual(existing.Annotations, kmeta.UnionMaps(existing.Annotations, desired.Annotations)) {
-		updated = true
-		existing.Annotations = desired.Annotations
-	}
-
-	if !reflect.DeepEqual(existing.OwnerReferences, desired.OwnerReferences) {
-		updated = true
-		existing.OwnerReferences = desired.OwnerReferences
-	}
-	return
-}
-
 func (r *Reconciler) reconcileService(ctx context.Context, el *v1beta1.EventListener) error {
 	service := resources.MakeService(el, r.config)
 
 	existingService, err := r.serviceLister.Services(el.Namespace).Get(el.Status.Configuration.GeneratedResourceName)
 	switch {
 	case err == nil:
-		// Determine if reconciliation has to occur
-		updated := reconcileObjectMeta(&existingService.ObjectMeta, service.ObjectMeta)
 		el.Status.SetExistsCondition(v1beta1.ServiceExists, nil)
 		el.Status.SetAddress(resources.ListenerHostname(el, r.config))
-		if !reflect.DeepEqual(existingService.Spec.Selector, service.Spec.Selector) {
-			existingService.Spec.Selector = service.Spec.Selector
-			updated = true
+
+		// Copy over output spec fields.
+		service.Spec.ClusterIP = existingService.Spec.ClusterIP
+
+		// Copy any assigned NodePorts
+		if service.Spec.Type == corev1.ServiceTypeNodePort &&
+			existingService.Spec.Type == corev1.ServiceTypeNodePort {
+			for i := range service.Spec.Ports {
+				if i >= len(existingService.Spec.Ports) {
+					break
+				}
+				service.Spec.Ports[i].NodePort = existingService.Spec.Ports[i].NodePort
+			}
 		}
-		if existingService.Spec.Type != service.Spec.Type {
-			existingService.Spec.Type = service.Spec.Type
-			// When transitioning from NodePort or LoadBalancer to ClusterIP
-			// we need to remove NodePort from Ports
-			existingService.Spec.Ports = service.Spec.Ports
-			updated = true
-		}
-		if !cmp.Equal(existingService.Spec.Ports, service.Spec.Ports, cmpopts.IgnoreFields(corev1.ServicePort{}, "NodePort")) {
-			existingService.Spec.Ports = service.Spec.Ports
-			updated = true
-		}
-		if updated {
-			if _, err := r.KubeClientSet.CoreV1().Services(el.Namespace).Update(ctx, existingService, metav1.UpdateOptions{}); err != nil {
+
+		if !equality.Semantic.DeepEqual(existingService.Spec, service.Spec) ||
+			!equality.Semantic.DeepEqual(existingService.Labels, service.Labels) ||
+			!equality.Semantic.DeepEqual(existingService.Annotations, service.Annotations) {
+			existingService = existingService.DeepCopy() // Don't modify the lister cache
+			existingService.Labels = service.Labels
+			existingService.Annotations = service.Annotations
+			existingService.Spec = service.Spec
+			if updated, err := r.KubeClientSet.CoreV1().Services(el.Namespace).Update(ctx, existingService, metav1.UpdateOptions{}); err != nil {
 				logging.FromContext(ctx).Errorf("Error updating EventListener Service: %s", err)
 				return err
+			} else if existingService.ResourceVersion != updated.ResourceVersion {
+				logging.FromContext(ctx).Infof("Updated EventListener Service %s in Namespace %s", existingService.Namespace, el.Namespace)
 			}
-			logging.FromContext(ctx).Infof("Updated EventListener Service %s in Namespace %s", existingService.Namespace, el.Namespace)
 		}
+
 	case errors.IsNotFound(err):
 		// Create the EventListener Service
 		_, err = r.KubeClientSet.CoreV1().Services(el.Namespace).Create(ctx, service, metav1.CreateOptions{})
@@ -213,6 +194,7 @@ func (r *Reconciler) reconcileService(ctx context.Context, el *v1beta1.EventList
 		}
 		el.Status.SetAddress(resources.ListenerHostname(el, r.config))
 		logging.FromContext(ctx).Infof("Created EventListener Service %s in Namespace %s", service.Name, el.Namespace)
+
 	default:
 		logging.FromContext(ctx).Error(err)
 		return err
@@ -263,110 +245,41 @@ func (r *Reconciler) reconcileDeployment(ctx context.Context, el *v1beta1.EventL
 		logging.FromContext(ctx).Error(err)
 		return err
 	}
-	container := deployment.Spec.Template.Spec.Containers[0]
 
 	existingDeployment, err := r.deploymentLister.Deployments(el.Namespace).Get(el.Status.Configuration.GeneratedResourceName)
 	switch {
 	case err == nil:
+		// TODO(mattmoor): Should this delete stuff for the CustomObject?  That path deletes Deployments,
+		// so it seems asymmetrical for this path to not.
+
 		el.Status.SetDeploymentConditions(existingDeployment.Status.Conditions)
 		el.Status.SetExistsCondition(v1beta1.DeploymentExists, nil)
 
-		// Determine if reconciliation has to occur
-		updated := reconcileObjectMeta(&existingDeployment.ObjectMeta, deployment.ObjectMeta)
-		if *existingDeployment.Spec.Replicas != *deployment.Spec.Replicas {
-			if el.Spec.Resources.KubernetesResource != nil {
-				if el.Spec.Resources.KubernetesResource.Replicas != nil {
-					existingDeployment.Spec.Replicas = deployment.Spec.Replicas
-					updated = true
-				}
-				// if no replicas found as part of el.Spec then replicas from existingDeployment will be considered
-			}
+		// If the scale of the deployment is unspecified, then persist the current
+		// scale of what is deployed.  This allows users to use HPA to automatically
+		// (or manually themselves) scale the underlying deployment.
+		if deployment.Spec.Replicas == nil {
+			deployment.Spec.Replicas = existingDeployment.Spec.Replicas
 		}
-		if existingDeployment.Spec.Selector != deployment.Spec.Selector {
-			existingDeployment.Spec.Selector = deployment.Spec.Selector
-			updated = true
-		}
-		if !reflect.DeepEqual(existingDeployment.Spec.Template.Labels, deployment.Spec.Template.Labels) {
-			existingDeployment.Spec.Template.Labels = deployment.Spec.Template.Labels
-			updated = true
-		}
-		if !reflect.DeepEqual(existingDeployment.Spec.Template.Annotations, deployment.Spec.Template.Annotations) {
-			existingDeployment.Spec.Template.Annotations = deployment.Spec.Template.Annotations
-			updated = true
-		}
-		if existingDeployment.Spec.Template.Spec.ServiceAccountName != deployment.Spec.Template.Spec.ServiceAccountName {
-			existingDeployment.Spec.Template.Spec.ServiceAccountName = deployment.Spec.Template.Spec.ServiceAccountName
-			updated = true
-		}
-		if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec.Tolerations, deployment.Spec.Template.Spec.Tolerations) {
-			existingDeployment.Spec.Template.Spec.Tolerations = deployment.Spec.Template.Spec.Tolerations
-			updated = true
-		}
-		if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec.NodeSelector, deployment.Spec.Template.Spec.NodeSelector) {
-			existingDeployment.Spec.Template.Spec.NodeSelector = deployment.Spec.Template.Spec.NodeSelector
-			updated = true
-		}
-		if len(existingDeployment.Spec.Template.Spec.Containers) == 0 ||
-			len(existingDeployment.Spec.Template.Spec.Containers) > 1 {
-			existingDeployment.Spec.Template.Spec.Containers = []corev1.Container{container}
-			updated = true
-		} else {
-			if existingDeployment.Spec.Template.Spec.Containers[0].Name != container.Name {
-				existingDeployment.Spec.Template.Spec.Containers[0].Name = container.Name
-				updated = true
-			}
-			if existingDeployment.Spec.Template.Spec.Containers[0].Image != container.Image {
-				existingDeployment.Spec.Template.Spec.Containers[0].Image = container.Image
-				updated = true
-			}
-			if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec.Containers[0].Ports, container.Ports) {
-				existingDeployment.Spec.Template.Spec.Containers[0].Ports = container.Ports
-				updated = true
-			}
-			if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec.Containers[0].Args, container.Args) {
-				existingDeployment.Spec.Template.Spec.Containers[0].Args = container.Args
-				updated = true
-			}
-			if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec.Containers[0].LivenessProbe, container.LivenessProbe) {
-				existingDeployment.Spec.Template.Spec.Containers[0].LivenessProbe = container.LivenessProbe
-				updated = true
-			}
-			if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec.Containers[0].ReadinessProbe, container.ReadinessProbe) {
-				existingDeployment.Spec.Template.Spec.Containers[0].ReadinessProbe = container.ReadinessProbe
-				updated = true
-			}
-			if existingDeployment.Spec.Template.Spec.Containers[0].Command != nil {
-				existingDeployment.Spec.Template.Spec.Containers[0].Command = nil
-				updated = true
-			}
-			if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec.Containers[0].Resources, container.Resources) {
-				existingDeployment.Spec.Template.Spec.Containers[0].Resources = container.Resources
-				updated = true
-			}
-			if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec.Containers[0].Env, container.Env) {
-				existingDeployment.Spec.Template.Spec.Containers[0].Env = container.Env
-				updated = true
-			}
-			if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec.Containers[0].VolumeMounts, deployment.Spec.Template.Spec.Containers[0].VolumeMounts) {
-				existingDeployment.Spec.Template.Spec.Containers[0].VolumeMounts = container.VolumeMounts
-				updated = true
-			}
-			if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec.Volumes, deployment.Spec.Template.Spec.Volumes) {
-				existingDeployment.Spec.Template.Spec.Volumes = deployment.Spec.Template.Spec.Volumes
-				updated = true
-			}
-			if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec.SecurityContext, deployment.Spec.Template.Spec.SecurityContext) && *r.config.SetSecurityContext {
-				existingDeployment.Spec.Template.Spec.SecurityContext = deployment.Spec.Template.Spec.SecurityContext
-				updated = true
-			}
-		}
-		if updated {
-			if _, err := r.KubeClientSet.AppsV1().Deployments(el.Namespace).Update(ctx, existingDeployment, metav1.UpdateOptions{}); err != nil {
+
+		if !equality.Semantic.DeepEqual(existingDeployment.Spec, deployment.Spec) ||
+			!equality.Semantic.DeepEqual(existingDeployment.Labels, deployment.Labels) ||
+			!equality.Semantic.DeepEqual(existingDeployment.Annotations, deployment.Annotations) {
+			existingDeployment = existingDeployment.DeepCopy() // Don't modify the lister cache
+			existingDeployment.Labels = deployment.Labels
+			existingDeployment.Annotations = deployment.Annotations
+			existingDeployment.Spec = deployment.Spec
+			// If the spec/labels/annotations of what we want and got are different, then
+			// issue an Update.  They may differ due to things like defaulting, so the
+			// Update may not change anything, so only log if the ResourceVersion changes.
+			if updated, err := r.KubeClientSet.AppsV1().Deployments(el.Namespace).Update(ctx, existingDeployment, metav1.UpdateOptions{}); err != nil {
 				logging.FromContext(ctx).Errorf("Error updating EventListener Deployment: %s", err)
 				return err
+			} else if existingDeployment.ResourceVersion != updated.ResourceVersion {
+				logging.FromContext(ctx).Infof("Updated EventListener Deployment %s in Namespace %s", existingDeployment.Name, el.Namespace)
 			}
-			logging.FromContext(ctx).Infof("Updated EventListener Deployment %s in Namespace %s", existingDeployment.Name, el.Namespace)
 		}
+
 	case errors.IsNotFound(err):
 		// Create the EventListener Deployment
 		deployment, err = r.KubeClientSet.AppsV1().Deployments(el.Namespace).Create(ctx, deployment, metav1.CreateOptions{})
@@ -377,6 +290,7 @@ func (r *Reconciler) reconcileDeployment(ctx context.Context, el *v1beta1.EventL
 		}
 		el.Status.SetDeploymentConditions(deployment.Status.Conditions)
 		logging.FromContext(ctx).Infof("Created EventListener Deployment %s in Namespace %s", deployment.Name, el.Namespace)
+
 	default:
 		logging.FromContext(ctx).Error(err)
 		return err
@@ -390,14 +304,22 @@ func (r *Reconciler) reconcileCustomObject(ctx context.Context, el *v1beta1.Even
 		logging.FromContext(ctx).Error(err)
 		return err
 	}
+	// TODO(mattmoor): This is missing reconciliation of the observability config, which reconcileDeployment has.
+	// Given that the CustomObject passes the config name, this probably should have it, but it probably makes
+	// the most sense to eliminate the configmap propagation altogether and translate that state into container
+	// config (env, args).
 
-	data, container, err := resources.MakeCustomObject(el, r.config)
+	data, err := resources.MakeCustomObject(el, r.config)
 	if err != nil {
 		logging.FromContext(ctx).Errorf("unable to construct custom object", err)
 		return err
 	}
 
 	gvr, _ := meta.UnsafeGuessKindToResource(data.GetObjectKind().GroupVersionKind())
+
+	// TODO(mattmoor): Consider replacing this with duck.InformerFactory, it actually has a bug where
+	// the podspecableTracker can only service a single GVR, despite multiple EventListener objects
+	// being able to specify unique resource types (yikes).
 	var watchError error
 	r.onlyOnce.Do(func() {
 		watchError = r.podspecableTracker.WatchOnDynamicObject(ctx, gvr)
@@ -407,9 +329,11 @@ func (r *Reconciler) reconcileCustomObject(ctx context.Context, el *v1beta1.Even
 		return watchError
 	}
 
+	// TODO(mattmoor): We should look into using duck.InformerFactory to have this be a lister fetch.
 	existingCustomObject, err := r.DynamicClientSet.Resource(gvr).Namespace(data.GetNamespace()).Get(ctx, data.GetName(), metav1.GetOptions{})
 	switch {
 	case err == nil:
+		// Clean up any Deployments that may have existed for this listener.
 		if _, err := r.deploymentLister.Deployments(el.Namespace).Get(el.Status.Configuration.GeneratedResourceName); err == nil {
 			if err := r.KubeClientSet.AppsV1().Deployments(el.Namespace).Delete(ctx, el.Status.Configuration.GeneratedResourceName,
 				metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
@@ -420,114 +344,25 @@ func (r *Reconciler) reconcileCustomObject(ctx context.Context, el *v1beta1.Even
 				return err
 			}
 		}
-		originalObject := &duckv1.WithPod{}
-		existingObject := &duckv1.WithPod{}
-		originalData, e := data.MarshalJSON()
-		if e != nil {
-			return e
-		}
-		if e := json.Unmarshal(originalData, &originalObject); e != nil {
-			return e
-		}
-		updatedData, e := existingCustomObject.MarshalJSON()
-		if e != nil {
-			return e
-		}
-		if e := json.Unmarshal(updatedData, &existingObject); e != nil {
-			return e
-		}
-		// Determine if reconciliation has to occur
-		updated := reconcileObjectMeta(&existingObject.ObjectMeta, originalObject.ObjectMeta)
-		if !reflect.DeepEqual(existingObject.Spec.Template.Name, originalObject.Spec.Template.Name) {
-			existingObject.Spec.Template.Name = originalObject.Spec.Template.Name
-			updated = true
-		}
-		if !reflect.DeepEqual(existingObject.Spec.Template.Labels, originalObject.Spec.Template.Labels) {
-			existingObject.Spec.Template.Labels = originalObject.Spec.Template.Labels
-			updated = true
-		}
-		if !reflect.DeepEqual(existingObject.Spec.Template.Annotations, originalObject.Spec.Template.Annotations) {
-			existingObject.Spec.Template.Annotations = originalObject.Spec.Template.Annotations
-			updated = true
-		}
-		if existingObject.Spec.Template.Spec.ServiceAccountName != originalObject.Spec.Template.Spec.ServiceAccountName {
-			existingObject.Spec.Template.Spec.ServiceAccountName = originalObject.Spec.Template.Spec.ServiceAccountName
-			updated = true
-		}
-		if !reflect.DeepEqual(existingObject.Spec.Template.Spec.Tolerations, originalObject.Spec.Template.Spec.Tolerations) {
-			existingObject.Spec.Template.Spec.Tolerations = originalObject.Spec.Template.Spec.Tolerations
-			updated = true
-		}
-		if !reflect.DeepEqual(existingObject.Spec.Template.Spec.NodeSelector, originalObject.Spec.Template.Spec.NodeSelector) {
-			existingObject.Spec.Template.Spec.NodeSelector = originalObject.Spec.Template.Spec.NodeSelector
-			updated = true
-		}
-		if len(existingObject.Spec.Template.Spec.Containers) == 0 ||
-			len(existingObject.Spec.Template.Spec.Containers) > 1 {
-			existingObject.Spec.Template.Spec.Containers = []corev1.Container{*container}
-			updated = true
-		} else {
-			if existingObject.Spec.Template.Spec.Containers[0].Name != container.Name {
-				existingObject.Spec.Template.Spec.Containers[0].Name = container.Name
-				updated = true
-			}
-			if existingObject.Spec.Template.Spec.Containers[0].Image != container.Image {
-				existingObject.Spec.Template.Spec.Containers[0].Image = container.Image
-				updated = true
-			}
-			if !reflect.DeepEqual(existingObject.Spec.Template.Spec.Containers[0].Ports, container.Ports) {
-				existingObject.Spec.Template.Spec.Containers[0].Ports = container.Ports
-				updated = true
-			}
-			if !reflect.DeepEqual(existingObject.Spec.Template.Spec.Containers[0].Args, container.Args) {
-				existingObject.Spec.Template.Spec.Containers[0].Args = container.Args
-				updated = true
-			}
-			if existingObject.Spec.Template.Spec.Containers[0].Command != nil {
-				existingObject.Spec.Template.Spec.Containers[0].Command = nil
-				updated = true
-			}
-			if !reflect.DeepEqual(existingObject.Spec.Template.Spec.Containers[0].Resources, container.Resources) {
-				existingObject.Spec.Template.Spec.Containers[0].Resources = container.Resources
-				updated = true
-			}
-			if !reflect.DeepEqual(existingObject.Spec.Template.Spec.Containers[0].Env, container.Env) {
-				existingObject.Spec.Template.Spec.Containers[0].Env = container.Env
-				updated = true
-			}
-			if !reflect.DeepEqual(existingObject.Spec.Template.Spec.Containers[0].ReadinessProbe, container.ReadinessProbe) {
-				existingObject.Spec.Template.Spec.Containers[0].ReadinessProbe = container.ReadinessProbe
-				updated = true
-			}
-			if !reflect.DeepEqual(existingObject.Spec.Template.Spec.Containers[0].VolumeMounts, originalObject.Spec.Template.Spec.Containers[0].VolumeMounts) {
-				existingObject.Spec.Template.Spec.Containers[0].VolumeMounts = container.VolumeMounts
-				updated = true
-			}
-			if !reflect.DeepEqual(existingObject.Spec.Template.Spec.Volumes, originalObject.Spec.Template.Spec.Volumes) {
-				existingObject.Spec.Template.Spec.Volumes = originalObject.Spec.Template.Spec.Volumes
-				updated = true
-			}
-		}
 
-		// if dynamicduck.ReconcileCustomObject(existingCustomObject, data) {
-		if updated {
-			existingMarshaledData, err := json.Marshal(existingObject)
-			if err != nil {
-				logging.FromContext(ctx).Errorf("failed to marshal custom object", err)
-				return err
-			}
-			existingCustomObject = new(unstructured.Unstructured)
-			if err := existingCustomObject.UnmarshalJSON(existingMarshaledData); err != nil {
-				logging.FromContext(ctx).Errorf("failed to unmarshal to unstructured object", err)
-				return err
-			}
-			if _, err := r.DynamicClientSet.Resource(gvr).Namespace(data.GetNamespace()).Update(ctx, existingCustomObject, metav1.UpdateOptions{}); err != nil {
+		if !equality.Semantic.DeepEqual(data.GetLabels(), existingCustomObject.GetLabels()) ||
+			!equality.Semantic.DeepEqual(data.GetAnnotations(), existingCustomObject.GetAnnotations()) ||
+			!equality.Semantic.DeepEqual(data.Object["spec"], existingCustomObject.Object["spec"]) {
+			data = data.DeepCopy()
+			data.SetLabels(existingCustomObject.GetLabels())
+			data.SetAnnotations(existingCustomObject.GetAnnotations())
+			data.Object["spec"] = existingCustomObject.Object["spec"]
+
+			if updated, err := r.DynamicClientSet.Resource(gvr).Namespace(data.GetNamespace()).Update(ctx, data, metav1.UpdateOptions{}); err != nil {
 				logging.FromContext(ctx).Errorf("error updating to eventListener custom object: %v", err)
 				return err
+			} else if data.GetResourceVersion() != updated.GetResourceVersion() {
+				logging.FromContext(ctx).Infof("Updated EventListener Custom Object %s in Namespace %s", data.GetName(), el.Namespace)
 			}
-			logging.FromContext(ctx).Infof("Updated EventListener Custom Object %s in Namespace %s", data.GetName(), el.Namespace)
 		}
 
+		// TODO(mattmoor): Consider replacing this stuff with the "addressable resolver"
+		// from knative.dev/pkg, which is purpose built for this kind of thing.
 		customConditions, url, err := dynamicduck.GetConditions(existingCustomObject)
 		if customConditions == nil {
 			// No status in the created object, it is weird but let's not fail
@@ -549,6 +384,7 @@ func (r *Reconciler) reconcileCustomObject(ctx context.Context, el *v1beta1.Even
 		if url != nil {
 			el.Status.SetAddress(strings.Split(fmt.Sprintf("%v", url), "//")[1])
 		}
+
 	case errors.IsNotFound(err):
 		createDynamicObject, err := r.DynamicClientSet.Resource(gvr).Namespace(data.GetNamespace()).Create(ctx, data, metav1.CreateOptions{})
 		if err != nil {
@@ -556,6 +392,7 @@ func (r *Reconciler) reconcileCustomObject(ctx context.Context, el *v1beta1.Even
 			return err
 		}
 		logging.FromContext(ctx).Infof("Created EventListener Deployment %s in Namespace %s", createDynamicObject.GetName(), el.Namespace)
+
 	default:
 		logging.FromContext(ctx).Error(err)
 		return err

--- a/pkg/reconciler/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/eventlistener/eventlistener_test.go
@@ -1158,7 +1158,7 @@ func TestReconcile(t *testing.T) {
 		endResources: test.Resources{
 			Namespaces:     []*corev1.Namespace{namespaceResource},
 			EventListeners: []*v1beta1.EventListener{elWithStatus},
-			Services:       []*corev1.Service{elService}, // Annotation is cleared.
+			Services:       []*corev1.Service{elServiceWithAnnotation},
 			Deployments:    []*appsv1.Deployment{elDeployment},
 			ConfigMaps:     []*corev1.ConfigMap{loggingConfigMap, observabilityConfigMap},
 		},
@@ -1208,7 +1208,7 @@ func TestReconcile(t *testing.T) {
 		endResources: test.Resources{
 			Namespaces:     []*corev1.Namespace{namespaceResource},
 			EventListeners: []*v1beta1.EventListener{elWithStatus},
-			Deployments:    []*appsv1.Deployment{elDeployment}, // labels are removed
+			Deployments:    []*appsv1.Deployment{elDeploymentWithAnnotations},
 			Services:       []*corev1.Service{elService},
 			ConfigMaps:     []*corev1.ConfigMap{loggingConfigMap, observabilityConfigMap},
 		},

--- a/pkg/reconciler/eventlistener/resources/custom.go
+++ b/pkg/reconciler/eventlistener/resources/custom.go
@@ -30,11 +30,11 @@ import (
 	"knative.dev/pkg/metrics"
 )
 
-func MakeCustomObject(el *v1beta1.EventListener, c Config) (*unstructured.Unstructured, *corev1.Container, error) {
+func MakeCustomObject(el *v1beta1.EventListener, c Config) (*unstructured.Unstructured, error) {
 	original := &duckv1.WithPod{}
 	decoder := json.NewDecoder(bytes.NewBuffer(el.Spec.Resources.CustomResource.Raw))
 	if err := decoder.Decode(&original); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	customObjectData := original.DeepCopy()
@@ -119,11 +119,11 @@ func MakeCustomObject(el *v1beta1.EventListener, c Config) (*unstructured.Unstru
 	}
 	marshaledData, err := json.Marshal(original)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	data := new(unstructured.Unstructured)
 	if err := data.UnmarshalJSON(marshaledData); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	if data.GetName() == "" {
@@ -132,5 +132,5 @@ func MakeCustomObject(el *v1beta1.EventListener, c Config) (*unstructured.Unstru
 	data.SetNamespace(namespace)
 	data.SetOwnerReferences([]metav1.OwnerReference{*kmeta.NewControllerRef(el)})
 
-	return data, &container, nil
+	return data, nil
 }

--- a/pkg/reconciler/eventlistener/resources/custom_test.go
+++ b/pkg/reconciler/eventlistener/resources/custom_test.go
@@ -327,7 +327,7 @@ func TestCustomObject(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _, err := MakeCustomObject(tt.el, config)
+			got, err := MakeCustomObject(tt.el, config)
 			if err != nil {
 				t.Fatalf("MakeCustomObject() = %v", err)
 			}
@@ -350,7 +350,7 @@ func TestCustomObjectError(t *testing.T) {
 
 	config := *MakeConfig()
 
-	got, _, err := MakeCustomObject(makeEL(func(el *v1beta1.EventListener) {
+	got, err := MakeCustomObject(makeEL(func(el *v1beta1.EventListener) {
 		el.Spec.Resources.CustomResource = &v1beta1.CustomResource{
 			RawExtension: runtime.RawExtension{
 				Raw: []byte(`garbage`),

--- a/pkg/reconciler/eventlistener/resources/deployment.go
+++ b/pkg/reconciler/eventlistener/resources/deployment.go
@@ -63,10 +63,10 @@ func MakeDeployment(el *v1beta1.EventListener, c Config) (*appsv1.Deployment, er
 	container := MakeContainer(el, c, opt, addCertsForSecureConnection(c))
 
 	var (
-		replicas                  = ptr.Int32(1)
 		podlabels                 = kmeta.UnionMaps(el.Labels, GenerateLabels(el.Name, c.StaticResourceLabels))
 		serviceAccountName        = el.Spec.ServiceAccountName
 		vol                       = []corev1.Volume{configLoggingVolume}
+		replicas                  *int32
 		tolerations               []corev1.Toleration
 		nodeSelector, annotations map[string]string
 	)

--- a/pkg/reconciler/eventlistener/resources/deployment_test.go
+++ b/pkg/reconciler/eventlistener/resources/deployment_test.go
@@ -62,7 +62,6 @@ func TestDeployment(t *testing.T) {
 				OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(makeEL())},
 			},
 			Spec: appsv1.DeploymentSpec{
-				Replicas: ptr.Int32(1),
 				Selector: &metav1.LabelSelector{
 					MatchLabels: labels,
 				},
@@ -143,7 +142,6 @@ func TestDeployment(t *testing.T) {
 				OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(makeEL())},
 			},
 			Spec: appsv1.DeploymentSpec{
-				Replicas: ptr.Int32(1),
 				Selector: &metav1.LabelSelector{
 					MatchLabels: labels,
 				},
@@ -191,7 +189,6 @@ func TestDeployment(t *testing.T) {
 				OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(makeEL())},
 			},
 			Spec: appsv1.DeploymentSpec{
-				Replicas: ptr.Int32(1),
 				Selector: &metav1.LabelSelector{
 					MatchLabels: labels,
 				},
@@ -236,7 +233,6 @@ func TestDeployment(t *testing.T) {
 				OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(makeEL())},
 			},
 			Spec: appsv1.DeploymentSpec{
-				Replicas: ptr.Int32(1),
 				Selector: &metav1.LabelSelector{
 					MatchLabels: labels,
 				},
@@ -268,7 +264,6 @@ func TestDeployment(t *testing.T) {
 				OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(makeEL())},
 			},
 			Spec: appsv1.DeploymentSpec{
-				Replicas: ptr.Int32(1),
 				Selector: &metav1.LabelSelector{
 					MatchLabels: labels,
 				},


### PR DESCRIPTION
Generally the flow we follow for reconciling child resources is something like this pseudo-code:
```go

want := resources.MakeThing(ctx, obj)

existing, err := lister.Get(name)
if apierrs.IsNotFound(err) {
  // It does not exist, so create it.
  created, err := client.Create(want)
  if err != nil {
    return err
  }
  existing = created
} else if err != nil {
  return err
} else if !equality.Semantic.DeepEqual(existing.Spec, want.Spec) { // Maybe also Labels/Annotations
  existing = existing.DeepCopy() // Don't modify the lister cache!
  existing.Spec = want.Spec // Fill in the parts we own (maybe also labels/annotations)
  updated, err := client.Update(existing)
  if err != nil {
    return err
  } else if existing.ResourceVersion != updated.ResourceVersion {
    // It changed!
  }
  existing = updated
}

// Update status based on what's in "existing"

```

The field-wise reconciliation that was happening previously was extremely verbose and hard to follow (and likely error-prone), so I have adjusted to follow this pattern across:
 * `reconcileService`: caveat here is that Service has a few output "spec" fields (warts of early-days K8s), which we need to copy over (e.g. `clusterIP` and `nodePort`s).
 * `reconcileDeployment`: caveat here is that to support scaling the deployment we use unspecified `replicas` as a guide (this is why `replicas` is a nullable field!).
 * `reconcileCustomObject`: caveat here is that we don't have strong types, or a lister.  I left a ton of TODOs here and even found a bug.

Other changes:
 * If the user doesn't specify `replicas` then neither do we (it defaults to 1), this is the conventional signal to NOT reconcile this field, so that the Deployment can be HPA'd.
 * Fix a test bug where the wrong security context was being cleared in a test.
 * Drop the container return value from `MakeCustomObject` (we no longer need it!)

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
EventListener is more aggressive about reconciling its child resources, so changes to their spec should be done through the EventListener object itself.
Autoscaling of the EventListener Deployment is allowed iff `replicas:` is omitted.
```
