### PR TITLE
Remove deprecated EL name/namespace fields from event response.

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -484,8 +484,6 @@ After detecting an event, the `EventListener` responds with the following messag
 
 ```json
 {
-  "eventListener": "listener",
-  "namespace": "default",
   "eventListenerUID": "ea71a6e4-9531-43a1-94fe-6136515d938c",
   "eventID": "14a657c3-6816-45bf-b214-4afdaefc4ebd"
 }
@@ -493,13 +491,6 @@ After detecting an event, the `EventListener` responds with the following messag
 
 - `eventListenerUID` - [UID](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids) of the target EventListener.
 - `eventID` - UID assigned to this event request
-
-### Deprecated Fields
-
-These fields are included in `EventListener` responses, but will be removed in a future release.
-
-- `eventListener` - name of the target EventListener. Use `eventListenerUID` instead.
-- `namespace` - namespace of the target EventListener. Use `eventListenerUID` instead.
 
 ## TLS HTTPS support in `EventListeners`
 

--- a/pkg/sink/sink.go
+++ b/pkg/sink/sink.go
@@ -77,12 +77,6 @@ type Sink struct {
 
 // Response defines the HTTP body that the Sink responds to events with.
 type Response struct {
-	// EventListener is the name of the eventListener.
-	// Deprecated: use EventListenerUID instead.
-	EventListener string `json:"eventListener"`
-	// Namespace is the namespace that the eventListener is running in.
-	// Deprecated: use EventListenerUID instead.
-	Namespace string `json:"namespace,omitempty"`
 	// EventListenerUID is the UID of the EventListener
 	EventListenerUID string `json:"eventListenerUID"`
 	// EventID is a uniqueID that gets assigned to each incoming request
@@ -154,9 +148,7 @@ func (r Sink) HandleEvent(response http.ResponseWriter, request *http.Request) {
 	response.WriteHeader(http.StatusAccepted)
 	response.Header().Set("Content-Type", "application/json")
 	body := Response{
-		EventListener:    r.EventListenerName,
 		EventListenerUID: elUID,
-		Namespace:        r.EventListenerNamespace,
 		EventID:          eventID,
 	}
 	if err := json.NewEncoder(response).Encode(body); err != nil {

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -223,9 +223,7 @@ func checkSinkResponse(t *testing.T, resp *http.Response, elName string) {
 		t.Fatalf("Error reading response body: %s", err)
 	}
 	wantBody := Response{
-		EventListener:    elName,
 		EventListenerUID: elUID,
-		Namespace:        namespace,
 		EventID:          eventID,
 	}
 	if diff := cmp.Diff(wantBody, gotBody); diff != "" {

--- a/pkg/sink/validate_payload.go
+++ b/pkg/sink/validate_payload.go
@@ -43,9 +43,7 @@ func (r Sink) IsValidPayload(eventHandler http.Handler) http.Handler {
 				response.WriteHeader(http.StatusBadRequest)
 				response.Header().Set("Content-Type", "application/json")
 				body := Response{
-					EventListener: r.EventListenerName,
-					Namespace:     r.EventListenerNamespace,
-					ErrorMessage:  errMsg,
+					ErrorMessage: errMsg,
 				}
 				if err := json.NewEncoder(response).Encode(body); err != nil {
 					r.Logger.Errorf("failed to write back sink response: %v", err)

--- a/test/eventlistener_test.go
+++ b/test/eventlistener_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*
@@ -497,8 +498,6 @@ func TestEventListenerCreate(t *testing.T) {
 		t.Errorf("sink did not return 2xx response. Got status code: %d", resp.StatusCode)
 	}
 	wantBody := sink.Response{
-		EventListener:    "my-eventlistener",
-		Namespace:        namespace,
 		EventListenerUID: string(el.GetUID()),
 	}
 	var gotBody sink.Response


### PR DESCRIPTION

# Changes

These fields were previously deprecated. This is change is removing the fields.

Clients should use UUID instead.

Fixes #1070 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Deprecated name/namespace fields removed from EventListener responses.
```

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
