### PR TITLE
Add a RegisterInterceptor helper function

### DIFF
--- a/pkg/interceptors/server/server.go
+++ b/pkg/interceptors/server/server.go
@@ -25,8 +25,15 @@ type Server struct {
 	interceptors map[string]triggersv1.InterceptorInterface
 }
 
-func NewWithCoreInterceptors(sl corev1lister.SecretLister, l *zap.SugaredLogger) (*Server, error) {
+// RegisterInterceptor sets up the interceptor to be served at the specfied path
+func (is *Server) RegisterInterceptor(path string, interceptor triggersv1.InterceptorInterface) {
+	if is.interceptors == nil {
+		is.interceptors = map[string]triggersv1.InterceptorInterface{}
+	}
+	is.interceptors[path] = interceptor
+}
 
+func NewWithCoreInterceptors(sl corev1lister.SecretLister, l *zap.SugaredLogger) (*Server, error) {
 	i := map[string]triggersv1.InterceptorInterface{
 		"bitbucket": bitbucket.NewInterceptor(sl, l),
 		"cel":       cel.NewInterceptor(sl, l),


### PR DESCRIPTION
# Changes

This makes it a lot easier to write custom interceptors while utilizing the
rest of the server helpers that we have created for the packaged core
interceptors.

(Since the interceptors field within `Server` is not exported, it becomes impossible to use the server code for interceptors not written within the Trigger source tree)

This should help a lot in the process of migrating the dogfooding interceptors in https://github.com/tektoncd/plumbing/tree/main/tekton/ci/interceptors to use the ClusterInterceptor CRD

/cc @afrittoli 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
NONE
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
Adds a RegisterInterceptor helper function that can be used by authors of custom interceptors to utilize the same interceptor server framework that we use for the core interceptors. See https://github.com/tektoncd/plumbing/pull/967 for an example.
```