### PR TITLE
Add metadata to our publish task for Tekton Chains to observe & sign

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: publish-triggers-release
+  annotations:
+    chains.tekton.dev/transparency-upload: "true"
 spec:
   params:
   - name: package
@@ -55,6 +57,10 @@ spec:
       value: "$(params.imageRegistryRegions)"
     - name: OUTPUT_RELEASE_DIR
       value: "$(workspaces.output.path)/$(params.versionTag)"
+  results:
+    # IMAGES result is picked up by Tekton Chains to sign the release.
+    # See https://github.com/tektoncd/plumbing/blob/main/docs/signing.md for more info.
+    - name: IMAGES
   steps:
 
   - name: container-registy-auth
@@ -173,6 +179,8 @@ spec:
         IMAGE_WITHOUT_SHA_AND_TAG=${IMAGE_WITHOUT_SHA%%:*}
         IMAGE_WITH_SHA=${IMAGE_WITHOUT_SHA_AND_TAG}@${IMAGE##*@}
 
+        echo $IMAGE_WITH_SHA, >> $(results.IMAGES.path)
+
         if [[ "$(params.releaseAsLatest)" == "true" ]]
         then
           crane cp ${IMAGE_WITH_SHA} ${IMAGE_WITHOUT_SHA_AND_TAG}:latest
@@ -189,6 +197,7 @@ spec:
           else
             TAG="$(params.versionTag)"
             crane cp ${IMAGE_WITH_SHA} ${REGION}.${IMAGE_WITHOUT_SHA_AND_TAG}:$TAG
+            echo ${REGION}.$IMAGE_WITH_SHA, >> $(results.IMAGES.path)
           fi
         done
       done


### PR DESCRIPTION
# Changes

This commit adds an annotation to indicate that build provenance should be
generated and an IMAGES result composed of a comma-separated list of
imageNames+digest to be signed.

This change is based on
https://github.com/tektoncd/chains/blob/main/release/publish.yaml and
https://github.com/tektoncd/plumbing/blob/main/docs/signing.md

/kind misc

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```