### PR TITLE
Fetch the secret in only one function 

### DIFF
--- a/pkg/interceptors/bitbucket/bitbucket.go
+++ b/pkg/interceptors/bitbucket/bitbucket.go
@@ -79,7 +79,7 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 		ns, _ := triggersv1.ParseTriggerID(r.Context.TriggerID)
 		secretToken, err := interceptors.GetSecretToken(nil, w.SecretLister, p.SecretRef, ns)
 		if err != nil {
-			return interceptors.Failf(codes.Internal, "error getting secret: %v", err)
+			return interceptors.Failf(codes.FailedPrecondition, "error getting secret: %v", err)
 		}
 
 		if err := gh.ValidateSignature(header, []byte(r.Body), secretToken); err != nil {

--- a/pkg/interceptors/bitbucket/bitbucket.go
+++ b/pkg/interceptors/bitbucket/bitbucket.go
@@ -78,11 +78,10 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 			return interceptors.Fail(codes.InvalidArgument, "no X-Hub-Signature header set")
 		}
 		ns, _ := triggersv1.ParseTriggerID(r.Context.TriggerID)
-		secret, err := w.SecretLister.Secrets(ns).Get(p.SecretRef.SecretName)
+		secretToken, err := interceptors.GetSecretToken(nil, w.SecretLister, p.SecretRef, ns)
 		if err != nil {
 			return interceptors.Failf(codes.Internal, fmt.Sprintf("error getting secret: %v", err))
 		}
-		secretToken := secret.Data[p.SecretRef.SecretKey]
 
 		if err := gh.ValidateSignature(header, []byte(r.Body), secretToken); err != nil {
 			return interceptors.Failf(codes.FailedPrecondition, err.Error())

--- a/pkg/interceptors/bitbucket/bitbucket.go
+++ b/pkg/interceptors/bitbucket/bitbucket.go
@@ -18,7 +18,6 @@ package bitbucket
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"google.golang.org/grpc/codes"
@@ -80,7 +79,7 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 		ns, _ := triggersv1.ParseTriggerID(r.Context.TriggerID)
 		secretToken, err := interceptors.GetSecretToken(nil, w.SecretLister, p.SecretRef, ns)
 		if err != nil {
-			return interceptors.Failf(codes.Internal, fmt.Sprintf("error getting secret: %v", err))
+			return interceptors.Failf(codes.Internal, "error getting secret: %v", err)
 		}
 
 		if err := gh.ValidateSignature(header, []byte(r.Body), secretToken); err != nil {

--- a/pkg/interceptors/gitlab/gitlab.go
+++ b/pkg/interceptors/gitlab/gitlab.go
@@ -19,7 +19,6 @@ package gitlab
 import (
 	"context"
 	"crypto/subtle"
-	"fmt"
 
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/pkg/interceptors"
@@ -79,7 +78,7 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 		ns, _ := triggersv1.ParseTriggerID(r.Context.TriggerID)
 		secretToken, err := interceptors.GetSecretToken(nil, w.SecretLister, p.SecretRef, ns)
 		if err != nil {
-			return interceptors.Fail(codes.Internal, fmt.Sprintf("error getting secret: %v", err))
+			return interceptors.Failf(codes.Internal, "error getting secret: %v", err)
 		}
 
 		// Make sure to use a constant time comparison here.

--- a/pkg/interceptors/gitlab/gitlab.go
+++ b/pkg/interceptors/gitlab/gitlab.go
@@ -77,11 +77,10 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 		}
 
 		ns, _ := triggersv1.ParseTriggerID(r.Context.TriggerID)
-		secret, err := w.SecretLister.Secrets(ns).Get(p.SecretRef.SecretName)
+		secretToken, err := interceptors.GetSecretToken(nil, w.SecretLister, p.SecretRef, ns)
 		if err != nil {
 			return interceptors.Fail(codes.Internal, fmt.Sprintf("error getting secret: %v", err))
 		}
-		secretToken := secret.Data[p.SecretRef.SecretKey]
 
 		// Make sure to use a constant time comparison here.
 		if subtle.ConstantTimeCompare([]byte(header), secretToken) == 0 {

--- a/pkg/interceptors/gitlab/gitlab.go
+++ b/pkg/interceptors/gitlab/gitlab.go
@@ -78,7 +78,7 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 		ns, _ := triggersv1.ParseTriggerID(r.Context.TriggerID)
 		secretToken, err := interceptors.GetSecretToken(nil, w.SecretLister, p.SecretRef, ns)
 		if err != nil {
-			return interceptors.Failf(codes.Internal, "error getting secret: %v", err)
+			return interceptors.Failf(codes.FailedPrecondition, "error getting secret: %v", err)
 		}
 
 		// Make sure to use a constant time comparison here.


### PR DESCRIPTION
# Changes

Interceptors all fetch the secret the same way. A util function exists
for this purpose `interceptors.GetSecretToken`. Let's use it for all
implementations.

http.Request is always nil when calling this function. It's something to
fix in the future.

With this single place where the code asks for secret, we can add a
good cache.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes


```release-note
NONE
```
