### PR TITLE
Add tests for validating that the error we get back is what we expect.

### DIFF
--- a/pkg/apis/triggers/v1beta1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_validation_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	pipelinev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/triggers/pkg/apis/triggers"
@@ -33,6 +34,11 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/ptr"
 )
+
+var myObjectMeta = metav1.ObjectMeta{
+	Name:      "name",
+	Namespace: "namespace",
+}
 
 func Test_EventListenerValidate_OnDelete(t *testing.T) {
 	el := &triggersv1beta1.EventListener{
@@ -56,15 +62,13 @@ func Test_EventListenerValidate_OnDelete(t *testing.T) {
 
 func Test_EventListenerValidate(t *testing.T) {
 	tests := []struct {
-		name string
-		el   *triggersv1beta1.EventListener
+		name    string
+		el      *triggersv1beta1.EventListener
+		wantErr *apis.FieldError
 	}{{
 		name: "TriggerTemplate Does Not Exist",
 		el: &triggersv1beta1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
+			ObjectMeta: myObjectMeta,
 			Spec: triggersv1beta1.EventListenerSpec{
 				Triggers: []triggersv1beta1.EventListenerTrigger{{
 					Template: &triggersv1beta1.EventListenerTemplate{
@@ -77,10 +81,7 @@ func Test_EventListenerValidate(t *testing.T) {
 	}, {
 		name: "Valid EventListener No TriggerBinding",
 		el: &triggersv1beta1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
+			ObjectMeta: myObjectMeta,
 			Spec: triggersv1beta1.EventListenerSpec{
 				Triggers: []triggersv1beta1.EventListenerTrigger{{
 					Template: &triggersv1beta1.EventListenerTemplate{
@@ -93,10 +94,7 @@ func Test_EventListenerValidate(t *testing.T) {
 	}, {
 		name: "Valid EventListener with TriggerRef",
 		el: &triggersv1beta1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
+			ObjectMeta: myObjectMeta,
 			Spec: triggersv1beta1.EventListenerSpec{
 				Triggers: []triggersv1beta1.EventListenerTrigger{{
 					TriggerRef: "tt",
@@ -120,10 +118,7 @@ func Test_EventListenerValidate(t *testing.T) {
 	}, {
 		name: "Valid EventListener with TriggerBinding",
 		el: &triggersv1beta1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
+			ObjectMeta: myObjectMeta,
 			Spec: triggersv1beta1.EventListenerSpec{
 				Triggers: []triggersv1beta1.EventListenerTrigger{{
 					Bindings: []*triggersv1beta1.EventListenerBinding{{
@@ -140,10 +135,7 @@ func Test_EventListenerValidate(t *testing.T) {
 	}, {
 		name: "Valid EventListener with ClusterTriggerBinding",
 		el: &triggersv1beta1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
+			ObjectMeta: myObjectMeta,
 			Spec: triggersv1beta1.EventListenerSpec{
 				Triggers: []triggersv1beta1.EventListenerTrigger{{
 					Bindings: []*triggersv1beta1.EventListenerBinding{{
@@ -160,10 +152,7 @@ func Test_EventListenerValidate(t *testing.T) {
 	}, {
 		name: "Valid EventListener with multiple TriggerBindings",
 		el: &triggersv1beta1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
+			ObjectMeta: myObjectMeta,
 			Spec: triggersv1beta1.EventListenerSpec{
 				Triggers: []triggersv1beta1.EventListenerTrigger{{
 					Bindings: []*triggersv1beta1.EventListenerBinding{{
@@ -188,10 +177,7 @@ func Test_EventListenerValidate(t *testing.T) {
 	}, {
 		name: "Valid EventListener Webhook Interceptor",
 		el: &triggersv1beta1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
+			ObjectMeta: myObjectMeta,
 			Spec: triggersv1beta1.EventListenerSpec{
 				Triggers: []triggersv1beta1.EventListenerTrigger{{
 					Interceptors: []*triggersv1beta1.EventInterceptor{{
@@ -218,10 +204,7 @@ func Test_EventListenerValidate(t *testing.T) {
 	}, {
 		name: "Valid EventListener Interceptor With Header",
 		el: &triggersv1beta1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
+			ObjectMeta: myObjectMeta,
 			Spec: triggersv1beta1.EventListenerSpec{
 				Triggers: []triggersv1beta1.EventListenerTrigger{{
 					Interceptors: []*triggersv1beta1.EventInterceptor{{
@@ -261,10 +244,7 @@ func Test_EventListenerValidate(t *testing.T) {
 	}, {
 		name: "Valid EventListener Two Triggers",
 		el: &triggersv1beta1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
+			ObjectMeta: myObjectMeta,
 			Spec: triggersv1beta1.EventListenerSpec{
 				Triggers: []triggersv1beta1.EventListenerTrigger{{
 					Bindings: []*triggersv1beta1.EventListenerBinding{{
@@ -290,10 +270,7 @@ func Test_EventListenerValidate(t *testing.T) {
 	}, {
 		name: "Valid EventListener with CEL interceptor",
 		el: &triggersv1beta1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
+			ObjectMeta: myObjectMeta,
 			Spec: triggersv1beta1.EventListenerSpec{
 				Triggers: []triggersv1beta1.EventListenerTrigger{{
 					Interceptors: []*triggersv1beta1.EventInterceptor{{
@@ -327,10 +304,7 @@ func Test_EventListenerValidate(t *testing.T) {
 	}, {
 		name: "Valid EventListener with no trigger name",
 		el: &triggersv1beta1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
+			ObjectMeta: myObjectMeta,
 			Spec: triggersv1beta1.EventListenerSpec{
 				Triggers: []triggersv1beta1.EventListenerTrigger{{
 					Bindings: []*triggersv1beta1.EventListenerBinding{{
@@ -347,10 +321,7 @@ func Test_EventListenerValidate(t *testing.T) {
 	}, {
 		name: "Namespace selector with label selector",
 		el: &triggersv1beta1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
+			ObjectMeta: myObjectMeta,
 			Spec: triggersv1beta1.EventListenerSpec{
 				NamespaceSelector: triggersv1beta1.NamespaceSelector{
 					MatchNames: []string{"foo"},
@@ -369,10 +340,7 @@ func Test_EventListenerValidate(t *testing.T) {
 	}, {
 		name: "Valid EventListener with kubernetes env for podspec",
 		el: &triggersv1beta1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
+			ObjectMeta: myObjectMeta,
 			Spec: triggersv1beta1.EventListenerSpec{
 				Triggers: []triggersv1beta1.EventListenerTrigger{{
 					Template: &triggersv1beta1.EventListenerTemplate{
@@ -414,10 +382,7 @@ func Test_EventListenerValidate(t *testing.T) {
 	}, {
 		name: "Valid Replicas for EventListener",
 		el: &triggersv1beta1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
+			ObjectMeta: myObjectMeta,
 			Spec: triggersv1beta1.EventListenerSpec{
 				Resources: triggersv1beta1.Resources{
 					KubernetesResource: &triggersv1beta1.KubernetesResource{
@@ -429,10 +394,7 @@ func Test_EventListenerValidate(t *testing.T) {
 	}, {
 		name: "Valid EventListener with env for TLS connection",
 		el: &triggersv1beta1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
+			ObjectMeta: myObjectMeta,
 			Spec: triggersv1beta1.EventListenerSpec{
 				Triggers: []triggersv1beta1.EventListenerTrigger{{
 					Template: &triggersv1beta1.EventListenerTemplate{
@@ -474,10 +436,7 @@ func Test_EventListenerValidate(t *testing.T) {
 	}, {
 		name: "Valid EventListener with custom resources",
 		el: &triggersv1beta1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
+			ObjectMeta: myObjectMeta,
 			Spec: triggersv1beta1.EventListenerSpec{
 				Triggers: []triggersv1beta1.EventListenerTrigger{{
 					TriggerRef: "triggerref",
@@ -492,10 +451,7 @@ func Test_EventListenerValidate(t *testing.T) {
 	}, {
 		name: "valid EventListener with embedded TriggerTemplate",
 		el: &triggersv1beta1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
+			ObjectMeta: myObjectMeta,
 			Spec: triggersv1beta1.EventListenerSpec{
 				Triggers: []triggersv1beta1.EventListenerTrigger{{
 					Bindings: []*triggersv1beta1.EventListenerBinding{{
@@ -540,8 +496,9 @@ func Test_EventListenerValidate(t *testing.T) {
 
 func TestEventListenerValidate_error(t *testing.T) {
 	tests := []struct {
-		name string
-		el   *triggersv1beta1.EventListener
+		name    string
+		el      *triggersv1beta1.EventListener
+		wantErr *apis.FieldError
 	}{{
 		name: "Invalid EventListener name",
 		el: &triggersv1beta1.EventListener{
@@ -557,6 +514,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 				}},
 			},
 		},
+		wantErr: apis.ErrInvalidValue(`eventListener name 'longlonglonglonglonglonglonglonglonglonglonglonglonglonglname' must be no more than 60 characters long`, "metadata.name"),
 	}, {
 		name: "Valid EventListener with empty TriggerTemplate name",
 		el: &triggersv1beta1.EventListener{
@@ -572,6 +530,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 				}},
 			},
 		},
+		wantErr: apis.ErrMissingField("spec.triggers[0].template.ref"),
 	}, {
 		name: "Invalid Annotation value",
 		el: &triggersv1beta1.EventListener{
@@ -586,8 +545,9 @@ func TestEventListenerValidate_error(t *testing.T) {
 				}},
 			},
 		},
+		wantErr: apis.ErrInvalidValue(`tekton.dev/payload-validation annotation must have value 'true' or 'false'`, "metadata.annotations"),
 	}, {
-		name: "TriggerBinding with no ref or spec",
+		name: "TriggerBinding with no ref or spec or name",
 		el: &triggersv1beta1.EventListener{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "name",
@@ -604,6 +564,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 				}},
 			},
 		},
+		wantErr: apis.ErrMissingOneOf("spec.triggers[0].bindings[0].name, spec.triggers[0].bindings[0].ref, spec.triggers[0].bindings[0].spec"),
 	}, {
 		name: "Bindings invalid ref",
 		el: &triggersv1beta1.EventListener{
@@ -618,6 +579,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 				}},
 			},
 		},
+		wantErr: apis.ErrMissingOneOf("spec.triggers[0].bindings[0].name, spec.triggers[0].bindings[0].ref, spec.triggers[0].bindings[0].spec"),
 	}, {
 		name: "Bindings missing kind",
 		el: &triggersv1beta1.EventListener{
@@ -632,6 +594,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 				}},
 			},
 		},
+		wantErr: apis.ErrInvalidValue("invalid kind", "spec.triggers[0].bindings[0].kind"),
 	}, {
 		name: "Template with wrong apiVersion",
 		el: &triggersv1beta1.EventListener{
@@ -646,8 +609,9 @@ func TestEventListenerValidate_error(t *testing.T) {
 				}},
 			},
 		},
+		wantErr: apis.ErrInvalidValue("invalid apiVersion", "spec.triggers[0].template.apiVersion"),
 	}, {
-		name: "Template with missing name",
+		name: "Template with both ref and name",
 		el: &triggersv1beta1.EventListener{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "name",
@@ -655,13 +619,14 @@ func TestEventListenerValidate_error(t *testing.T) {
 			},
 			Spec: triggersv1beta1.EventListenerSpec{
 				Triggers: []triggersv1beta1.EventListenerTrigger{{
-					Bindings: []*triggersv1beta1.EventListenerBinding{{Kind: triggersv1beta1.NamespacedTriggerBindingKind, Ref: "tb"}},
-					Template: &triggersv1beta1.EventListenerTemplate{Ref: ptr.String(""), APIVersion: "triggersv1beta1"},
+					Bindings: []*triggersv1beta1.EventListenerBinding{{Kind: triggersv1beta1.NamespacedTriggerBindingKind, Ref: "tb", Name: "somename"}},
+					Template: &triggersv1beta1.EventListenerTemplate{Ref: ptr.String("tt"), APIVersion: "v1beta1"},
 				}},
 			},
 		},
+		wantErr: apis.ErrMultipleOneOf("spec.triggers[0].bindings[0].name", "spec.triggers[0].bindings[0].ref"),
 	}, {
-		name: "Interceptor Name only",
+		name: "Interceptor Name and APIVersion only",
 		el: &triggersv1beta1.EventListener{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "name",
@@ -673,14 +638,35 @@ func TestEventListenerValidate_error(t *testing.T) {
 					Template: &triggersv1beta1.EventListenerTemplate{Ref: ptr.String("tt")},
 					Interceptors: []*triggersv1beta1.EventInterceptor{{
 						Webhook: &triggersv1beta1.WebhookInterceptor{
-							ObjectRef: &corev1.ObjectReference{Name: "svc"},
+							ObjectRef: &corev1.ObjectReference{Name: "svc", APIVersion: "v1"},
 						},
 					}},
 				}},
 			},
 		},
+		wantErr: apis.ErrMissingField("spec.triggers[0].interceptors[0].interceptor.webhook.objectRef.kind"),
 	}, {
-		name: "Interceptor Missing ObjectRef",
+		name: "Interceptor Name and Kind only",
+		el: &triggersv1beta1.EventListener{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Spec: triggersv1beta1.EventListenerSpec{
+				Triggers: []triggersv1beta1.EventListenerTrigger{{
+					Bindings: []*triggersv1beta1.EventListenerBinding{{Kind: triggersv1beta1.NamespacedTriggerBindingKind, Ref: "tb"}},
+					Template: &triggersv1beta1.EventListenerTemplate{Ref: ptr.String("tt")},
+					Interceptors: []*triggersv1beta1.EventInterceptor{{
+						Webhook: &triggersv1beta1.WebhookInterceptor{
+							ObjectRef: &corev1.ObjectReference{Name: "svc", Kind: "Service"},
+						},
+					}},
+				}},
+			},
+		},
+		wantErr: apis.ErrMissingField("spec.triggers[0].interceptors[0].interceptor.webhook.objectRef.apiVersion"),
+	}, {
+		name: "Interceptor Missing Interceptor",
 		el: &triggersv1beta1.EventListener{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "name",
@@ -694,6 +680,25 @@ func TestEventListenerValidate_error(t *testing.T) {
 				}},
 			},
 		},
+		wantErr: apis.ErrMissingField("spec.triggers[0].interceptors[0].interceptor"),
+	}, {
+		name: "Interceptor Missing ObjectRef",
+		el: &triggersv1beta1.EventListener{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Spec: triggersv1beta1.EventListenerSpec{
+				Triggers: []triggersv1beta1.EventListenerTrigger{{
+					Bindings: []*triggersv1beta1.EventListenerBinding{{Kind: triggersv1beta1.NamespacedTriggerBindingKind, Ref: "tb"}},
+					Template: &triggersv1beta1.EventListenerTemplate{Ref: ptr.String("tt")},
+					Interceptors: []*triggersv1beta1.EventInterceptor{{
+						Webhook: &triggersv1beta1.WebhookInterceptor{},
+					}},
+				}},
+			},
+		},
+		wantErr: apis.ErrMissingField("spec.triggers[0].interceptors[0].interceptor.webhook.objectRef"),
 	}, {
 		name: "Interceptor Empty ObjectRef",
 		el: &triggersv1beta1.EventListener{
@@ -715,6 +720,12 @@ func TestEventListenerValidate_error(t *testing.T) {
 				}},
 			},
 		},
+		wantErr: func() *apis.FieldError {
+			var errs *apis.FieldError
+			errs = errs.Also(apis.ErrMissingField("spec.triggers[0].interceptors[0].interceptor.webhook.objectRef.apiVersion"))
+			errs = errs.Also(apis.ErrMissingField("spec.triggers[0].interceptors[0].interceptor.webhook.objectRef.kind"))
+			return errs
+		}(),
 	}, {
 		name: "Valid EventListener with invalid TriggerBinding",
 		el: &triggersv1beta1.EventListener{
@@ -725,10 +736,11 @@ func TestEventListenerValidate_error(t *testing.T) {
 			Spec: triggersv1beta1.EventListenerSpec{
 				Triggers: []triggersv1beta1.EventListenerTrigger{{
 					Bindings: []*triggersv1beta1.EventListenerBinding{{Kind: "badBindingKind", Ref: "tb"}},
-					Template: &triggersv1beta1.EventListenerTemplate{Ref: ptr.String(""), APIVersion: "triggersv1beta1"},
+					Template: &triggersv1beta1.EventListenerTemplate{Ref: ptr.String("tt"), APIVersion: "v1beta1"},
 				}},
 			},
 		},
+		wantErr: apis.ErrInvalidValue("invalid kind", "spec.triggers[0].bindings[0].kind"),
 	}, {
 		name: "Interceptor Wrong APIVersion",
 		el: &triggersv1beta1.EventListener{
@@ -753,6 +765,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 				}},
 			},
 		},
+		wantErr: apis.ErrInvalidValue("invalid apiVersion", "spec.triggers[0].interceptors[0].interceptor.webhook.objectRef.apiVersion"),
 	}, {
 		name: "Interceptor Wrong Kind",
 		el: &triggersv1beta1.EventListener{
@@ -777,6 +790,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 				}},
 			},
 		},
+		wantErr: apis.ErrInvalidValue("invalid kind", "spec.triggers[0].interceptors[0].interceptor.webhook.objectRef.kind"),
 	}, {
 		name: "Interceptor Non-Canonical Header",
 		el: &triggersv1beta1.EventListener{
@@ -808,6 +822,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 				}},
 			},
 		},
+		wantErr: apis.ErrInvalidValue("invalid header name", "spec.triggers[0].interceptors[0].interceptor.webhook.header[0].name"),
 	}, {
 		name: "Interceptor Empty Header Name",
 		el: &triggersv1beta1.EventListener{
@@ -839,6 +854,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 				}},
 			},
 		},
+		wantErr: apis.ErrInvalidValue("invalid header name", "spec.triggers[0].interceptors[0].interceptor.webhook.header[0].name"),
 	}, {
 		name: "Interceptor Empty Header Value",
 		el: &triggersv1beta1.EventListener{
@@ -870,6 +886,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 				}},
 			},
 		},
+		wantErr: apis.ErrInvalidValue("invalid header value", "spec.triggers[0].interceptors[0].interceptor.webhook.header[0].value"),
 	}, {
 		name: "Triggers name has invalid label characters",
 		el: &triggersv1beta1.EventListener{
@@ -881,10 +898,11 @@ func TestEventListenerValidate_error(t *testing.T) {
 				Triggers: []triggersv1beta1.EventListenerTrigger{{
 					Bindings: []*triggersv1beta1.EventListenerBinding{{Kind: triggersv1beta1.NamespacedTriggerBindingKind, Ref: "tb"}},
 					Name:     "github.com/tektoncd/triggers",
-					Template: &triggersv1beta1.EventListenerTemplate{Ref: ptr.String(""), APIVersion: "triggersv1beta1"},
+					Template: &triggersv1beta1.EventListenerTemplate{Ref: ptr.String("tt"), APIVersion: "v1beta1"},
 				}},
 			},
 		},
+		wantErr: apis.ErrInvalidValue(`trigger name 'github.com/tektoncd/triggers' must be a valid label value`, "spec.triggers[0].name"),
 	}, {
 		name: "Triggers name is longer than the allowable label value (63 characters)",
 		el: &triggersv1beta1.EventListener{
@@ -896,30 +914,11 @@ func TestEventListenerValidate_error(t *testing.T) {
 				Triggers: []triggersv1beta1.EventListenerTrigger{{
 					Bindings: []*triggersv1beta1.EventListenerBinding{{Kind: triggersv1beta1.NamespacedTriggerBindingKind, Ref: "tb"}},
 					Name:     "1234567890123456789012345678901234567890123456789012345678901234",
-					Template: &triggersv1beta1.EventListenerTemplate{Ref: ptr.String(""), APIVersion: "triggersv1beta1"},
+					Template: &triggersv1beta1.EventListenerTemplate{Ref: ptr.String("tt"), APIVersion: "v1beta1"},
 				}},
 			},
 		},
-	}, {
-		name: "user specify invalid deprecated replicas",
-		el: &triggersv1beta1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
-			Spec: triggersv1beta1.EventListenerSpec{
-				Triggers: []triggersv1beta1.EventListenerTrigger{{
-					Template: &triggersv1beta1.EventListenerTemplate{
-						Ref: ptr.String("tt"),
-					},
-				}},
-				Resources: triggersv1beta1.Resources{
-					KubernetesResource: &triggersv1beta1.KubernetesResource{
-						Replicas: ptr.Int32(-1),
-					},
-				},
-			},
-		},
+		wantErr: apis.ErrInvalidValue(`trigger name '1234567890123456789012345678901234567890123456789012345678901234' must be a valid label value`, "spec.triggers[0].name"),
 	}, {
 		name: "user specify invalid replicas",
 		el: &triggersv1beta1.EventListener{
@@ -940,6 +939,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 				},
 			},
 		},
+		wantErr: apis.ErrInvalidValue(-1, "spec.resources.kubernetesResource.spec.replicas"),
 	}, {
 		name: "user specify multiple containers",
 		el: &triggersv1beta1.EventListener{
@@ -970,6 +970,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 				}},
 			},
 		},
+		wantErr: apis.ErrMultipleOneOf("spec.resources.kubernetesResource.spec.template.spec.containers"),
 	}, {
 		name: "user specifies an unsupported podspec field",
 		el: &triggersv1beta1.EventListener{
@@ -996,6 +997,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 				}},
 			},
 		},
+		wantErr: apis.ErrDisallowedFields("spec.resources.kubernetesResource.spec.template.spec.nodeName"),
 	}, {
 		name: "user specifies an unsupported container fields",
 		el: &triggersv1beta1.EventListener{
@@ -1035,6 +1037,13 @@ func TestEventListenerValidate_error(t *testing.T) {
 				}},
 			},
 		},
+		wantErr: func() *apis.FieldError {
+			var errs *apis.FieldError
+			errs = errs.Also(apis.ErrDisallowedFields("spec.resources.kubernetesResource.spec.template.spec.containers[0].env[0].value"))
+			errs = errs.Also(apis.ErrDisallowedFields("spec.resources.kubernetesResource.spec.template.spec.containers[0].env[1].valueFrom.configMapKeyRef"))
+			errs = errs.Also(apis.ErrDisallowedFields("spec.resources.kubernetesResource.spec.template.spec.containers[0].name"))
+			return errs
+		}(),
 	}, {
 		name: "user specifies an invalid env for TLS connection",
 		el: &triggersv1beta1.EventListener{
@@ -1073,6 +1082,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 				}},
 			},
 		},
+		wantErr: apis.ErrGeneric("Expected env's are TLS_CERT and TLS_KEY, but got only one env TLS_CERT"),
 	}, {
 		name: "user specify both kubernetes and custom resources",
 		el: &triggersv1beta1.EventListener{
@@ -1098,6 +1108,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 				},
 			},
 		},
+		wantErr: apis.ErrMultipleOneOf("spec.resources.customResource", "spec.resources.kubernetesResource"),
 	}, {
 		name: "user specify multiple containers, unsupported podspec and container field in custom resources",
 		el: &triggersv1beta1.EventListener{
@@ -1110,7 +1121,7 @@ func TestEventListenerValidate_error(t *testing.T) {
 					Bindings: []*triggersv1beta1.EventListenerBinding{{
 						Ref:        "tb",
 						Kind:       "TriggerBinding",
-						APIVersion: "triggersv1beta1",
+						APIVersion: "v1beta1",
 					}},
 				}},
 				Resources: triggersv1beta1.Resources{
@@ -1120,6 +1131,13 @@ func TestEventListenerValidate_error(t *testing.T) {
 				},
 			},
 		},
+		wantErr: func() *apis.FieldError {
+			var errs *apis.FieldError
+			errs = errs.Also(apis.ErrMultipleOneOf("spec.resources.customResource.spec.template.spec.containers"))
+			errs = errs.Also(apis.ErrMissingOneOf("spec.triggers[0].template", "spec.triggers[0].triggerRef"))
+			errs = errs.Also(apis.ErrDisallowedFields("spec.resources.customResource.spec.template.spec.nodeName"))
+			return errs
+		}(),
 	}, {
 		name: "specify TriggerTemplate along with TriggerRef",
 		el: &triggersv1beta1.EventListener{
@@ -1141,12 +1159,15 @@ func TestEventListenerValidate_error(t *testing.T) {
 				},
 			},
 		},
+		wantErr: apis.ErrMultipleOneOf("spec.triggers[0].template or bindings or interceptors", "spec.triggers[0].triggerRef"),
 	}}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := tc.el.Validate(context.Background()); err == nil {
-				t.Errorf("EventListener.Validate() expected error, but get none, EventListener: %v", tc.el)
+			got := tc.el.Validate(context.Background())
+
+			if diff := cmp.Diff(tc.wantErr.Error(), got.Error()); diff != "" {
+				t.Error("EventListener.Validate() (-want, +got) =", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Clean up the unit tests to not return unintended errors, for example
in many cases we were using triggersv1beta1 instead of v1beta1, which
would return errors that were not part of the unit tests.

Start working on https://github.com/tektoncd/triggers/issues/1228 by
fixing a few places were we were using inconsistent casing.

Fix the nil pointer crash and add a test for it.
https://github.com/tektoncd/triggers/issues/1229

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes
```release-note
Fix nil pointer panic: https://github.com/tektoncd/triggers/issues/1229
```

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
Fix nil pointer panic: https://github.com/tektoncd/triggers/issues/1229
```
-->
