### PR TITLE
Replace cmpopts.IgnoreTypes with IgnoreFields

### DIFF
--- a/pkg/apis/triggers/v1alpha1/event_listener_types_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_types_test.go
@@ -294,8 +294,8 @@ func TestSetConditionsForDynamicObjects(t *testing.T) {
 			}},
 		},
 	}
-	if diff := cmp.Diff(expected, status, cmpopts.IgnoreTypes(
-		apis.Condition{}.LastTransitionTime.Inner.Time)); diff != "" {
+	if diff := cmp.Diff(expected, status, cmpopts.IgnoreFields(
+		apis.Condition{}, "LastTransitionTime.Inner.Time")); diff != "" {
 		t.Fatalf("SetConditionsForDynamicObjects() error. Diff (-want/+got) : %s", diff)
 	}
 }
@@ -404,8 +404,8 @@ func TestEventListenerStatus_SetReadyCondition(t *testing.T) {
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.initial.SetReadyCondition()
-			if diff := cmp.Diff(tc.want, tc.initial, cmpopts.IgnoreTypes(
-				apis.Condition{}.LastTransitionTime.Inner.Time), cmpopts.SortSlices(func(x, y apis.Condition) bool {
+			if diff := cmp.Diff(tc.want, tc.initial, cmpopts.IgnoreFields(
+				apis.Condition{}, "LastTransitionTime.Inner.Time"), cmpopts.SortSlices(func(x, y apis.Condition) bool {
 				return x.Type < y.Type
 			})); diff != "" {
 				t.Fatalf("SetReadyCondition() mismatch. -want/+got: %s", diff)

--- a/pkg/apis/triggers/v1beta1/event_listener_types_test.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_types_test.go
@@ -294,8 +294,8 @@ func TestSetConditionsForDynamicObjects(t *testing.T) {
 			}},
 		},
 	}
-	if diff := cmp.Diff(expected, status, cmpopts.IgnoreTypes(
-		apis.Condition{}.LastTransitionTime.Inner.Time)); diff != "" {
+	if diff := cmp.Diff(expected, status, cmpopts.IgnoreFields(
+		apis.Condition{}, "LastTransitionTime.Inner.Time")); diff != "" {
 		t.Fatalf("SetConditionsForDynamicObjects() error. Diff (-want/+got) : %s", diff)
 	}
 }
@@ -404,8 +404,8 @@ func TestEventListenerStatus_SetReadyCondition(t *testing.T) {
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.initial.SetReadyCondition()
-			if diff := cmp.Diff(tc.want, tc.initial, cmpopts.IgnoreTypes(
-				apis.Condition{}.LastTransitionTime.Inner.Time), cmpopts.SortSlices(func(x, y apis.Condition) bool {
+			if diff := cmp.Diff(tc.want, tc.initial, cmpopts.IgnoreFields(
+				apis.Condition{}, "LastTransitionTime.Inner.Time"), cmpopts.SortSlices(func(x, y apis.Condition) bool {
 				return x.Type < y.Type
 			})); diff != "" {
 				t.Fatalf("SetReadyCondition() mismatch. -want/+got: %s", diff)

--- a/pkg/reconciler/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/eventlistener/eventlistener_test.go
@@ -1393,9 +1393,10 @@ func TestReconcile(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(tt.endResources, *actualEndResources, cmpopts.IgnoreTypes(
-				apis.Condition{}.LastTransitionTime.Inner.Time,
-			), cmpopts.SortSlices(compareCondition), cmpopts.SortSlices(compareEnv)); diff != "" {
+			if diff := cmp.Diff(tt.endResources, *actualEndResources,
+				cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime.Inner.Time"),
+				cmpopts.SortSlices(compareCondition),
+				cmpopts.SortSlices(compareEnv)); diff != "" {
 				t.Errorf("eventlistener.Reconcile() equality mismatch. Diff request body: -want +got: %s", diff)
 			}
 		})
@@ -1535,10 +1536,9 @@ func TestReconcile_InvalidForCustomResource(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(tt.endResources, *actualEndResources, cmpopts.IgnoreTypes(
-				apis.Condition{}.LastTransitionTime.Inner.Time,
-				metav1.ObjectMeta{}.Finalizers,
-			), cmpopts.SortSlices(compareCondition)); diff == "" {
+			if diff := cmp.Diff(tt.endResources, *actualEndResources,
+				cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime.Inner.Time"),
+				cmpopts.SortSlices(compareCondition)); diff == "" {
 				t.Errorf("eventlistener.Reconcile() equality mismatch. Diff request body: -want +got: %s", diff)
 			}
 		})
@@ -1620,7 +1620,7 @@ func TestReconcile_Delete(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(tt.endResources, *actualEndResources, cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)); diff != "" {
+			if diff := cmp.Diff(tt.endResources, *actualEndResources, cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime.Inner.Time")); diff != "" {
 				t.Errorf("eventlistener.Reconcile() equality mismatch. Diff request body: -want +got: %s", diff)
 			}
 		})

--- a/test/builder/eventlistener_test.go
+++ b/test/builder/eventlistener_test.go
@@ -596,7 +596,7 @@ func TestEventListenerBuilder(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if diff := cmp.Diff(tt.normal, tt.builder, cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)); diff != "" {
+			if diff := cmp.Diff(tt.normal, tt.builder, cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime.Inner.Time")); diff != "" {
 				t.Errorf("EventListener() builder equality mismatch. Diff request body: -want +got: %s", diff)
 			}
 		})

--- a/test/builder/trigger_test.go
+++ b/test/builder/trigger_test.go
@@ -277,7 +277,7 @@ func TestTriggerBuilder(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if diff := cmp.Diff(tt.normal, tt.builder, cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)); diff != "" {
+			if diff := cmp.Diff(tt.normal, tt.builder, cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime.Inner.Time")); diff != "" {
 				t.Errorf("EventListener() builder equality mismatch. Diff request body: -want +got: %s", diff)
 			}
 		})


### PR DESCRIPTION
# Changes

IgnoreTypes will ignore all values of the given type i.e. for `apis.Condition{}.LastTransitionTime.Inner.Time`,
it will ignore all instances of `time.Time`. Using `cmpopts.IgnoreFields` will only ignore the specific field.
This was the root cause behind #1245 since we were ignoring all []string values
while trying to ignore only objectMeta.Finalizer (which is of type []string)

Signed-off-by: Dibyo Mukherjee <dibyo@google.com>

Fixes #1245
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [N/A] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [N/A] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [N/A] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
