### PR TITLE
Add kubernetes based events for triggers

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -85,6 +85,9 @@ rules:
     resources: ["podsecuritypolicies"]
     resourceNames: ["tekton-triggers"]
     verbs: ["use"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create"]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,51 @@
+<!--
+---
+linkTitle: "Events"
+weight: 700
+---
+-->
+# Events in Tekton Triggers
+
+Triggers event controller emits [Kubernetes events](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#event-v1-core)
+when EventListener get request to process `Triggers`. This allows you to monitor and react to what's happening during execution by
+retrieving those events using the `kubectl get events` command.
+
+## Events in `EventListener`
+
+`EventListener` emit events for the following `Reasons`:
+
+- `Started`: emitted the first time when the `EventListener` received request.
+- `Succeeded`: emitted when eventlistener received request and process all triggers request.
+- `Failed`: emitted if triggers failed to process the request.
+
+## Events format
+
+Resource            |Event      |Event Type
+:-------------------|:---------:|:----------------------------------------------------------
+`EventListener`     | `Started` | `dev.tekton.event.triggers.started.v1`
+`EventListener`     | `Succeed` | `dev.tekton.event.triggers.successful.v1`
+`EventListener`     | `Failed`  | `dev.tekton.event.triggers.failed.v1`
+
+##Note
+By default Kubernetes events are disabled for EventListener.
+
+To enable Kubernetes events for each EventListener need to add below annotation
+```yaml
+  annotations:
+    enable-eventlistener-events: "true"
+```
+
+ex:
+```yaml
+apiVersion: triggers.tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: github-listener
+  annotations:
+    enable-eventlistener-events: "true"
+spec:
+---
+```
+To view the events execute below command
+
+`kubectl get events`

--- a/pkg/apis/triggers/v1alpha1/event_listener_types.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_types.go
@@ -261,6 +261,12 @@ func (els *EventListenerStatus) SetConditionsForDynamicObjects(conditions v1beta
 			Message: cond.Message,
 		})
 	}
+
+	els.SetCondition(&apis.Condition{
+		Type:    apis.ConditionReady,
+		Status:  corev1.ConditionTrue,
+		Message: "EventListener is ready",
+	})
 }
 
 // SetExistsCondition simplifies setting the exists conditions on the

--- a/pkg/apis/triggers/v1alpha1/event_listener_types_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_types_test.go
@@ -289,8 +289,8 @@ func TestSetConditionsForDynamicObjects(t *testing.T) {
 			Conditions: []apis.Condition{{
 				Type:    apis.ConditionReady,
 				Status:  corev1.ConditionTrue,
-				Reason:  "Reason",
-				Message: "Message",
+				Reason:  "",
+				Message: "EventListener is ready",
 			}},
 		},
 	}

--- a/pkg/apis/triggers/v1beta1/event_listener_types.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_types.go
@@ -287,6 +287,12 @@ func (els *EventListenerStatus) SetConditionsForDynamicObjects(conditions v1beta
 			Message: cond.Message,
 		})
 	}
+
+	els.SetCondition(&apis.Condition{
+		Type:    apis.ConditionReady,
+		Status:  corev1.ConditionTrue,
+		Message: "EventListener is ready",
+	})
 }
 
 // SetExistsCondition simplifies setting the exists conditions on the

--- a/pkg/apis/triggers/v1beta1/event_listener_types_test.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_types_test.go
@@ -289,8 +289,8 @@ func TestSetConditionsForDynamicObjects(t *testing.T) {
 			Conditions: []apis.Condition{{
 				Type:    apis.ConditionReady,
 				Status:  corev1.ConditionTrue,
-				Reason:  "Reason",
-				Message: "Message",
+				Reason:  "",
+				Message: "EventListener is ready",
 			}},
 		},
 	}

--- a/pkg/reconciler/eventlistener/eventlistener.go
+++ b/pkg/reconciler/eventlistener/eventlistener.go
@@ -19,7 +19,6 @@ package eventlistener
 import (
 	"context"
 	"encoding/json"
-	stdError "errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -342,8 +341,8 @@ func (r *Reconciler) reconcileCustomObject(ctx context.Context, el *v1beta1.Even
 		for _, cond := range customConditions {
 			if cond.Type == apis.ConditionReady {
 				if cond.Status != corev1.ConditionTrue {
-					logging.FromContext(ctx).Warn("custom object is not yet ready")
-					return stdError.New("custom object is not yet ready")
+					logging.FromContext(ctx).Warnf("custom object is not yet ready because %s", cond.Message)
+					return fmt.Errorf("custom object is not yet ready because %s", cond.Message)
 				}
 			}
 		}

--- a/pkg/reconciler/events/doc.go
+++ b/pkg/reconciler/events/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package events defines the interface and different implementations for events
+//
+// Tekton uses events to notify about changes in Condition of resources, like a
+// TaskRun is starting, a PipelineRun failed to run or could not be validated.
+package events

--- a/pkg/reconciler/events/event.go
+++ b/pkg/reconciler/events/event.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package events
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+)
+
+const (
+	// Emit events if user provides enable-eventlistener-events: "true"
+	EnableEventListenerEvents = "enable-eventlistener-events"
+	// TriggerProcessingStartedV1 is sent for Sink Triggers when a trigger is started
+	TriggerProcessingStartedV1 = "dev.tekton.event.triggers.started.v1"
+	// TriggerProcessingSuccessfulV1 is sent for Sink Triggers when a trigger is successful
+	TriggerProcessingSuccessfulV1 = "dev.tekton.event.triggers.successful.v1"
+	// TriggerProcessingFailedEventV1 is sent for Sink Triggers when we fail to process trigger
+	TriggerProcessingFailedV1 = "dev.tekton.event.triggers.failed.v1"
+)
+
+// Emit emits events for object
+// Supported events are k8s events.
+func Emit(recorder record.EventRecorder, eventType string, object runtime.Object, err error) {
+	sendKubernetesEvents(recorder, eventType, object, err)
+}
+
+func sendKubernetesEvents(c record.EventRecorder, eventType string, object runtime.Object, err error) {
+	switch err {
+	case nil:
+		if eventType == TriggerProcessingFailedV1 {
+			c.Event(object, corev1.EventTypeWarning, eventType, "")
+		} else {
+			c.Event(object, corev1.EventTypeNormal, eventType, "")
+		}
+	default:
+		c.Event(object, corev1.EventTypeWarning, eventType, err.Error())
+	}
+}

--- a/pkg/reconciler/events/event_test.go
+++ b/pkg/reconciler/events/event_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
+	"k8s.io/client-go/tools/record"
+)
+
+func TestEmit(t *testing.T) {
+	testcases := []struct {
+		name      string
+		eventType string
+		error     error
+		reason    string
+		wantEvent string
+	}{{
+		name:      "Trigger processing is success",
+		eventType: TriggerProcessingSuccessfulV1,
+		error:     nil,
+		wantEvent: "Normal dev.tekton.event.triggers.successful.v1",
+	}, {
+		name:      "Trigger processing is started",
+		eventType: TriggerProcessingStartedV1,
+		error:     nil,
+		wantEvent: "Normal dev.tekton.event.triggers.started.v1",
+	}, {
+		name:      "EventListener is Ready but some operation failed while serving HTTP req",
+		eventType: TriggerProcessingFailedV1,
+		error:     errors.New("failed to read request body"),
+		wantEvent: "Warning dev.tekton.event.triggers.failed.v1 failed to read request body",
+	}}
+
+	for _, ts := range testcases {
+		fr := record.NewFakeRecorder(1)
+		tr := &v1beta1.EventListener{}
+		sendKubernetesEvents(fr, ts.eventType, tr, ts.error)
+
+		err := checkEvents(t, fr, ts.name, ts.wantEvent)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+	}
+}
+
+func eventFromChannel(c chan string, testName string, wantEvent string) error {
+	timer := time.NewTimer(10 * time.Millisecond)
+	select {
+	case event := <-c:
+		if wantEvent == "" {
+			return fmt.Errorf("received event \"%s\" for %s but none expected", event, testName)
+		}
+		matching, err := regexp.MatchString(wantEvent, event)
+		if err == nil {
+			if !matching {
+				return fmt.Errorf("expected event \"%s\" but got \"%s\" instead for %s", wantEvent, event, testName)
+			}
+		}
+	case <-timer.C:
+		if wantEvent != "" {
+			return fmt.Errorf("received no events for %s but %s expected", testName, wantEvent)
+		}
+	}
+	return nil
+}
+
+func checkEvents(t *testing.T, fr *record.FakeRecorder, testName string, wantEvent string) error {
+	t.Helper()
+	return eventFromChannel(fr.Events, testName, wantEvent)
+}

--- a/pkg/sink/initialization.go
+++ b/pkg/sink/initialization.go
@@ -92,6 +92,7 @@ type Clients struct {
 	DiscoveryClient discoveryclient.DiscoveryInterface
 	RESTClient      restclient.Interface
 	TriggersClient  triggersclientset.Interface
+	K8sClient       *kubeclientset.Clientset
 }
 
 // GetArgs returns the flagged Args
@@ -136,5 +137,6 @@ func ConfigureClients(clusterConfig *rest.Config) (Clients, error) {
 		DiscoveryClient: kubeClient.Discovery(),
 		RESTClient:      kubeClient.RESTClient(),
 		TriggersClient:  triggersClient,
+		K8sClient:       kubeClient,
 	}, nil
 }

--- a/pkg/sink/sink.go
+++ b/pkg/sink/sink.go
@@ -33,6 +33,7 @@ import (
 	listers "github.com/tektoncd/triggers/pkg/client/listers/triggers/v1beta1"
 	"github.com/tektoncd/triggers/pkg/interceptors"
 	"github.com/tektoncd/triggers/pkg/interceptors/webhook"
+	"github.com/tektoncd/triggers/pkg/reconciler/events"
 	"github.com/tektoncd/triggers/pkg/resources"
 	"github.com/tektoncd/triggers/pkg/template"
 	"github.com/tidwall/sjson"
@@ -42,6 +43,7 @@ import (
 	discoveryclient "k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
 )
 
 var (
@@ -65,6 +67,7 @@ type Sink struct {
 	// WGProcessTriggers keeps track of triggers or triggerGroups currently being processed
 	// Currently only used in tests to wait for all triggers to finish processing
 	WGProcessTriggers *sync.WaitGroup
+	EventRecorder     record.EventRecorder
 
 	// listers index properties about resources
 	EventListenerLister         listers.EventListenerLister
@@ -91,19 +94,42 @@ type Response struct {
 	ErrorMessage string `json:"errorMessage,omitempty"`
 }
 
+func (r Sink) emitEvents(recorder record.EventRecorder, el *triggersv1.EventListener, eventType string, err error) {
+	if el.Annotations[events.EnableEventListenerEvents] == "true" {
+		events.Emit(recorder, eventType, el, err)
+	}
+}
+
 // HandleEvent processes an incoming HTTP event for the event listener.
 func (r Sink) HandleEvent(response http.ResponseWriter, request *http.Request) {
 	log := r.Logger.With(
 		zap.String("eventlistener", r.EventListenerName),
 		zap.String("namespace", r.EventListenerNamespace),
 	)
+	elTemp := triggersv1.EventListener{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "EventListener",
+			APIVersion: "v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      r.EventListenerName,
+			Namespace: r.EventListenerNamespace,
+			Annotations: map[string]string{
+				// enabled by default for temporary EL
+				events.EnableEventListenerEvents: "true",
+			}}}
+
 	el, err := r.EventListenerLister.EventListeners(r.EventListenerNamespace).Get(r.EventListenerName)
 	if err != nil {
 		log.Errorf("Error getting EventListener %s in Namespace %s: %s", r.EventListenerName, r.EventListenerNamespace, err)
 		r.recordCountMetrics(failTag)
 		response.WriteHeader(http.StatusInternalServerError)
+		r.emitEvents(r.EventRecorder, &elTemp, events.TriggerProcessingFailedV1, err)
 		return
 	}
+
+	r.emitEvents(r.EventRecorder, el, events.TriggerProcessingStartedV1, nil)
+
 	elUID := string(el.GetUID())
 	log = log.With(zap.String("eventlistenerUID", elUID))
 	event, err := ioutil.ReadAll(request.Body)
@@ -111,6 +137,7 @@ func (r Sink) HandleEvent(response http.ResponseWriter, request *http.Request) {
 		log.Errorf("Error reading event body: %s", err)
 		r.recordCountMetrics(failTag)
 		response.WriteHeader(http.StatusInternalServerError)
+		r.emitEvents(r.EventRecorder, el, events.TriggerProcessingFailedV1, err)
 		return
 	}
 
@@ -121,6 +148,7 @@ func (r Sink) HandleEvent(response http.ResponseWriter, request *http.Request) {
 	if err != nil {
 		r.Logger.Errorf("unable to select configured mergedTriggers: %s", err)
 		response.WriteHeader(http.StatusInternalServerError)
+		r.emitEvents(r.EventRecorder, el, events.TriggerProcessingFailedV1, err)
 		return
 	}
 
@@ -129,6 +157,7 @@ func (r Sink) HandleEvent(response http.ResponseWriter, request *http.Request) {
 	if err != nil {
 		log.Errorf("error merging triggers: %s", err)
 		response.WriteHeader(http.StatusInternalServerError)
+		r.emitEvents(r.EventRecorder, el, events.TriggerProcessingFailedV1, err)
 		return
 	}
 	r.WGProcessTriggers.Add(len(mergedTriggers))
@@ -161,7 +190,9 @@ func (r Sink) HandleEvent(response http.ResponseWriter, request *http.Request) {
 	}
 	if err := json.NewEncoder(response).Encode(body); err != nil {
 		log.Errorf("failed to write back sink response: %v", err)
+		r.emitEvents(r.EventRecorder, el, events.TriggerProcessingFailedV1, err)
 	}
+	r.emitEvents(r.EventRecorder, el, events.TriggerProcessingSuccessfulV1, nil)
 }
 
 func (r Sink) merge(et []triggersv1.EventListenerTrigger, trItems []*triggersv1.Trigger) ([]*triggersv1.Trigger, error) {

--- a/pkg/sink/validate_payload_test.go
+++ b/pkg/sink/validate_payload_test.go
@@ -25,7 +25,9 @@ import (
 
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/test"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 )
 
 func TestSink_IsValidPayload(t *testing.T) {
@@ -76,6 +78,14 @@ func TestSink_IsValidPayload(t *testing.T) {
 				elName = tc.testResources.EventListeners[0].Name
 			}
 			sink, _ := getSinkAssets(t, tc.testResources, elName, nil)
+
+			for _, el := range tc.testResources.EventListeners {
+				el.Status.SetCondition(&apis.Condition{
+					Type:    apis.ConditionReady,
+					Status:  corev1.ConditionTrue,
+					Message: "EventListener is Ready",
+				})
+			}
 
 			ts := httptest.NewServer(sink.IsValidPayload(http.HandlerFunc(sink.HandleEvent)))
 			defer ts.Close()
@@ -140,6 +150,13 @@ func TestSink_IsValidPayload_PayloadValidation(t *testing.T) {
 			}
 			sink, _ := getSinkAssets(t, tc.testResources, elName, nil)
 
+			for _, el := range tc.testResources.EventListeners {
+				el.Status.SetCondition(&apis.Condition{
+					Type:    apis.ConditionReady,
+					Status:  corev1.ConditionTrue,
+					Message: "EventListener is Ready",
+				})
+			}
 			// Disabling payload validation
 			sink.PayloadValidation = false
 


### PR DESCRIPTION
# Changes

This PR adds changes to display k8s events for EventListener Pod when http request reaches to EL

```
kubectl get events -w | grep eventlistener

0s          Normal    dev.tekton.event.triggers.started.v1   eventlistener/github-listener              
0s          Normal    dev.tekton.event.triggers.successful.v1   eventlistener/github-listener              

```
/cc @dibyom @khrm

Addresses https://github.com/tektoncd/triggers/issues/649

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
Triggers now support emitting Kubernetes events from EventListener Pod
```