### PR TITLE
Add metrics for ClusterInteceptor, CTB, EL, TT and TB count

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,20 @@
+<!--
+---
+linkTitle: "Triggers Metrics"
+weight: 1200
+---
+-->
+# Tekton Triggers Controller Metrics
+
+The following tekton triggers metrics are available at `controller-service` on port `9000`.
+
+We expose several kinds of exporters, including Prometheus, Google Stackdriver, and many others. You can set them up using [observability configuration](../config/config-observability.yaml).
+
+|  Name | Type | Description |
+| ---------- | ----------- | ----------- |
+| `controller_clusterinterceptor_count` | Gauge | Number of clusterinteceptor |
+| `controller_eventlistener_count` | Gauge | Number of eventlistener |
+| `controller_clustertriggerbinding_count` | Gauge | Number of clustertriggerbinding |
+| `controller_triggerbinding_count` | Gauge | Number of triggerbinding |
+| `controller_triggertemplate_count` | Gauge | Number of triggertemplate |
+

--- a/pkg/reconciler/eventlistener/controller.go
+++ b/pkg/reconciler/eventlistener/controller.go
@@ -26,6 +26,7 @@ import (
 	eventlistenerreconciler "github.com/tektoncd/triggers/pkg/client/injection/reconciler/triggers/v1beta1/eventlistener"
 	dynamicduck "github.com/tektoncd/triggers/pkg/dynamic"
 	"github.com/tektoncd/triggers/pkg/reconciler/eventlistener/resources"
+	"github.com/tektoncd/triggers/pkg/reconciler/metrics"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	reconcilersource "knative.dev/eventing/pkg/reconciler/source"
@@ -58,6 +59,7 @@ func NewController(config resources.Config) func(context.Context, configmap.Watc
 			serviceLister:     serviceInformer.Lister(),
 			configAcc:         reconcilersource.WatchConfigurations(ctx, "eventlistener", cmw),
 			config:            config,
+			Metrics:           metrics.Get(ctx),
 		}
 
 		impl := eventlistenerreconciler.NewImpl(ctx, reconciler, func(impl *controller.Impl) controller.Options {

--- a/pkg/reconciler/eventlistener/eventlistener.go
+++ b/pkg/reconciler/eventlistener/eventlistener.go
@@ -29,6 +29,7 @@ import (
 	eventlistenerreconciler "github.com/tektoncd/triggers/pkg/client/injection/reconciler/triggers/v1beta1/eventlistener"
 	dynamicduck "github.com/tektoncd/triggers/pkg/dynamic"
 	"github.com/tektoncd/triggers/pkg/reconciler/eventlistener/resources"
+	"github.com/tektoncd/triggers/pkg/reconciler/metrics"
 	"golang.org/x/xerrors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -86,6 +87,9 @@ type Reconciler struct {
 	config             resources.Config
 	podspecableTracker dynamicduck.ListableTracker
 	onlyOnce           sync.Once
+
+	// Metrics Recorder config
+	Metrics *metrics.Recorder
 }
 
 var (

--- a/pkg/reconciler/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/eventlistener/eventlistener_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	"github.com/tektoncd/triggers/pkg/reconciler/eventlistener/resources"
+	"github.com/tektoncd/triggers/pkg/reconciler/metrics"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -114,6 +115,7 @@ func compareEnv(x, y corev1.EnvVar) bool {
 func getEventListenerTestAssets(t *testing.T, r test.Resources, c *resources.Config) (test.Assets, context.CancelFunc) {
 	t.Helper()
 	ctx, _ := test.SetupFakeContext(t)
+	ctx = metrics.WithClient(ctx)
 	ctx, cancel := context.WithCancel(ctx)
 	kubeClient := fakekubeclient.Get(ctx)
 	// Fake client reactor chain ignores non handled reactors until v1.40.0

--- a/pkg/reconciler/metrics/injection.go
+++ b/pkg/reconciler/metrics/injection.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+
+	ciInformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1alpha1/clusterinterceptor"
+	ctbInformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1beta1/clustertriggerbinding"
+	elInformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1beta1/eventlistener"
+	tbInformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1beta1/triggerbinding"
+	ttInformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1beta1/triggertemplate"
+	"k8s.io/client-go/rest"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection"
+	"knative.dev/pkg/logging"
+)
+
+func init() {
+	injection.Default.RegisterClient(func(ctx context.Context, _ *rest.Config) context.Context { return WithClient(ctx) })
+	injection.Default.RegisterInformer(WithInformer)
+
+	injection.Dynamic.RegisterDynamicClient(WithClient)
+	injection.Dynamic.RegisterDynamicInformer(func(ctx context.Context) context.Context {
+		ctx, _ = WithInformer(ctx)
+		return ctx
+	})
+}
+
+// RecorderKey is used for associating the Recorder inside the context.Context.
+type RecorderKey struct{}
+
+func WithClient(ctx context.Context) context.Context {
+	rec, err := NewRecorder(ctx)
+	if err != nil {
+		logging.FromContext(ctx).Errorf("Failed to create trigger metrics recorder %v", err)
+	}
+	return context.WithValue(ctx, RecorderKey{}, rec)
+}
+
+// Get extracts the pipelinerunmetrics.Recorder from the context.
+func Get(ctx context.Context) *Recorder {
+	untyped := ctx.Value(RecorderKey{})
+	if untyped == nil {
+		logging.FromContext(ctx).Panic("Unable to fetch *metrics.Recorder from context.")
+	}
+	return untyped.(*Recorder)
+}
+
+type recorderInformer struct {
+	ctx     context.Context
+	metrics *Recorder
+	listers
+}
+
+// InformerKey is used for associating the Informer inside the context.Context.
+type InformerKey struct{}
+
+func WithInformer(ctx context.Context) (context.Context, controller.Informer) {
+	return ctx, &recorderInformer{
+		ctx:     ctx,
+		metrics: Get(ctx),
+		listers: listers{
+			el:  elInformer.Get(ctx).Lister(),
+			ctb: ctbInformer.Get(ctx).Lister(),
+			tb:  tbInformer.Get(ctx).Lister(),
+			tt:  ttInformer.Get(ctx).Lister(),
+			ci:  ciInformer.Get(ctx).Lister(),
+		},
+	}
+}
+
+var _ controller.Informer = (*recorderInformer)(nil)
+
+func (ri *recorderInformer) Run(stopCh <-chan struct{}) {
+	// Turn the stopCh into a context for reporting metrics.
+	ctx, cancel := context.WithCancel(ri.ctx)
+	go func() {
+		<-stopCh
+		cancel()
+	}()
+
+	go ri.metrics.ReportCountMetrics(ctx, ri.listers)
+}
+
+func (ri *recorderInformer) HasSynced() bool {
+	return true
+}

--- a/pkg/reconciler/metrics/metrics.go
+++ b/pkg/reconciler/metrics/metrics.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/tektoncd/triggers/pkg/client/listers/triggers/v1alpha1"
+	"github.com/tektoncd/triggers/pkg/client/listers/triggers/v1beta1"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"k8s.io/apimachinery/pkg/labels"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/metrics"
+)
+
+var (
+	elMetricsName = "eventlistener_count"
+	elCount       = stats.Float64(elMetricsName,
+		"number of eventlistener",
+		stats.UnitDimensionless)
+	elCountView *view.View
+
+	tbMetricsName = "triggerbinding_count"
+	tbCount       = stats.Float64(tbMetricsName,
+		"number of triggerbinding",
+		stats.UnitDimensionless)
+	tbCountView *view.View
+
+	ctbMetricsName = "clustertriggerbinding_count"
+	ctbCount       = stats.Float64(ctbMetricsName,
+		"number of clustertriggerbinding",
+		stats.UnitDimensionless)
+	ctbCountView *view.View
+
+	ttMetricsName = "triggertemplate_count"
+	ttCount       = stats.Float64(ttMetricsName,
+		"number of triggertemplate",
+		stats.UnitDimensionless)
+	ttCountView *view.View
+
+	ciMetricsName = "clusterinterceptor_count"
+	ciCount       = stats.Float64(ciMetricsName,
+		"number of clusterinterceptor",
+		stats.UnitDimensionless)
+	ciCountView *view.View
+)
+
+type listers struct {
+	el  v1beta1.EventListenerLister
+	ctb v1beta1.ClusterTriggerBindingLister
+	tb  v1beta1.TriggerBindingLister
+	tt  v1beta1.TriggerTemplateLister
+	ci  v1alpha1.ClusterInterceptorLister
+}
+
+// Recorder holds information for Trigger metrics
+type Recorder struct {
+	initialized     bool
+	ReportingPeriod time.Duration
+}
+
+// We cannot register the view multiple times, so NewRecorder lazily
+// initializes this singleton and returns the same recorder across any
+// subsequent invocations.
+var (
+	once        sync.Once
+	r           *Recorder
+	recorderErr error
+)
+
+// NewRecorder creates a new metrics recorder instance
+// to log the PipelineRun related metrics
+func NewRecorder(ctx context.Context) (*Recorder, error) {
+	once.Do(func() {
+		r = &Recorder{
+			initialized: true,
+			// Default to reporting metrics every 60s.
+			ReportingPeriod: 60 * time.Second,
+		}
+
+		recorderErr = viewRegister()
+		if recorderErr != nil {
+			r.initialized = false
+			return
+		}
+	})
+
+	return r, recorderErr
+}
+
+func viewRegister() error {
+	elCountView = &view.View{
+		Description: elCount.Description(),
+		Measure:     elCount,
+		Aggregation: view.LastValue(),
+	}
+
+	tbCountView = &view.View{
+		Description: tbCount.Description(),
+		Measure:     tbCount,
+		Aggregation: view.LastValue(),
+	}
+
+	ctbCountView = &view.View{
+		Description: ctbCount.Description(),
+		Measure:     ctbCount,
+		Aggregation: view.LastValue(),
+	}
+
+	ttCountView = &view.View{
+		Description: ttCount.Description(),
+		Measure:     ttCount,
+		Aggregation: view.LastValue(),
+	}
+
+	ciCountView = &view.View{
+		Description: ciCount.Description(),
+		Measure:     ciCount,
+		Aggregation: view.LastValue(),
+	}
+
+	return view.Register(
+		elCountView,
+		tbCountView,
+		ctbCountView,
+		ttCountView,
+		ciCountView,
+	)
+}
+
+func (r *Recorder) ReportCountMetrics(ctx context.Context, li listers) {
+
+	for {
+		select {
+		case <-ctx.Done():
+			// When the context is cancelled, stop reporting.
+			return
+
+		case <-time.After(r.ReportingPeriod):
+			r.CountMetrics(ctx, li)
+		}
+	}
+}
+
+func (r *Recorder) CountMetrics(ctx context.Context, li listers) {
+	logger := logging.FromContext(ctx)
+
+	el, err := li.el.List(labels.Everything())
+	if err != nil {
+		logger.Errorf("error reporting trigger metrics for eventlisteners: %v", err)
+	} else {
+		count := len(el)
+		r.countMetrics(ctx, float64(count), elCount)
+	}
+	ci, err := li.ci.List(labels.Everything())
+	if err != nil {
+		logger.Errorf("error reporting trigger metrics for clusterinterceptor: %v", err)
+	} else {
+		count := len(ci)
+		r.countMetrics(ctx, float64(count), ciCount)
+	}
+	tb, err := li.tb.List(labels.Everything())
+	if err != nil {
+		logger.Errorf("error reporting trigger metrics for triggerbindings : %v", err)
+	} else {
+		count := len(tb)
+		r.countMetrics(ctx, float64(count), tbCount)
+	}
+	ctb, err := li.ctb.List(labels.Everything())
+	if err != nil {
+		logger.Errorf("error reporting trigger metrics for clustertriggerbindings: %v", err)
+	} else {
+		count := len(ctb)
+		r.countMetrics(ctx, float64(count), ctbCount)
+	}
+	tt, err := li.tt.List(labels.Everything())
+	if err != nil {
+		logger.Errorf("error reporting trigger metrics for triggertemplates: %v", err)
+	} else {
+		count := len(tt)
+		r.countMetrics(ctx, float64(count), ttCount)
+	}
+
+}
+
+func (r *Recorder) countMetrics(ctx context.Context, count float64, measure *stats.Float64Measure) {
+	logger := logging.FromContext(ctx)
+
+	if !r.initialized {
+		logger.Errorf("ignoring the metrics recording for %s, failed to initialize the metrics recorder", measure.Description())
+	}
+
+	metrics.Record(ctx, measure.M(count))
+}

--- a/pkg/reconciler/metrics/metrics_test.go
+++ b/pkg/reconciler/metrics/metrics_test.go
@@ -1,0 +1,276 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	"github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
+	fakeCIInformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1alpha1/clusterinterceptor/fake"
+	fakeCTBInformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1beta1/clustertriggerbinding/fake"
+	fakeELInformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1beta1/eventlistener/fake"
+	fakeTBInformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1beta1/triggerbinding/fake"
+	fakeTTInformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1beta1/triggertemplate/fake"
+	"github.com/tektoncd/triggers/test"
+	"knative.dev/pkg/metrics/metricstest"
+	_ "knative.dev/pkg/metrics/testing"
+)
+
+func TestUninitializedMetrics(t *testing.T) {
+	metrics := &Recorder{}
+	ctx, _ := test.SetupFakeContext(t)
+
+	metrics.countMetrics(ctx, 3, elCount)
+	metricstest.CheckStatsNotReported(t, "eventlistener_count")
+
+	metrics.countMetrics(ctx, 3, ctbCount)
+	metricstest.CheckStatsNotReported(t, "clustertriggerbinding_count")
+
+	metrics.countMetrics(ctx, 3, tbCount)
+	metricstest.CheckStatsNotReported(t, "triggerbinding_count")
+
+	metrics.countMetrics(ctx, 3, ttCount)
+	metricstest.CheckStatsNotReported(t, "triggertemplate_count")
+
+	metrics.countMetrics(ctx, 3, ciCount)
+	metricstest.CheckStatsNotReported(t, "clusterinterceptor_count")
+
+}
+
+func TestCountMetrics(t *testing.T) {
+	unregisterMetrics()
+	ctx, _ := test.SetupFakeContext(t)
+	ctx = WithClient(ctx)
+
+	rec := Get(ctx)
+
+	fakeELIn := fakeELInformer.Get(ctx)
+	fakeCTBIn := fakeCTBInformer.Get(ctx)
+	fakeTBIn := fakeTBInformer.Get(ctx)
+	fakeTTIn := fakeTTInformer.Get(ctx)
+	fakeCIIn := fakeCIInformer.Get(ctx)
+	e1 := &v1beta1.EventListener{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-1",
+			Namespace: "test",
+		},
+	}
+	e2 := &v1beta1.EventListener{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-2",
+			Namespace: "test",
+		},
+	}
+	e3 := &v1beta1.EventListener{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-3",
+			Namespace: "test",
+		},
+	}
+
+	for _, el := range []*v1beta1.EventListener{e1, e2, e3} {
+		if err := fakeELIn.Informer().GetIndexer().Add(el); err != nil {
+			t.Fatalf("Adding EL to informer: %v", err)
+		}
+	}
+
+	tt1 := &v1beta1.TriggerTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-1",
+			Namespace: "test",
+		},
+	}
+
+	tt2 := &v1beta1.TriggerTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-2",
+			Namespace: "test",
+		},
+	}
+
+	tt3 := &v1beta1.TriggerTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-3",
+			Namespace: "test",
+		},
+	}
+
+	for _, tt := range []*v1beta1.TriggerTemplate{tt1, tt2, tt3} {
+		if err := fakeTTIn.Informer().GetIndexer().Add(tt); err != nil {
+			t.Fatalf("Adding TT to informer: %v", err)
+		}
+	}
+
+	tb1 := &v1beta1.TriggerBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-1",
+			Namespace: "test",
+		},
+	}
+
+	tb2 := &v1beta1.TriggerBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-2",
+			Namespace: "test",
+		},
+	}
+
+	tb3 := &v1beta1.TriggerBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-3",
+			Namespace: "test",
+		},
+	}
+
+	for _, tb := range []*v1beta1.TriggerBinding{tb1, tb2, tb3} {
+		if err := fakeTBIn.Informer().GetIndexer().Add(tb); err != nil {
+			t.Fatalf("Adding TB to informer: %v", err)
+		}
+	}
+
+	ctb1 := &v1beta1.ClusterTriggerBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-1",
+			Namespace: "test",
+		},
+	}
+
+	ctb2 := &v1beta1.ClusterTriggerBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-2",
+			Namespace: "test",
+		},
+	}
+
+	ctb3 := &v1beta1.ClusterTriggerBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-3",
+			Namespace: "test",
+		},
+	}
+
+	for _, ctb := range []*v1beta1.ClusterTriggerBinding{ctb1, ctb2, ctb3} {
+		if err := fakeCTBIn.Informer().GetIndexer().Add(ctb); err != nil {
+			t.Fatalf("Adding CTB to informer: %v", err)
+		}
+	}
+
+	ci1 := &v1alpha1.ClusterInterceptor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-1",
+			Namespace: "test",
+		},
+	}
+
+	ci2 := &v1alpha1.ClusterInterceptor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-2",
+			Namespace: "test",
+		},
+	}
+
+	ci3 := &v1alpha1.ClusterInterceptor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-3",
+			Namespace: "test",
+		},
+	}
+
+	for _, ci := range []*v1alpha1.ClusterInterceptor{ci1, ci2, ci3} {
+		if err := fakeCIIn.Informer().GetIndexer().Add(ci); err != nil {
+			t.Fatalf("Adding CI to informer: %v", err)
+		}
+	}
+
+	li := listers{
+		el:  fakeELIn.Lister(),
+		ctb: fakeCTBIn.Lister(),
+		tb:  fakeTBIn.Lister(),
+		tt:  fakeTTIn.Lister(),
+		ci:  fakeCIIn.Lister(),
+	}
+
+	rec.CountMetrics(ctx, li)
+	metricstest.CheckLastValueData(t, elMetricsName, map[string]string{}, 3)
+	metricstest.CheckLastValueData(t, ttMetricsName, map[string]string{}, 3)
+	metricstest.CheckLastValueData(t, tbMetricsName, map[string]string{}, 3)
+	metricstest.CheckLastValueData(t, ctbMetricsName, map[string]string{}, 3)
+	metricstest.CheckLastValueData(t, ciMetricsName, map[string]string{}, 3)
+}
+
+func TestELCount(t *testing.T) {
+	unregisterMetrics()
+	ctx, _ := test.SetupFakeContext(t)
+	ctx = WithClient(ctx)
+
+	rec := Get(ctx)
+	rec.countMetrics(ctx, float64(3), elCount)
+	metricstest.CheckLastValueData(t, elMetricsName, map[string]string{}, 3)
+}
+
+func TestTTCount(t *testing.T) {
+	unregisterMetrics()
+	ctx, _ := test.SetupFakeContext(t)
+	ctx = WithClient(ctx)
+
+	rec := Get(ctx)
+	rec.countMetrics(ctx, float64(3), ttCount)
+	metricstest.CheckLastValueData(t, ttMetricsName, map[string]string{}, 3)
+}
+
+func TestTBCount(t *testing.T) {
+	unregisterMetrics()
+	ctx, _ := test.SetupFakeContext(t)
+	ctx = WithClient(ctx)
+
+	rec := Get(ctx)
+	rec.countMetrics(ctx, float64(3), tbCount)
+	metricstest.CheckLastValueData(t, tbMetricsName, map[string]string{}, 3)
+}
+
+func TestCTBCount(t *testing.T) {
+	unregisterMetrics()
+	ctx, _ := test.SetupFakeContext(t)
+	ctx = WithClient(ctx)
+
+	rec := Get(ctx)
+	rec.countMetrics(ctx, float64(3), ctbCount)
+	metricstest.CheckLastValueData(t, ctbMetricsName, map[string]string{}, 3)
+}
+
+func TestCICount(t *testing.T) {
+	unregisterMetrics()
+	ctx, _ := test.SetupFakeContext(t)
+	ctx = WithClient(ctx)
+
+	rec := Get(ctx)
+	rec.countMetrics(ctx, float64(3), ciCount)
+	metricstest.CheckLastValueData(t, ciMetricsName, map[string]string{}, 3)
+}
+
+func unregisterMetrics() {
+	metricstest.Unregister(elMetricsName, tbMetricsName, ctbMetricsName, ttMetricsName, ciMetricsName)
+
+	// Allow the recorder singleton to be recreated.
+	once = sync.Once{}
+	r = nil
+	recorderErr = nil
+}

--- a/vendor/knative.dev/pkg/metrics/testing/config.go
+++ b/vendor/knative.dev/pkg/metrics/testing/config.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"os"
+
+	"knative.dev/pkg/metrics"
+)
+
+func init() {
+	os.Setenv(metrics.DomainEnv, "knative.dev/testing")
+	metrics.InitForTesting()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1147,6 +1147,7 @@ knative.dev/pkg/logging/testing
 knative.dev/pkg/metrics
 knative.dev/pkg/metrics/metricskey
 knative.dev/pkg/metrics/metricstest
+knative.dev/pkg/metrics/testing
 knative.dev/pkg/network
 knative.dev/pkg/network/handlers
 knative.dev/pkg/profiling


### PR DESCRIPTION
Adding metrics for counting EL, TT, CTB, ClusterInteceptor and TB.
Fixes #1294

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Add Metrics for ClusterInteceptor, eventlistener, triggertemplate, clustertriggerbinding and triggerbinding count.
```
