### PR TITLE
Fix validation failure issue for Knative service

### DIFF
--- a/pkg/reconciler/eventlistener/eventlistener.go
+++ b/pkg/reconciler/eventlistener/eventlistener.go
@@ -354,15 +354,19 @@ func (r *Reconciler) reconcileCustomObject(ctx context.Context, el *v1beta1.Even
 			}
 		}
 
+		// Preserve any externally added annotations
+		data.SetAnnotations(kmeta.UnionMaps(data.GetAnnotations(), existingCustomObject.GetAnnotations()))
+
 		if !equality.Semantic.DeepEqual(data.GetLabels(), existingCustomObject.GetLabels()) ||
 			!equality.Semantic.DeepEqual(data.GetAnnotations(), existingCustomObject.GetAnnotations()) ||
 			!equality.Semantic.DeepEqual(data.Object["spec"], existingCustomObject.Object["spec"]) {
-			data = data.DeepCopy()
-			data.SetLabels(existingCustomObject.GetLabels())
-			data.SetAnnotations(existingCustomObject.GetAnnotations())
-			data.Object["spec"] = existingCustomObject.Object["spec"]
+			// Don't modify informer copy
+			existingCustomObject = existingCustomObject.DeepCopy()
+			existingCustomObject.SetLabels(data.GetLabels())
+			existingCustomObject.SetAnnotations(data.GetAnnotations())
+			existingCustomObject.Object["spec"] = data.Object["spec"]
 
-			if updated, err := r.DynamicClientSet.Resource(gvr).Namespace(data.GetNamespace()).Update(ctx, data, metav1.UpdateOptions{}); err != nil {
+			if updated, err := r.DynamicClientSet.Resource(gvr).Namespace(data.GetNamespace()).Update(ctx, existingCustomObject, metav1.UpdateOptions{}); err != nil {
 				logging.FromContext(ctx).Errorf("error updating to eventListener custom object: %v", err)
 				return err
 			} else if data.GetResourceVersion() != updated.GetResourceVersion() {

--- a/pkg/reconciler/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/eventlistener/eventlistener_test.go
@@ -400,7 +400,8 @@ func makeWithPod(ops ...func(d *duckv1.WithPod)) *duckv1.WithPod {
 			OwnerReferences: []metav1.OwnerReference{
 				*ownerRefs,
 			},
-			Labels: generatedLabels,
+			Annotations: map[string]string{},
+			Labels:      generatedLabels,
 		},
 		Spec: duckv1.WithPodSpec{
 			Template: duckv1.PodSpecable{
@@ -1379,6 +1380,7 @@ func TestReconcile(t *testing.T) {
 			Namespaces:     []*corev1.Namespace{namespaceResource},
 			EventListeners: []*v1beta1.EventListener{elWithCustomResourceForEnv},
 			ConfigMaps:     []*corev1.ConfigMap{loggingConfigMap, observabilityConfigMap},
+			WithPod:        []*duckv1.WithPod{envForCustomResource},
 		},
 		endResources: test.Resources{
 			Namespaces:     []*corev1.Namespace{namespaceResource},
@@ -1408,6 +1410,7 @@ func TestReconcile(t *testing.T) {
 			Namespaces:     []*corev1.Namespace{namespaceResource},
 			EventListeners: []*v1beta1.EventListener{elWithCustomResourceForArgs},
 			ConfigMaps:     []*corev1.ConfigMap{loggingConfigMap, observabilityConfigMap},
+			WithPod:        []*duckv1.WithPod{argsForCustomResource},
 		},
 		endResources: test.Resources{
 			Namespaces:     []*corev1.Namespace{namespaceResource},
@@ -1422,6 +1425,7 @@ func TestReconcile(t *testing.T) {
 			Namespaces:     []*corev1.Namespace{namespaceResource},
 			EventListeners: []*v1beta1.EventListener{elWithCustomResourceForImage},
 			ConfigMaps:     []*corev1.ConfigMap{loggingConfigMap, observabilityConfigMap},
+			WithPod:        []*duckv1.WithPod{imageForCustomResource},
 		},
 		endResources: test.Resources{
 			Namespaces:     []*corev1.Namespace{namespaceResource},


### PR DESCRIPTION
# Changes

PR fixes the issue reported here https://github.com/tektoncd/triggers/issues/1219#issuecomment-933291237

**Root Cause:**
Its a regression issue which got introduced in 0.16.0 triggers while refactoring eventlistener code.

Previous fix : https://github.com/tektoncd/triggers/pull/995

/cc @dibyom @vaikas 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```