### PR TITLE
Allow creating v1alpha1 Run types

### DIFF
--- a/pkg/client/dynamic/clientset/tekton/tekton.go
+++ b/pkg/client/dynamic/clientset/tekton/tekton.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	allowedPipelineTypes = map[string][]string{
-		"v1alpha1": {"pipelineresources", "pipelineruns", "taskruns", "pipelines", "clustertasks", "tasks", "conditions"},
+		"v1alpha1": {"pipelineresources", "pipelineruns", "taskruns", "pipelines", "clustertasks", "tasks", "conditions", "runs"},
 		"v1beta1":  {"pipelineruns", "taskruns", "pipelines", "clustertasks", "tasks"},
 	}
 	allowedTriggersTypes = map[string][]string{


### PR DESCRIPTION

# Changes

This seems like an unintentional omission since we do allow creating
TriggerTemplates with the Run kind.

Addressing #494 should have caught this earlier.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
Triggers users can create resources of the Run kind i.e. they can create custom task runs
```
-->
