### PR TITLE
Patch vendor/ apimachinery to work on 1.22

### DIFF
--- a/hack/patches/patch-vendor-apimachinery-to-work-on-1.22.patch
+++ b/hack/patches/patch-vendor-apimachinery-to-work-on-1.22.patch
@@ -1,0 +1,38 @@
+From 041c3e5eb0cd8bd2f96946692acdf86822737d54 Mon Sep 17 00:00:00 2001
+From: Vincent Demeester <vdemeest@redhat.com>
+Date: Tue, 17 Aug 2021 09:44:24 +0200
+Subject: [PATCH] Patch vendor/ apimachinery to work on 1.22
+
+A new field is there in k8s 1.22, name subresource in the
+managedfields. This proves to make knative based types to not be valid
+on 1.22 and above, making tektoncd/pipeline as well as any other
+component using knative/pkg to be broken on 1.22 and above.
+
+Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
+---
+ vendor/k8s.io/apimachinery/pkg/apis/meta/v1/types.go | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/types.go b/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+index d84878d7..522336cb 100644
+--- a/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
++++ b/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+@@ -1158,6 +1158,15 @@ type ManagedFieldsEntry struct {
+ 	// FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
+ 	// +optional
+ 	FieldsV1 *FieldsV1 `json:"fieldsV1,omitempty" protobuf:"bytes,7,opt,name=fieldsV1"`
++
++	// Subresource is the name of the subresource used to update that object, or
++	// empty string if the object was updated through the main resource. The
++	// value of this field is used to distinguish between managers, even if they
++	// share the same name. For example, a status update will be distinct from a
++	// regular update using the same manager name.
++	// Note that the APIVersion field is not related to the Subresource field and
++	// it always corresponds to the version of the main resource.
++	Subresource string `json:"subresource,omitempty" protobuf:"bytes,8,opt,name=subresource"`
+ }
+ 
+ // ManagedFieldsOperationType is the type of operation which lead to a ManagedFieldsEntry being created.
+-- 
+2.32.0
+

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -52,4 +52,13 @@ fi
 go mod tidy
 go mod vendor
 
+# Applying patches
+if [[ -d hack/patches ]];then
+    for f in hack/patches/*.patch;do
+        [[ -f ${f} ]] || continue
+        # Apply patches but do not commit
+        git apply ${f}
+    done
+fi
+
 update_licenses third_party/

--- a/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -1157,6 +1157,15 @@ type ManagedFieldsEntry struct {
 	// FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
 	// +optional
 	FieldsV1 *FieldsV1 `json:"fieldsV1,omitempty" protobuf:"bytes,7,opt,name=fieldsV1"`
+
+	// Subresource is the name of the subresource used to update that object, or
+	// empty string if the object was updated through the main resource. The
+	// value of this field is used to distinguish between managers, even if they
+	// share the same name. For example, a status update will be distinct from a
+	// regular update using the same manager name.
+	// Note that the APIVersion field is not related to the Subresource field and
+	// it always corresponds to the version of the main resource.
+	Subresource string `json:"subresource,omitempty" protobuf:"bytes,8,opt,name=subresource"`
 }
 
 // ManagedFieldsOperationType is the type of operation which lead to a ManagedFieldsEntry being created.


### PR DESCRIPTION
Cherry-pick of https://github.com/tektoncd/triggers/pull/1197 to support Triggers v0.15.x on K8s v.122

(cherry picked from commit ce5e0f0f6a7dee422cde7e3e8c1855aed0277852)

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [N/A ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ N/A ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ N/A ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ N/A ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
NONE
```