### PR TITLE
Use the same mechanism to load kubeconfig

### DIFF
--- a/cmd/interceptors/main.go
+++ b/cmd/interceptors/main.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/tektoncd/triggers/pkg/interceptors/server"
 	"go.uber.org/zap"
-	"k8s.io/client-go/rest"
 	secretInformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
 	"knative.dev/pkg/injection"
 	"knative.dev/pkg/logging"
@@ -45,12 +44,9 @@ func main() {
 	// set up signals so we handle the first shutdown signal gracefully
 	ctx := signals.NewContext()
 
-	clusterConfig, err := rest.InClusterConfig()
-	if err != nil {
-		log.Fatalf("Failed to build config: %v", err)
-	}
+	cfg := injection.ParseAndGetRESTConfigOrDie()
 
-	ctx, startInformer := injection.EnableInjectionOrDie(ctx, clusterConfig)
+	ctx, startInformer := injection.EnableInjectionOrDie(ctx, cfg)
 
 	zap, err := zap.NewProduction()
 	if err != nil {


### PR DESCRIPTION

# Changes

Interceptors and EL are both running in the cluster. They should share
the same way of loading the kubeconfig.

Using injection package, it allows the user to override the kubeconfig
with an env. variable.


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
NONE
```
