### PR TITLE
Fix example feature flag config formatting

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -90,5 +90,6 @@ kind: ConfigMap
 metadata:
   name: feature-flags-triggers
 data:
-  enable-api-fields: "alpha" # Allow "alpha" fields to be used in v1beta1 Triggers' resources. Defaults to "stable" features only.``
+  enable-api-fields: "alpha" # Allow "alpha" fields to be used in v1beta1 Triggers' resources. Defaults to "stable" features only.
   labels-exclusion-pattern: "^tekton-dev-"
+```


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

[The `ConfigMap` at the end of the page](https://tekton.dev/docs/triggers/install/#customizing-the-triggers-controller-behavior) is rendered in a weird way, so I tried to fix it. I'm not sure how can I render the documentation locally, if you can give me some pointers, I'd be happy to test it.

<img width="1013" alt="Screenshot 2021-10-15 at 22 41 00" src="https://user-images.githubusercontent.com/296735/137551202-808b48d8-fd28-4084-812d-0b72a73766f3.png">

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```