### PR TITLE
Fix issue 1219

### DIFF
--- a/pkg/reconciler/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/eventlistener/eventlistener_test.go
@@ -390,7 +390,8 @@ func makeWithPod(ops ...func(d *duckv1.WithPod)) *duckv1.WithPod {
 			OwnerReferences: []metav1.OwnerReference{
 				*ownerRefs,
 			},
-			Labels: generatedLabels,
+			Labels:          generatedLabels,
+			ResourceVersion: "testresourceversion",
 		},
 		Spec: duckv1.WithPodSpec{
 			Template: duckv1.PodSpecable{
@@ -669,7 +670,8 @@ func TestReconcile(t *testing.T) {
 					APIVersion: "serving.knative.dev/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name: generatedResourceName,
+					Name:            generatedResourceName,
+					ResourceVersion: "testresourceversion",
 				},
 				Spec: duckv1.WithPodSpec{Template: duckv1.PodSpecable{
 					Spec: corev1.PodSpec{
@@ -697,7 +699,8 @@ func TestReconcile(t *testing.T) {
 					APIVersion: "serving.knative.dev/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name: generatedResourceName,
+					Name:            generatedResourceName,
+					ResourceVersion: "testresourceversion",
 				},
 				Spec: duckv1.WithPodSpec{
 					Template: duckv1.PodSpecable{
@@ -719,7 +722,8 @@ func TestReconcile(t *testing.T) {
 					APIVersion: "serving.knative.dev/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name: generatedResourceName,
+					Name:            generatedResourceName,
+					ResourceVersion: "testresourceversion",
 				},
 				Spec: duckv1.WithPodSpec{
 					Template: duckv1.PodSpecable{
@@ -742,7 +746,8 @@ func TestReconcile(t *testing.T) {
 					APIVersion: "serving.knative.dev/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name: generatedResourceName,
+					Name:            generatedResourceName,
+					ResourceVersion: "testresourceversion",
 				},
 				Spec: duckv1.WithPodSpec{
 					Template: duckv1.PodSpecable{
@@ -763,7 +768,8 @@ func TestReconcile(t *testing.T) {
 					APIVersion: "serving.knative.dev/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name: generatedResourceName,
+					Name:            generatedResourceName,
+					ResourceVersion: "testresourceversion",
 					Annotations: map[string]string{
 						"key": "value",
 					},


### PR DESCRIPTION
# Changes

Fixes issue #1219 

The problem was that the object being updated was created without the proper ObjectMeta, namely ResourceVersion was missing. So, use the fetched resource, overwrite: labels, annotations, and spec and then update with that.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
Fix issue #1219 
```

