### PR TITLE
Fix eventlistener crash with multiple interceptors extensions

### DIFF
--- a/pkg/sink/sink.go
+++ b/pkg/sink/sink.go
@@ -44,10 +44,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-var (
-	emptyExtensions = map[string]interface{}{}
-)
-
 // Sink defines the sink resource for processing incoming events for the
 // EventListener.
 type Sink struct {
@@ -136,6 +132,7 @@ func (r Sink) HandleEvent(response http.ResponseWriter, request *http.Request) {
 		go func(t triggersv1.Trigger) {
 			defer r.WGProcessTriggers.Done()
 			localRequest := request.Clone(request.Context())
+			emptyExtensions := make(map[string]interface{})
 			r.processTrigger(t, localRequest, event, eventID, log, emptyExtensions)
 		}(*t)
 	}


### PR DESCRIPTION
When multiple interceptors are present in an event listener and they produce an extension, a race condition can occur due to a global variable written to in a goroutine.

It is possible that this also affects which pipelines could be triggered if the extensions are used for trigger routing.

# Changes

A global shared variable was being written to when extensions were
present in the interceptor output. This resulted in a race condition
verified by `go test -race ./pkg/sink` with the new test.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes
- Bug fixes

```release-note
Fix race condition in eventlistener when multiple interceptors return extentions
```
