### PR TITLE
Add validation to validate TriggerBinding Spec

### DIFF
--- a/pkg/apis/triggers/v1alpha1/cluster_trigger_binding_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/cluster_trigger_binding_validation_test.go
@@ -51,13 +51,6 @@ func Test_ClusterTriggerBindingValidate(t *testing.T) {
 		name string
 		tb   *v1alpha1.ClusterTriggerBinding
 	}{{
-		name: "empty",
-		tb: &v1alpha1.ClusterTriggerBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "name",
-			},
-		},
-	}, {
 		name: "multiple params",
 		tb: &v1alpha1.ClusterTriggerBinding{
 			ObjectMeta: metav1.ObjectMeta{
@@ -110,6 +103,13 @@ func Test_ClusterTriggerBindingValidate_error(t *testing.T) {
 		name string
 		tb   *v1alpha1.ClusterTriggerBinding
 	}{{
+		name: "empty",
+		tb: &v1alpha1.ClusterTriggerBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "name",
+			},
+		},
+	}, {
 		name: "duplicate params",
 		tb: &v1alpha1.ClusterTriggerBinding{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/triggers/v1alpha1/trigger_binding_validation.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_binding_validation.go
@@ -21,21 +21,28 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/tektoncd/pipeline/pkg/apis/validate"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/apis"
 )
 
 // Validate TriggerBinding.
-func (tb *TriggerBinding) Validate(ctx context.Context) *apis.FieldError {
+func (tb *TriggerBinding) Validate(ctx context.Context) (errs *apis.FieldError) {
+	errs = validate.ObjectMetadata(tb.GetObjectMeta()).ViaField("metadata")
+
 	if apis.IsInDelete(ctx) {
 		return nil
 	}
-	return tb.Spec.Validate(ctx).ViaField("spec")
+	return errs.Also(tb.Spec.Validate(ctx).ViaField("spec"))
 }
 
 // Validate TriggerBindingSpec.
-func (s *TriggerBindingSpec) Validate(ctx context.Context) *apis.FieldError {
-	return validateParams(s.Params).ViaField("params")
+func (s *TriggerBindingSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
+	if equality.Semantic.DeepEqual(s, &TriggerBindingSpec{}) {
+		return errs.Also(apis.ErrMissingField(apis.CurrentField))
+	}
+	return errs.Also(validateParams(s.Params).ViaField("params"))
 }
 
 func validateParams(params []Param) *apis.FieldError {

--- a/pkg/apis/triggers/v1alpha1/trigger_binding_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_binding_validation_test.go
@@ -53,14 +53,6 @@ func Test_TriggerBindingValidate(t *testing.T) {
 		name string
 		tb   *v1alpha1.TriggerBinding
 	}{{
-		name: "empty",
-		tb: &v1alpha1.TriggerBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
-		},
-	}, {
 		name: "multiple params",
 		tb: &v1alpha1.TriggerBinding{
 			ObjectMeta: metav1.ObjectMeta{
@@ -133,6 +125,15 @@ func Test_TriggerBindingValidate_error(t *testing.T) {
 		tb     *v1alpha1.TriggerBinding
 		errMsg string
 	}{{
+		name: "empty",
+		tb: &v1alpha1.TriggerBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+		},
+		errMsg: "missing field(s): spec",
+	}, {
 		name: "duplicate params",
 		tb: &v1alpha1.TriggerBinding{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/triggers/v1beta1/cluster_trigger_binding_validation_test.go
+++ b/pkg/apis/triggers/v1beta1/cluster_trigger_binding_validation_test.go
@@ -51,13 +51,6 @@ func Test_ClusterTriggerBindingValidate(t *testing.T) {
 		name string
 		tb   *v1beta1.ClusterTriggerBinding
 	}{{
-		name: "empty",
-		tb: &v1beta1.ClusterTriggerBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "name",
-			},
-		},
-	}, {
 		name: "multiple params",
 		tb: &v1beta1.ClusterTriggerBinding{
 			ObjectMeta: metav1.ObjectMeta{
@@ -110,6 +103,13 @@ func Test_ClusterTriggerBindingValidate_error(t *testing.T) {
 		name string
 		tb   *v1beta1.ClusterTriggerBinding
 	}{{
+		name: "empty",
+		tb: &v1beta1.ClusterTriggerBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "name",
+			},
+		},
+	}, {
 		name: "duplicate params",
 		tb: &v1beta1.ClusterTriggerBinding{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/triggers/v1beta1/trigger_binding_validation.go
+++ b/pkg/apis/triggers/v1beta1/trigger_binding_validation.go
@@ -21,21 +21,27 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/tektoncd/pipeline/pkg/apis/validate"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/apis"
 )
 
 // Validate TriggerBinding.
 func (tb *TriggerBinding) Validate(ctx context.Context) *apis.FieldError {
+	errs := validate.ObjectMetadata(tb.GetObjectMeta()).ViaField("metadata")
 	if apis.IsInDelete(ctx) {
 		return nil
 	}
-	return tb.Spec.Validate(ctx).ViaField("spec")
+	return errs.Also(tb.Spec.Validate(ctx).ViaField("spec"))
 }
 
 // Validate TriggerBindingSpec.
-func (s *TriggerBindingSpec) Validate(ctx context.Context) *apis.FieldError {
-	return validateParams(s.Params).ViaField("params")
+func (s *TriggerBindingSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
+	if equality.Semantic.DeepEqual(s, &TriggerBindingSpec{}) {
+		return errs.Also(apis.ErrMissingField(apis.CurrentField))
+	}
+	return errs.Also(validateParams(s.Params).ViaField("params"))
 }
 
 func validateParams(params []Param) *apis.FieldError {

--- a/pkg/apis/triggers/v1beta1/trigger_binding_validation_test.go
+++ b/pkg/apis/triggers/v1beta1/trigger_binding_validation_test.go
@@ -53,14 +53,6 @@ func Test_TriggerBindingValidate(t *testing.T) {
 		name string
 		tb   *v1beta1.TriggerBinding
 	}{{
-		name: "empty",
-		tb: &v1beta1.TriggerBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
-		},
-	}, {
 		name: "multiple params",
 		tb: &v1beta1.TriggerBinding{
 			ObjectMeta: metav1.ObjectMeta{
@@ -133,6 +125,15 @@ func Test_TriggerBindingValidate_error(t *testing.T) {
 		tb     *v1beta1.TriggerBinding
 		errMsg string
 	}{{
+		name: "empty",
+		tb: &v1beta1.TriggerBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+		},
+		errMsg: "missing field(s): spec",
+	}, {
 		name: "duplicate params",
 		tb: &v1beta1.TriggerBinding{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
# Changes

Add changes to validate TriggerBinding when provided `spec` is empty

/cc @dibyom @khrm 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
TriggerBinding validates if provided spec is empty
```
