### PR TITLE
Avoid watching all secrets in the cluster

### DIFF
--- a/cmd/interceptors/main.go
+++ b/cmd/interceptors/main.go
@@ -83,7 +83,7 @@ func main() {
 	}
 
 	secretLister := secretInformer.Get(ctx).Lister()
-	service, err := server.NewWithCoreInterceptors(interceptors.NewKubeClientSecretGetter(kubeclient.Get(ctx).CoreV1()), logger)
+	service, err := server.NewWithCoreInterceptors(interceptors.NewKubeClientSecretGetter(kubeclient.Get(ctx).CoreV1(), 1024, 5*time.Second), logger)
 	if err != nil {
 		logger.Errorf("failed to initialize core interceptors: %s", err)
 		return

--- a/cmd/interceptors/main.go
+++ b/cmd/interceptors/main.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	triggersclientset "github.com/tektoncd/triggers/pkg/client/clientset/versioned"
+	"github.com/tektoncd/triggers/pkg/interceptors"
 	"github.com/tektoncd/triggers/pkg/interceptors/server"
 	"go.uber.org/zap"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -81,7 +82,7 @@ func main() {
 	}
 
 	secretLister := secretInformer.Get(ctx).Lister()
-	service, err := server.NewWithCoreInterceptors(secretLister, logger)
+	service, err := server.NewWithCoreInterceptors(interceptors.NewListerSecretGetter(secretLister), logger)
 	if err != nil {
 		logger.Errorf("failed to initialize core interceptors: %s", err)
 		return

--- a/cmd/interceptors/main.go
+++ b/cmd/interceptors/main.go
@@ -36,6 +36,7 @@ import (
 	kubeclientset "k8s.io/client-go/kubernetes"
 	v1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	secretInformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
 	"knative.dev/pkg/injection"
 	"knative.dev/pkg/logging"
@@ -82,7 +83,7 @@ func main() {
 	}
 
 	secretLister := secretInformer.Get(ctx).Lister()
-	service, err := server.NewWithCoreInterceptors(interceptors.NewListerSecretGetter(secretLister), logger)
+	service, err := server.NewWithCoreInterceptors(interceptors.NewKubeClientSecretGetter(kubeclient.Get(ctx).CoreV1()), logger)
 	if err != nil {
 		logger.Errorf("failed to initialize core interceptors: %s", err)
 		return

--- a/pkg/interceptors/bitbucket/bitbucket.go
+++ b/pkg/interceptors/bitbucket/bitbucket.go
@@ -77,7 +77,7 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 			return interceptors.Fail(codes.InvalidArgument, "no X-Hub-Signature header set")
 		}
 		ns, _ := triggersv1.ParseTriggerID(r.Context.TriggerID)
-		secretToken, err := interceptors.GetSecretToken(nil, w.SecretLister, p.SecretRef, ns)
+		secretToken, err := interceptors.GetSecretToken(w.SecretLister, p.SecretRef, ns)
 		if err != nil {
 			return interceptors.Failf(codes.FailedPrecondition, "error getting secret: %v", err)
 		}

--- a/pkg/interceptors/bitbucket/bitbucket.go
+++ b/pkg/interceptors/bitbucket/bitbucket.go
@@ -75,7 +75,7 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 			return interceptors.Fail(codes.InvalidArgument, "no X-Hub-Signature header set")
 		}
 		ns, _ := triggersv1.ParseTriggerID(r.Context.TriggerID)
-		secretToken, err := w.SecretGetter.Get(ns, p.SecretRef)
+		secretToken, err := w.SecretGetter.Get(ctx, ns, p.SecretRef)
 		if err != nil {
 			return interceptors.Failf(codes.FailedPrecondition, "error getting secret: %v", err)
 		}

--- a/pkg/interceptors/bitbucket/bitbucket.go
+++ b/pkg/interceptors/bitbucket/bitbucket.go
@@ -20,25 +20,23 @@ import (
 	"context"
 	"net/http"
 
-	"google.golang.org/grpc/codes"
-	corev1lister "k8s.io/client-go/listers/core/v1"
-
 	gh "github.com/google/go-github/v31/github"
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/pkg/interceptors"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
 )
 
 var _ triggersv1.InterceptorInterface = (*Interceptor)(nil)
 
 type Interceptor struct {
-	SecretLister corev1lister.SecretLister
+	SecretGetter interceptors.SecretGetter
 	Logger       *zap.SugaredLogger
 }
 
-func NewInterceptor(sl corev1lister.SecretLister, l *zap.SugaredLogger) *Interceptor {
+func NewInterceptor(sg interceptors.SecretGetter, l *zap.SugaredLogger) *Interceptor {
 	return &Interceptor{
-		SecretLister: sl,
+		SecretGetter: sg,
 		Logger:       l,
 	}
 }
@@ -77,7 +75,7 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 			return interceptors.Fail(codes.InvalidArgument, "no X-Hub-Signature header set")
 		}
 		ns, _ := triggersv1.ParseTriggerID(r.Context.TriggerID)
-		secretToken, err := interceptors.GetSecretToken(w.SecretLister, p.SecretRef, ns)
+		secretToken, err := w.SecretGetter.Get(ns, p.SecretRef)
 		if err != nil {
 			return interceptors.Failf(codes.FailedPrecondition, "error getting secret: %v", err)
 		}

--- a/pkg/interceptors/bitbucket/bitbucket_test.go
+++ b/pkg/interceptors/bitbucket/bitbucket_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+	"time"
 
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/pkg/interceptors"
@@ -110,7 +111,7 @@ func TestInterceptor_Process_ShouldContinue(t *testing.T) {
 				ctx, clientset = fakekubeclient.With(ctx, tt.secret)
 			}
 			w := &Interceptor{
-				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1()),
+				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second),
 				Logger:       logger.Sugar(),
 			}
 
@@ -268,7 +269,7 @@ func TestInterceptor_Process_ShouldNotContinue(t *testing.T) {
 				ctx, clientset = fakekubeclient.With(ctx, tt.secret)
 			}
 			w := &Interceptor{
-				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1()),
+				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second),
 				Logger:       logger.Sugar(),
 			}
 
@@ -307,7 +308,7 @@ func TestInterceptor_Process_InvalidParams(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 
 	w := &Interceptor{
-		SecretGetter: interceptors.NewKubeClientSecretGetter(fakekubeclient.Get(ctx).CoreV1()),
+		SecretGetter: interceptors.NewKubeClientSecretGetter(fakekubeclient.Get(ctx).CoreV1(), 1024, 5*time.Second),
 		Logger:       logger.Sugar(),
 	}
 

--- a/pkg/interceptors/bitbucket/bitbucket_test.go
+++ b/pkg/interceptors/bitbucket/bitbucket_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
+	"github.com/tektoncd/triggers/pkg/interceptors"
 	"github.com/tektoncd/triggers/test"
 	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"
@@ -106,7 +107,7 @@ func TestInterceptor_Process_ShouldContinue(t *testing.T) {
 			secretInformer := fakeSecretInformer.Get(ctx)
 
 			w := &Interceptor{
-				SecretLister: secretInformer.Lister(),
+				SecretGetter: interceptors.NewListerSecretGetter(secretInformer.Lister()),
 				Logger:       logger.Sugar(),
 			}
 
@@ -267,7 +268,7 @@ func TestInterceptor_Process_ShouldNotContinue(t *testing.T) {
 			secretInformer := fakeSecretInformer.Get(ctx)
 
 			w := &Interceptor{
-				SecretLister: secretInformer.Lister(),
+				SecretGetter: interceptors.NewListerSecretGetter(secretInformer.Lister()),
 				Logger:       logger.Sugar(),
 			}
 
@@ -313,7 +314,7 @@ func TestInterceptor_Process_InvalidParams(t *testing.T) {
 	secretInformer := fakeSecretInformer.Get(ctx)
 
 	w := &Interceptor{
-		SecretLister: secretInformer.Lister(),
+		SecretGetter: interceptors.NewListerSecretGetter(secretInformer.Lister()),
 		Logger:       logger.Sugar(),
 	}
 

--- a/pkg/interceptors/cel/cel.go
+++ b/pkg/interceptors/cel/cel.go
@@ -89,10 +89,10 @@ func evaluate(expr string, env *cel.Env, data map[string]interface{}) (ref.Val, 
 	return out, nil
 }
 
-func makeCelEnv(ns string, sg interceptors.SecretGetter) (*cel.Env, error) {
+func makeCelEnv(ctx context.Context, ns string, sg interceptors.SecretGetter) (*cel.Env, error) {
 	mapStrDyn := decls.NewMapType(decls.String, decls.Dyn)
 	return cel.NewEnv(
-		Triggers(ns, sg),
+		Triggers(ctx, ns, sg),
 		celext.Strings(),
 		celext.Encoders(),
 		cel.Declarations(
@@ -124,7 +124,7 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 	}
 
 	ns, _ := triggersv1.ParseTriggerID(r.Context.TriggerID)
-	env, err := makeCelEnv(ns, w.SecretGetter)
+	env, err := makeCelEnv(ctx, ns, w.SecretGetter)
 	if err != nil {
 		return interceptors.Failf(codes.Internal, "error creating cel environment: %v", err)
 	}

--- a/pkg/interceptors/cel/cel_test.go
+++ b/pkg/interceptors/cel/cel_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/go-cmp/cmp"
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
+	"github.com/tektoncd/triggers/pkg/interceptors"
 	"github.com/tektoncd/triggers/test"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -284,7 +285,7 @@ func TestInterceptor_Process(t *testing.T) {
 				t.Fatal(err)
 			}
 			w := &Interceptor{
-				SecretLister: secretInformer.Lister(),
+				SecretGetter: interceptors.NewListerSecretGetter(secretInformer.Lister()),
 				Logger:       logger.Sugar(),
 			}
 			res := w.Process(ctx, &triggersv1.InterceptorRequest{
@@ -663,7 +664,7 @@ func TestExpressionEvaluation(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			env, err := makeCelEnv(testNS, secretInformer.Lister())
+			env, err := makeCelEnv(testNS, interceptors.NewListerSecretGetter(secretInformer.Lister()))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -794,7 +795,7 @@ func TestExpressionEvaluation_Error(t *testing.T) {
 				}
 				ns = tt.secretNS
 			}
-			env, err := makeCelEnv(ns, secretInformer.Lister())
+			env, err := makeCelEnv(ns, interceptors.NewListerSecretGetter(secretInformer.Lister()))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/interceptors/cel/cel_test.go
+++ b/pkg/interceptors/cel/cel_test.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"go.uber.org/zap/zaptest"
 	"google.golang.org/grpc/codes"
@@ -283,7 +284,7 @@ func TestInterceptor_Process(t *testing.T) {
 			var clientset *fake.Clientset
 			ctx, clientset = fakekubeclient.With(ctx, makeSecret())
 			w := &Interceptor{
-				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1()),
+				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second),
 				Logger:       logger.Sugar(),
 			}
 			res := w.Process(ctx, &triggersv1.InterceptorRequest{
@@ -660,7 +661,7 @@ func TestExpressionEvaluation(t *testing.T) {
 			if tt.secret != nil {
 				_, clientset = fakekubeclient.With(ctx, tt.secret)
 			}
-			env, err := makeCelEnv(context.Background(), testNS, interceptors.NewKubeClientSecretGetter(clientset.CoreV1()))
+			env, err := makeCelEnv(context.Background(), testNS, interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -789,7 +790,7 @@ func TestExpressionEvaluation_Error(t *testing.T) {
 				_, clientset = fakekubeclient.With(ctx, makeSecret())
 				ns = tt.secretNS
 			}
-			env, err := makeCelEnv(context.Background(), ns, interceptors.NewKubeClientSecretGetter(clientset.CoreV1()))
+			env, err := makeCelEnv(context.Background(), ns, interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/interceptors/cel/cel_test.go
+++ b/pkg/interceptors/cel/cel_test.go
@@ -28,7 +28,6 @@ import (
 	"testing"
 
 	"go.uber.org/zap/zaptest"
-
 	"google.golang.org/grpc/codes"
 
 	"github.com/google/cel-go/common/types"
@@ -39,7 +38,8 @@ import (
 	"github.com/tektoncd/triggers/test"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	fakeSecretInformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/fake"
+	"k8s.io/client-go/kubernetes/fake"
+	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 )
 
 const testNS = "testing-ns"
@@ -280,12 +280,10 @@ func TestInterceptor_Process(t *testing.T) {
 		t.Run(tt.name, func(rt *testing.T) {
 			logger := zaptest.NewLogger(t)
 			ctx, _ := test.SetupFakeContext(t)
-			secretInformer := fakeSecretInformer.Get(ctx)
-			if err := secretInformer.Informer().GetIndexer().Add(makeSecret()); err != nil {
-				t.Fatal(err)
-			}
+			var clientset *fake.Clientset
+			ctx, clientset = fakekubeclient.With(ctx, makeSecret())
 			w := &Interceptor{
-				SecretGetter: interceptors.NewListerSecretGetter(secretInformer.Lister()),
+				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1()),
 				Logger:       logger.Sugar(),
 			}
 			res := w.Process(ctx, &triggersv1.InterceptorRequest{
@@ -658,13 +656,11 @@ func TestExpressionEvaluation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(rt *testing.T) {
 			ctx, _ := test.SetupFakeContext(rt)
-			secretInformer := fakeSecretInformer.Get(ctx)
+			clientset := fakekubeclient.Get(ctx)
 			if tt.secret != nil {
-				if err := secretInformer.Informer().GetIndexer().Add(tt.secret); err != nil {
-					t.Fatal(err)
-				}
+				_, clientset = fakekubeclient.With(ctx, tt.secret)
 			}
-			env, err := makeCelEnv(testNS, interceptors.NewListerSecretGetter(secretInformer.Lister()))
+			env, err := makeCelEnv(context.Background(), testNS, interceptors.NewKubeClientSecretGetter(clientset.CoreV1()))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -787,15 +783,13 @@ func TestExpressionEvaluation_Error(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(rt *testing.T) {
 			ctx, _ := test.SetupFakeContext(t)
-			secretInformer := fakeSecretInformer.Get(ctx)
 			ns := testNS
+			clientset := fakekubeclient.Get(ctx)
 			if tt.secretNS != "" {
-				if err := secretInformer.Informer().GetIndexer().Add(makeSecret()); err != nil {
-					t.Fatal(err)
-				}
+				_, clientset = fakekubeclient.With(ctx, makeSecret())
 				ns = tt.secretNS
 			}
-			env, err := makeCelEnv(ns, interceptors.NewListerSecretGetter(secretInformer.Lister()))
+			env, err := makeCelEnv(context.Background(), ns, interceptors.NewKubeClientSecretGetter(clientset.CoreV1()))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/interceptors/cel/triggers.go
+++ b/pkg/interceptors/cel/triggers.go
@@ -326,7 +326,7 @@ func makeCompareSecret(defaultNS string, sl corev1lister.SecretLister) functions
 		// GetSecretToken uses request as a cache key to cache secret lookup. Since multiple
 		// triggers execute concurrently in separate goroutines, this cache is not very effective
 		// for this use case
-		secretToken, err := interceptors.GetSecretToken(nil, sl, secretRef, string(secretNS))
+		secretToken, err := interceptors.GetSecretToken(sl, secretRef, string(secretNS))
 		if err != nil {
 			return types.NewErr("failed to find secret '%#v' in compareSecret: %w", *secretRef, err)
 		}

--- a/pkg/interceptors/github/github.go
+++ b/pkg/interceptors/github/github.go
@@ -82,7 +82,7 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 		}
 
 		ns, _ := triggersv1.ParseTriggerID(r.Context.TriggerID)
-		secretToken, err := w.SecretGetter.Get(ns, p.SecretRef)
+		secretToken, err := w.SecretGetter.Get(ctx, ns, p.SecretRef)
 		if err != nil {
 			return interceptors.Failf(codes.FailedPrecondition, "error getting secret: %v", err)
 		}

--- a/pkg/interceptors/github/github.go
+++ b/pkg/interceptors/github/github.go
@@ -83,7 +83,7 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 		}
 
 		ns, _ := triggersv1.ParseTriggerID(r.Context.TriggerID)
-		secretToken, err := interceptors.GetSecretToken(nil, w.SecretLister, p.SecretRef, ns)
+		secretToken, err := interceptors.GetSecretToken(w.SecretLister, p.SecretRef, ns)
 		if err != nil {
 			return interceptors.Failf(codes.FailedPrecondition, "error getting secret: %v", err)
 		}

--- a/pkg/interceptors/github/github_test.go
+++ b/pkg/interceptors/github/github_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
+	"github.com/tektoncd/triggers/pkg/interceptors"
 	"github.com/tektoncd/triggers/test"
 	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"
@@ -138,7 +139,7 @@ func TestInterceptor_ExecuteTrigger_Signature(t *testing.T) {
 			}
 
 			w := &Interceptor{
-				SecretLister: secretInformer.Lister(),
+				SecretGetter: interceptors.NewListerSecretGetter(secretInformer.Lister()),
 				Logger:       logger.Sugar(),
 			}
 			res := w.Process(ctx, req)
@@ -299,7 +300,7 @@ func TestInterceptor_ExecuteTrigger_ShouldNotContinue(t *testing.T) {
 				}
 			}
 			w := &Interceptor{
-				SecretLister: secretInformer.Lister(),
+				SecretGetter: interceptors.NewListerSecretGetter(secretInformer.Lister()),
 				Logger:       logger.Sugar(),
 			}
 			res := w.Process(ctx, req)
@@ -329,7 +330,7 @@ func TestInterceptor_ExecuteTrigger_with_invalid_content_type(t *testing.T) {
 		},
 	}
 	w := &Interceptor{
-		SecretLister: secretInformer.Lister(),
+		SecretGetter: interceptors.NewListerSecretGetter(secretInformer.Lister()),
 		Logger:       logger.Sugar(),
 	}
 	res := w.Process(ctx, req)
@@ -347,7 +348,7 @@ func TestInterceptor_Process_InvalidParams(t *testing.T) {
 	secretInformer := fakeSecretInformer.Get(ctx)
 
 	w := &Interceptor{
-		SecretLister: secretInformer.Lister(),
+		SecretGetter: interceptors.NewListerSecretGetter(secretInformer.Lister()),
 		Logger:       logger.Sugar(),
 	}
 

--- a/pkg/interceptors/github/github_test.go
+++ b/pkg/interceptors/github/github_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+	"time"
 
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/pkg/interceptors"
@@ -138,7 +139,7 @@ func TestInterceptor_ExecuteTrigger_Signature(t *testing.T) {
 			}
 
 			w := &Interceptor{
-				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1()),
+				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second),
 				Logger:       logger.Sugar(),
 			}
 			res := w.Process(ctx, req)
@@ -299,7 +300,7 @@ func TestInterceptor_ExecuteTrigger_ShouldNotContinue(t *testing.T) {
 			}
 
 			w := &Interceptor{
-				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1()),
+				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second),
 				Logger:       logger.Sugar(),
 			}
 			res := w.Process(ctx, req)
@@ -328,7 +329,7 @@ func TestInterceptor_ExecuteTrigger_with_invalid_content_type(t *testing.T) {
 		},
 	}
 	w := &Interceptor{
-		SecretGetter: interceptors.NewKubeClientSecretGetter(fakekubeclient.Get(ctx).CoreV1()),
+		SecretGetter: interceptors.NewKubeClientSecretGetter(fakekubeclient.Get(ctx).CoreV1(), 1024, 5*time.Second),
 		Logger:       logger.Sugar(),
 	}
 	res := w.Process(ctx, req)
@@ -345,7 +346,7 @@ func TestInterceptor_Process_InvalidParams(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 
 	w := &Interceptor{
-		SecretGetter: interceptors.NewKubeClientSecretGetter(fakekubeclient.Get(ctx).CoreV1()),
+		SecretGetter: interceptors.NewKubeClientSecretGetter(fakekubeclient.Get(ctx).CoreV1(), 1024, 5*time.Second),
 		Logger:       logger.Sugar(),
 	}
 

--- a/pkg/interceptors/gitlab/gitlab.go
+++ b/pkg/interceptors/gitlab/gitlab.go
@@ -75,7 +75,7 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 		}
 
 		ns, _ := triggersv1.ParseTriggerID(r.Context.TriggerID)
-		secretToken, err := w.SecretGetter.Get(ns, p.SecretRef)
+		secretToken, err := w.SecretGetter.Get(ctx, ns, p.SecretRef)
 		if err != nil {
 			return interceptors.Failf(codes.FailedPrecondition, "error getting secret: %v", err)
 		}

--- a/pkg/interceptors/gitlab/gitlab.go
+++ b/pkg/interceptors/gitlab/gitlab.go
@@ -76,7 +76,7 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 		}
 
 		ns, _ := triggersv1.ParseTriggerID(r.Context.TriggerID)
-		secretToken, err := interceptors.GetSecretToken(nil, w.SecretLister, p.SecretRef, ns)
+		secretToken, err := interceptors.GetSecretToken(w.SecretLister, p.SecretRef, ns)
 		if err != nil {
 			return interceptors.Failf(codes.FailedPrecondition, "error getting secret: %v", err)
 		}

--- a/pkg/interceptors/gitlab/gitlab_test.go
+++ b/pkg/interceptors/gitlab/gitlab_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
+	"github.com/tektoncd/triggers/pkg/interceptors"
 	"github.com/tektoncd/triggers/test"
 	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"
@@ -123,7 +124,7 @@ func TestInterceptor_ExecuteTrigger_ShouldContinue(t *testing.T) {
 				}
 			}
 			w := &Interceptor{
-				SecretLister: secretInformer.Lister(),
+				SecretGetter: interceptors.NewListerSecretGetter(secretInformer.Lister()),
 				Logger:       logger.Sugar(),
 			}
 			res := w.Process(ctx, req)
@@ -278,7 +279,7 @@ func TestInterceptor_ExecuteTrigger_ShouldNotContinue(t *testing.T) {
 				}
 			}
 			w := &Interceptor{
-				SecretLister: secretInformer.Lister(),
+				SecretGetter: interceptors.NewListerSecretGetter(secretInformer.Lister()),
 				Logger:       logger.Sugar(),
 			}
 			res := w.Process(ctx, req)
@@ -295,7 +296,7 @@ func TestInterceptor_Process_InvalidParams(t *testing.T) {
 	secretInformer := fakeSecretInformer.Get(ctx)
 
 	w := &Interceptor{
-		SecretLister: secretInformer.Lister(),
+		SecretGetter: interceptors.NewListerSecretGetter(secretInformer.Lister()),
 		Logger:       logger.Sugar(),
 	}
 

--- a/pkg/interceptors/gitlab/gitlab_test.go
+++ b/pkg/interceptors/gitlab/gitlab_test.go
@@ -19,6 +19,7 @@ package gitlab
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/pkg/interceptors"
@@ -122,7 +123,7 @@ func TestInterceptor_ExecuteTrigger_ShouldContinue(t *testing.T) {
 				ctx, clientset = fakekubeclient.With(ctx, tt.secret)
 			}
 			w := &Interceptor{
-				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1()),
+				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second),
 				Logger:       logger.Sugar(),
 			}
 			res := w.Process(ctx, req)
@@ -275,7 +276,7 @@ func TestInterceptor_ExecuteTrigger_ShouldNotContinue(t *testing.T) {
 				ctx, clientset = fakekubeclient.With(ctx, tt.secret)
 			}
 			w := &Interceptor{
-				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1()),
+				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second),
 				Logger:       logger.Sugar(),
 			}
 			res := w.Process(ctx, req)
@@ -291,7 +292,7 @@ func TestInterceptor_Process_InvalidParams(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 
 	w := &Interceptor{
-		SecretGetter: interceptors.NewKubeClientSecretGetter(fakekubeclient.Get(ctx).CoreV1()),
+		SecretGetter: interceptors.NewKubeClientSecretGetter(fakekubeclient.Get(ctx).CoreV1(), 1024, 5*time.Second),
 		Logger:       logger.Sugar(),
 	}
 

--- a/pkg/interceptors/interceptors.go
+++ b/pkg/interceptors/interceptors.go
@@ -23,11 +23,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	triggersv1alpha1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	triggersv1beta1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"google.golang.org/grpc/codes"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/cache"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"knative.dev/pkg/apis"
 )
@@ -47,11 +49,20 @@ type SecretGetter interface {
 
 type kubeclientSecretGetter struct {
 	getter v1.SecretsGetter
+	cache  *cache.LRUExpireCache
+	ttl    time.Duration
 }
 
-func NewKubeClientSecretGetter(getter v1.SecretsGetter) SecretGetter {
+type cacheKey struct {
+	triggerNS string
+	sr        triggersv1beta1.SecretRef
+}
+
+func NewKubeClientSecretGetter(getter v1.SecretsGetter, cacheSize int, ttl time.Duration) SecretGetter {
 	return &kubeclientSecretGetter{
 		getter: getter,
+		cache:  cache.NewLRUExpireCache(cacheSize),
+		ttl:    ttl,
 	}
 }
 
@@ -62,6 +73,14 @@ func NewKubeClientSecretGetter(getter v1.SecretsGetter) SecretGetter {
 // As we may have many triggers that all use the same secret, we cache the secret values
 // in the request cache.
 func (g *kubeclientSecretGetter) Get(ctx context.Context, triggerNS string, sr *triggersv1beta1.SecretRef) ([]byte, error) {
+	key := cacheKey{
+		triggerNS: triggerNS,
+		sr:        *sr,
+	}
+	val, ok := g.cache.Get(key)
+	if ok {
+		return val.([]byte), nil
+	}
 	secret, err := g.getter.Secrets(triggerNS).Get(ctx, sr.SecretName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
@@ -70,6 +89,7 @@ func (g *kubeclientSecretGetter) Get(ctx context.Context, triggerNS string, sr *
 	if !ok {
 		return nil, fmt.Errorf("cannot find %s key in secret %s/%s", sr.SecretKey, triggerNS, sr.SecretName)
 	}
+	g.cache.Add(key, secretValue, g.ttl)
 	return secretValue, nil
 }
 

--- a/pkg/interceptors/interceptors.go
+++ b/pkg/interceptors/interceptors.go
@@ -65,7 +65,10 @@ func (g *listerSecretGetter) Get(triggerNS string, sr *triggersv1beta1.SecretRef
 	if err != nil {
 		return nil, err
 	}
-	secretValue := secret.Data[sr.SecretKey]
+	secretValue, ok := secret.Data[sr.SecretKey]
+	if !ok {
+		return nil, fmt.Errorf("cannot find %s key in secret %s/%s", sr.SecretKey, triggerNS, sr.SecretName)
+	}
 	return secretValue, nil
 }
 

--- a/pkg/interceptors/interceptors.go
+++ b/pkg/interceptors/interceptors.go
@@ -40,14 +40,28 @@ type Interceptor interface {
 	ExecuteTrigger(req *http.Request) (*http.Response, error)
 }
 
-// GetSecretToken queries Kubernetes for the given secret reference. We use this function
+type SecretGetter interface {
+	Get(triggerNS string, sr *triggersv1beta1.SecretRef) ([]byte, error)
+}
+
+type listerSecretGetter struct {
+	lister corev1lister.SecretLister
+}
+
+func NewListerSecretGetter(lister corev1lister.SecretLister) SecretGetter {
+	return &listerSecretGetter{
+		lister: lister,
+	}
+}
+
+// Get queries Kubernetes for the given secret reference. We use this function
 // to resolve secret material like GitHub webhook secrets, and call it once for every
 // trigger that references it.
 //
 // As we may have many triggers that all use the same secret, we cache the secret values
 // in the request cache.
-func GetSecretToken(sl corev1lister.SecretLister, sr *triggersv1beta1.SecretRef, triggerNS string) ([]byte, error) {
-	secret, err := sl.Secrets(triggerNS).Get(sr.SecretName)
+func (g *listerSecretGetter) Get(triggerNS string, sr *triggersv1beta1.SecretRef) ([]byte, error) {
+	secret, err := g.lister.Secrets(triggerNS).Get(sr.SecretName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/interceptors/interceptors_test.go
+++ b/pkg/interceptors/interceptors_test.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -37,8 +38,10 @@ import (
 	"go.uber.org/zap/zaptest"
 	"google.golang.org/grpc/codes"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 )
 
 func TestGetInterceptorParams(t *testing.T) {
@@ -508,5 +511,45 @@ func TestExecute_Error(t *testing.T) {
 				t.Fatalf("Execute() did not get expected error. Response was %+v", got)
 			}
 		})
+	}
+}
+
+func TestCacheSecrets(t *testing.T) {
+	ctx, _ := test.SetupFakeContext(t)
+	_, clientset := fakekubeclient.With(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "ns",
+		},
+		Data: map[string][]byte{
+			"key": []byte("foobar"),
+		},
+	})
+	getter := interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second)
+
+	bin, err := getter.Get(context.Background(), "ns", &triggersv1.SecretRef{
+		SecretKey:  "key",
+		SecretName: "name",
+	})
+	if err != nil {
+		t.Fatalf("Get() unexpected error: %s", err)
+	}
+	if string(bin) != "foobar" {
+		t.Fatalf("Unexpected payload. Got: %s", string(bin))
+	}
+
+	if err := clientset.CoreV1().Secrets("ns").Delete(context.Background(), "name", metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("Cannot delete secret: %s", err)
+	}
+
+	bin, err = getter.Get(context.Background(), "ns", &triggersv1.SecretRef{
+		SecretKey:  "key",
+		SecretName: "name",
+	})
+	if err != nil {
+		t.Fatalf("Get() unexpected error: %s", err)
+	}
+	if string(bin) != "foobar" {
+		t.Fatalf("Unexpected payload. Got: %s", string(bin))
 	}
 }

--- a/pkg/interceptors/server/server.go
+++ b/pkg/interceptors/server/server.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/tektoncd/triggers/pkg/interceptors"
 	"github.com/tektoncd/triggers/pkg/interceptors/bitbucket"
 	"github.com/tektoncd/triggers/pkg/interceptors/cel"
 	"github.com/tektoncd/triggers/pkg/interceptors/github"
@@ -17,7 +18,6 @@ import (
 
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"go.uber.org/zap"
-	corev1lister "k8s.io/client-go/listers/core/v1"
 )
 
 type Server struct {
@@ -33,12 +33,12 @@ func (is *Server) RegisterInterceptor(path string, interceptor triggersv1.Interc
 	is.interceptors[path] = interceptor
 }
 
-func NewWithCoreInterceptors(sl corev1lister.SecretLister, l *zap.SugaredLogger) (*Server, error) {
+func NewWithCoreInterceptors(sg interceptors.SecretGetter, l *zap.SugaredLogger) (*Server, error) {
 	i := map[string]triggersv1.InterceptorInterface{
-		"bitbucket": bitbucket.NewInterceptor(sl, l),
-		"cel":       cel.NewInterceptor(sl, l),
-		"github":    github.NewInterceptor(sl, l),
-		"gitlab":    gitlab.NewInterceptor(sl, l),
+		"bitbucket": bitbucket.NewInterceptor(sg, l),
+		"cel":       cel.NewInterceptor(sg, l),
+		"github":    github.NewInterceptor(sg, l),
+		"gitlab":    gitlab.NewInterceptor(sg, l),
 	}
 
 	for k, v := range i {

--- a/pkg/interceptors/server/server_test.go
+++ b/pkg/interceptors/server/server_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
-
 	"google.golang.org/grpc/codes"
 
 	"github.com/google/go-cmp/cmp"
@@ -21,7 +20,7 @@ import (
 	"github.com/tektoncd/triggers/pkg/interceptors"
 	"github.com/tektoncd/triggers/test"
 	"go.uber.org/zap/zaptest"
-	fakeSecretInformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/fake"
+	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 )
 
 func TestServer_ServeHTTP(t *testing.T) {
@@ -78,9 +77,8 @@ func TestServer_ServeHTTP(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			logger := zaptest.NewLogger(t)
 			ctx, _ := test.SetupFakeContext(t)
-			secretLister := fakeSecretInformer.Get(ctx).Lister()
 
-			server, err := NewWithCoreInterceptors(interceptors.NewListerSecretGetter(secretLister), logger.Sugar())
+			server, err := NewWithCoreInterceptors(interceptors.NewKubeClientSecretGetter(fakekubeclient.Get(ctx).CoreV1()), logger.Sugar())
 			if err != nil {
 				t.Fatalf("error initializing core interceptors: %v", err)
 			}
@@ -138,9 +136,8 @@ func TestServer_ServeHTTP_Error(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			logger := zaptest.NewLogger(t)
 			ctx, _ := test.SetupFakeContext(t)
-			secretLister := fakeSecretInformer.Get(ctx).Lister()
 
-			server, err := NewWithCoreInterceptors(interceptors.NewListerSecretGetter(secretLister), logger.Sugar())
+			server, err := NewWithCoreInterceptors(interceptors.NewKubeClientSecretGetter(fakekubeclient.Get(ctx).CoreV1()), logger.Sugar())
 			if err != nil {
 				t.Fatalf("error initializing core interceptors: %v", err)
 			}

--- a/pkg/interceptors/server/server_test.go
+++ b/pkg/interceptors/server/server_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	"github.com/tektoncd/triggers/pkg/interceptors"
 	"github.com/tektoncd/triggers/test"
 	"go.uber.org/zap/zaptest"
 	fakeSecretInformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/fake"
@@ -79,7 +80,7 @@ func TestServer_ServeHTTP(t *testing.T) {
 			ctx, _ := test.SetupFakeContext(t)
 			secretLister := fakeSecretInformer.Get(ctx).Lister()
 
-			server, err := NewWithCoreInterceptors(secretLister, logger.Sugar())
+			server, err := NewWithCoreInterceptors(interceptors.NewListerSecretGetter(secretLister), logger.Sugar())
 			if err != nil {
 				t.Fatalf("error initializing core interceptors: %v", err)
 			}
@@ -139,7 +140,7 @@ func TestServer_ServeHTTP_Error(t *testing.T) {
 			ctx, _ := test.SetupFakeContext(t)
 			secretLister := fakeSecretInformer.Get(ctx).Lister()
 
-			server, err := NewWithCoreInterceptors(secretLister, logger.Sugar())
+			server, err := NewWithCoreInterceptors(interceptors.NewListerSecretGetter(secretLister), logger.Sugar())
 			if err != nil {
 				t.Fatalf("error initializing core interceptors: %v", err)
 			}

--- a/pkg/interceptors/server/server_test.go
+++ b/pkg/interceptors/server/server_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"google.golang.org/grpc/codes"
@@ -78,7 +79,7 @@ func TestServer_ServeHTTP(t *testing.T) {
 			logger := zaptest.NewLogger(t)
 			ctx, _ := test.SetupFakeContext(t)
 
-			server, err := NewWithCoreInterceptors(interceptors.NewKubeClientSecretGetter(fakekubeclient.Get(ctx).CoreV1()), logger.Sugar())
+			server, err := NewWithCoreInterceptors(interceptors.NewKubeClientSecretGetter(fakekubeclient.Get(ctx).CoreV1(), 1024, 5*time.Second), logger.Sugar())
 			if err != nil {
 				t.Fatalf("error initializing core interceptors: %v", err)
 			}
@@ -137,7 +138,7 @@ func TestServer_ServeHTTP_Error(t *testing.T) {
 			logger := zaptest.NewLogger(t)
 			ctx, _ := test.SetupFakeContext(t)
 
-			server, err := NewWithCoreInterceptors(interceptors.NewKubeClientSecretGetter(fakekubeclient.Get(ctx).CoreV1()), logger.Sugar())
+			server, err := NewWithCoreInterceptors(interceptors.NewKubeClientSecretGetter(fakekubeclient.Get(ctx).CoreV1(), 1024, 5*time.Second), logger.Sugar())
 			if err != nil {
 				t.Fatalf("error initializing core interceptors: %v", err)
 			}

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -58,10 +58,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	fakedynamic "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
-	corev1lister "k8s.io/client-go/listers/core/v1"
 	ktesting "k8s.io/client-go/testing"
 	"knative.dev/pkg/apis"
-	fakeSecretInformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/fake"
+	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/ptr"
 )
@@ -133,10 +132,9 @@ func getSinkAssets(t *testing.T, res test.Resources, elName string, webhookInter
 
 	dynamicClient := fakedynamic.NewSimpleDynamicClient(runtime.NewScheme())
 	dynamicSet := dynamicclientset.New(tekton.WithClient(dynamicClient))
-	secretLister := fakeSecretInformer.Get(ctx).Lister()
 
 	// Setup a handler for core interceptors using httptest
-	httpClient := setupInterceptors(t, secretLister, clients.Kube, logger.Sugar(), webhookInterceptor)
+	httpClient := setupInterceptors(t, clients.Kube, logger.Sugar(), webhookInterceptor)
 
 	ceClient, _ := cloudeventstest.NewMockSenderClient(t, 1)
 
@@ -168,10 +166,10 @@ func getSinkAssets(t *testing.T, res test.Resources, elName string, webhookInter
 
 // setupInterceptors creates a httptest server with all coreInterceptors and any passed in webhook interceptor
 // It returns a http.Client that can be used to talk to these interceptors
-func setupInterceptors(t *testing.T, s corev1lister.SecretLister, k kubernetes.Interface, l *zap.SugaredLogger, webhookInterceptor http.Handler) *http.Client {
+func setupInterceptors(t *testing.T, k kubernetes.Interface, l *zap.SugaredLogger, webhookInterceptor http.Handler) *http.Client {
 	t.Helper()
 	// Setup a handler for core interceptors using httptest
-	coreInterceptors, err := server.NewWithCoreInterceptors(interceptors.NewListerSecretGetter(s), l)
+	coreInterceptors, err := server.NewWithCoreInterceptors(interceptors.NewKubeClientSecretGetter(k.CoreV1()), l)
 	if err != nil {
 		t.Fatalf("failed to initialize core interceptors: %v", err)
 	}
@@ -1277,7 +1275,8 @@ func (f *sequentialInterceptor) ServeHTTP(w http.ResponseWriter, r *http.Request
 // that the last response is as expected.
 func TestExecuteInterceptor_Sequential(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	httpClient := setupInterceptors(t, nil, nil, logger.Sugar(), &sequentialInterceptor{})
+	ctx, _ := test.SetupFakeContext(t)
+	httpClient := setupInterceptors(t, fakekubeclient.Get(ctx), logger.Sugar(), &sequentialInterceptor{})
 
 	r := Sink{
 		HTTPClient: httpClient,
@@ -1352,7 +1351,8 @@ func TestExecuteInterceptor_error(t *testing.T) {
 	r.MatcherFunc(match).Handler(&errorInterceptor{})
 	si := &sequentialInterceptor{}
 	r.Handle("/", si)
-	httpClient := setupInterceptors(t, nil, nil, logger.Sugar(), r)
+	ctx, _ := test.SetupFakeContext(t)
+	httpClient := setupInterceptors(t, fakekubeclient.Get(ctx), logger.Sugar(), r)
 
 	s := Sink{
 		HTTPClient: httpClient,

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	cloudeventstest "github.com/cloudevents/sdk-go/v2/client/test"
 	"github.com/google/go-cmp/cmp"
@@ -169,7 +170,7 @@ func getSinkAssets(t *testing.T, res test.Resources, elName string, webhookInter
 func setupInterceptors(t *testing.T, k kubernetes.Interface, l *zap.SugaredLogger, webhookInterceptor http.Handler) *http.Client {
 	t.Helper()
 	// Setup a handler for core interceptors using httptest
-	coreInterceptors, err := server.NewWithCoreInterceptors(interceptors.NewKubeClientSecretGetter(k.CoreV1()), l)
+	coreInterceptors, err := server.NewWithCoreInterceptors(interceptors.NewKubeClientSecretGetter(k.CoreV1(), 1024, 5*time.Second), l)
 	if err != nil {
 		t.Fatalf("failed to initialize core interceptors: %v", err)
 	}

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -171,7 +171,7 @@ func getSinkAssets(t *testing.T, res test.Resources, elName string, webhookInter
 func setupInterceptors(t *testing.T, s corev1lister.SecretLister, k kubernetes.Interface, l *zap.SugaredLogger, webhookInterceptor http.Handler) *http.Client {
 	t.Helper()
 	// Setup a handler for core interceptors using httptest
-	coreInterceptors, err := server.NewWithCoreInterceptors(s, l)
+	coreInterceptors, err := server.NewWithCoreInterceptors(interceptors.NewListerSecretGetter(s), l)
 	if err != nil {
 		t.Fatalf("failed to initialize core interceptors: %v", err)
 	}


### PR DESCRIPTION
# Changes

Replace the secret informer by a secret getter.
It implies that for each webhook an API call will be issued against the
k8s API to get the secret.
Previously, all secrets of the cluster were in the interceptor memory.

Before this change:
crictl stats reports 79.18MB with around 5k secrets of 2.5kB with kind.

After this change:
crictl stats reports 8.221MB

Proposition related to https://github.com/tektoncd/triggers/issues/1268

The other way to solve this would be to add a specific label on all secrets watched by the interceptor.
But it would introduce a breaking change between 2 releases.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Reduce memory usage of the core-interceptors container
```