### PR TITLE
Raise the resync period to something more reasonable.

### DIFF
--- a/cmd/eventlistenersink/main.go
+++ b/cmd/eventlistenersink/main.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	cminformer "knative.dev/pkg/configmap/informer"
+	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection"
 	"knative.dev/pkg/injection/sharedmain"
 	"knative.dev/pkg/logging"
@@ -130,10 +131,10 @@ func main() {
 
 	// Create a sharedInformer factory so that we can cache API server calls
 	factory := externalversions.NewSharedInformerFactoryWithOptions(sinkClients.TriggersClient,
-		30*time.Second, externalversions.WithNamespace(sinkArgs.ElNamespace))
+		controller.DefaultResyncPeriod, externalversions.WithNamespace(sinkArgs.ElNamespace))
 	if sinkArgs.IsMultiNS {
 		factory = externalversions.NewSharedInformerFactory(sinkClients.TriggersClient,
-			30*time.Second)
+			controller.DefaultResyncPeriod)
 	}
 
 	recorder, err := sink.NewRecorder()


### PR DESCRIPTION
A 30s resync period is an unfortunate anti-pattern perpetuated by `k8s.io/sample-controller`, which has historically:
 * Masked bugs due to a missing informer event (hidden in e2e tests by the frequent "resync"),
 * Leads to problems at scale (lots of resources) because 30s is inadequate to process all resources continuously.

The `controller.DefaultResyncPeriod` is `10h` adopted from controller-runtime, and the main motivation for using
anything lower than this would be if it were necessary to poll an external system not modeled by informers, where
the resync period effectively becomes a ceiling on the poll interval.

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
