### PR TITLE
Add validation for eventlistener spec

### DIFF
--- a/pkg/apis/triggers/v1alpha1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation.go
@@ -56,6 +56,10 @@ func (e *EventListener) Validate(ctx context.Context) *apis.FieldError {
 }
 
 func (s *EventListenerSpec) validate(ctx context.Context) (errs *apis.FieldError) {
+	if s.LabelSelector == nil && len(s.NamespaceSelector.MatchNames) == 0 && len(s.Triggers) == 0 {
+		return apis.ErrMissingOneOf("spec.labelSelector", "spec.namespaceSelector", "spec.triggers")
+	}
+
 	for i, trigger := range s.Triggers {
 		errs = errs.Also(trigger.validate(ctx).ViaField(fmt.Sprintf("spec.triggers[%d]", i)))
 	}

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
@@ -419,6 +419,11 @@ func Test_EventListenerValidate(t *testing.T) {
 				Namespace: "namespace",
 			},
 			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					Template: &v1alpha1.EventListenerTemplate{
+						Ref: ptr.String("tt"),
+					},
+				}},
 				Resources: v1alpha1.Resources{
 					KubernetesResource: &v1alpha1.KubernetesResource{
 						Replicas: ptr.Int32(1),
@@ -1194,6 +1199,14 @@ func TestEventListenerValidate_error(t *testing.T) {
 						RawExtension: getValidRawData(t),
 					},
 				},
+			},
+		},
+	}, {
+		name: "empty spec for eventlistener",
+		el: &v1alpha1.EventListener{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
 			},
 		},
 	}}

--- a/pkg/apis/triggers/v1beta1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_validation.go
@@ -58,6 +58,10 @@ func (e *EventListener) Validate(ctx context.Context) *apis.FieldError {
 }
 
 func (s *EventListenerSpec) validate(ctx context.Context) (errs *apis.FieldError) {
+	if s.LabelSelector == nil && len(s.NamespaceSelector.MatchNames) == 0 && len(s.TriggerGroups) == 0 && len(s.Triggers) == 0 {
+		return apis.ErrMissingOneOf("spec.labelSelector", "spec.namespaceSelector", "spec.triggerGroups", "spec.triggers")
+	}
+
 	for i, trigger := range s.Triggers {
 		errs = errs.Also(trigger.validate(ctx).ViaField(fmt.Sprintf("spec.triggers[%d]", i)))
 	}

--- a/pkg/apis/triggers/v1beta1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_validation_test.go
@@ -392,6 +392,11 @@ func Test_EventListenerValidate(t *testing.T) {
 		el: &triggersv1beta1.EventListener{
 			ObjectMeta: myObjectMeta,
 			Spec: triggersv1beta1.EventListenerSpec{
+				Triggers: []triggersv1beta1.EventListenerTrigger{{
+					Template: &triggersv1beta1.EventListenerTemplate{
+						Ref: ptr.String("tt"),
+					},
+				}},
 				Resources: triggersv1beta1.Resources{
 					KubernetesResource: &triggersv1beta1.KubernetesResource{
 						Replicas: ptr.Int32(1),
@@ -1286,6 +1291,16 @@ func TestEventListenerValidate_error(t *testing.T) {
 				},
 			},
 			wantErr: apis.ErrMissingField("spec.triggerGroups[0].interceptors"),
+		}, {
+			name: "empty spec for eventlistener",
+			ctx:  ctxWithAlphaFieldsEnabled,
+			el: &triggersv1beta1.EventListener{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "namespace",
+				},
+			},
+			wantErr: apis.ErrMissingOneOf("spec.labelSelector", "spec.namespaceSelector", "spec.triggerGroups", "spec.triggers"),
 		}}
 
 	for _, tc := range tests {


### PR DESCRIPTION
# Changes
Fixes https://github.com/tektoncd/triggers/issues/1269

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
BREAKING CHANGE: Triggers now validates and give error if provided EventListener spec is empty.
```