### PR TITLE
eldeployment: remove securityContext.runAsUser

### DIFF
--- a/pkg/reconciler/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/eventlistener/eventlistener_test.go
@@ -260,7 +260,6 @@ func makeDeployment(ops ...func(d *appsv1.Deployment)) *appsv1.Deployment {
 					}},
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: ptr.Bool(true),
-						RunAsUser:    ptr.Int64(65532),
 					},
 				},
 			},

--- a/pkg/reconciler/eventlistener/resources/deployment.go
+++ b/pkg/reconciler/eventlistener/resources/deployment.go
@@ -50,7 +50,6 @@ var (
 	}
 	strongerSecurityPolicy = corev1.PodSecurityContext{
 		RunAsNonRoot: ptr.Bool(true),
-		RunAsUser:    ptr.Int64(65532),
 	}
 )
 


### PR DESCRIPTION
The setting on `securityContext.runAsUser` is redundant. The container
runtime determines which user to run based on image config and thus uses
65532 by default.

Furthermore, some kubernetes distributions randomizes runAsUser id
according to their security policies(for e.g, openshift enables per
application uid range), and when that happens, the uid can be set to
something else.

```console
$ crane config gcr.io/distroless/static:nonroot | jq .
{
  "architecture": "amd64",
  "author": "Bazel",
  "created": "1970-01-01T00:00:00Z",
  "history": [
    {
      "author": "Bazel",
      "created": "1970-01-01T00:00:00Z",
      "created_by": "bazel build ..."
    }
  ],
  "os": "linux",
  "rootfs": {
    "type": "layers",
    "diff_ids": [
      "sha256:07363fa8421000ad294c2881d17b0535aabdd17ced2a874eb354a9d8514d3d59"
    ]
  },
  "config": {
    "Env": [
      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
      "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"
    ],
    "User": "65532",
    "WorkingDir": "/home/nonroot"
  }
}
```

See `config.User` on its default configuration.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```