### PR TITLE
Add omitempty tag for TriggerGroups type

### DIFF
--- a/pkg/apis/triggers/v1beta1/event_listener_types.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_types.go
@@ -58,9 +58,9 @@ var _ kmeta.OwnerRefable = (*EventListener)(nil)
 // by a list of Triggers.
 type EventListenerSpec struct {
 	ServiceAccountName string                 `json:"serviceAccountName,omitempty"`
-	Triggers           []EventListenerTrigger `json:"triggers"`
+	Triggers           []EventListenerTrigger `json:"triggers,omitempty"`
 	// Trigger groups allow for centralized processing of an interceptor chain
-	TriggerGroups     []EventListenerTriggerGroup `json:"triggerGroups"`
+	TriggerGroups     []EventListenerTriggerGroup `json:"triggerGroups,omitempty"`
 	NamespaceSelector NamespaceSelector           `json:"namespaceSelector,omitempty"`
 	LabelSelector     *metav1.LabelSelector       `json:"labelSelector,omitempty"`
 	Resources         Resources                   `json:"resources,omitempty"`


### PR DESCRIPTION
# Changes
Fixes: https://github.com/tektoncd/triggers/issues/1248
Addresses comment: https://github.com/tektoncd/triggers/pull/1232#discussion_r733859861

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [N/A ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ N/A] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ N/A] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
