### PR TITLE
Removes v1beta1 AdmissionReview

### DIFF
--- a/config/500-webhooks.yaml
+++ b/config/500-webhooks.yaml
@@ -36,7 +36,6 @@ metadata:
     triggers.tekton.dev/release: "devel"
 webhooks:
 - admissionReviewVersions:
-  - v1beta1
   - v1
   clientConfig:
     service:
@@ -58,7 +57,6 @@ metadata:
     triggers.tekton.dev/release: "devel"
 webhooks:
 - admissionReviewVersions:
-  - v1beta1
   - v1
   clientConfig:
     service:
@@ -79,7 +77,6 @@ metadata:
     triggers.tekton.dev/release: "devel"
 webhooks:
 - admissionReviewVersions:
-  - v1beta1
   - v1
   clientConfig:
     service:


### PR DESCRIPTION
This removes v1beta1 from the possible admission review versions,
as it doesn't seem like the admission handler accepts it.
It was deprecated in k8s 1.16 for v1.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>



<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
