### PR TITLE
add tool for evaluating cel expresssions

### DIFF
--- a/cmd/cel-eval/README.md
+++ b/cmd/cel-eval/README.md
@@ -1,0 +1,34 @@
+# cel-eval
+
+`cel-eval` is a tool that you can use to evaluate CEL expressions locally. It works by allowing you to define an HTTP request and a CEL expression that is evaluated against the request.
+
+## How to use
+
+1. Build `cel-eval` by running `go build` in this directory.
+2. Define an HTTP request
+
+```
+$ cat > request <<EOF
+POST /foo HTTP/1.1
+Content-Length: 29
+Content-Type: application/json
+X-Header: tacocat
+
+{"test": {"nested": "value"}}
+EOF
+```
+
+3. Define the CEL expression
+
+```
+$ cat > expression <<EOF
+body.test.nested == "value"
+EOF
+```
+
+4. Run `cel-eval`
+
+```console
+$ ./cel-eval --expression ./expression --http-request ./request
+true
+```

--- a/cmd/cel-eval/cmd/root.go
+++ b/cmd/cel-eval/cmd/root.go
@@ -1,0 +1,174 @@
+package cmd
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/checker/decls"
+	celext "github.com/google/cel-go/ext"
+	"github.com/spf13/cobra"
+	triggerscel "github.com/tektoncd/triggers/pkg/interceptors/cel"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	corev1lister "k8s.io/client-go/listers/core/v1"
+)
+
+var (
+	rootCmd = &cobra.Command{
+		Use:   "cel-eval",
+		Short: "Tekton CEL interceptor evaluator",
+		Run:   rootRun,
+	}
+
+	expressionPath string
+	httpPath       string
+)
+
+func init() {
+	rootCmd.Flags().StringVarP(&expressionPath, "expression", "e", "", "Expression to evaluate")
+	rootCmd.Flags().StringVarP(&httpPath, "http-request", "r", "", "Path to HTTP request")
+	if err := rootCmd.MarkFlagRequired("expression"); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
+	if err := rootCmd.MarkFlagRequired("http-request"); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
+}
+
+func rootRun(cmd *cobra.Command, args []string) {
+	if err := evalCEL(os.Stdout, expressionPath, httpPath); err != nil {
+		log.Fatal(err)
+	}
+}
+
+type secretLister struct{}
+
+func (sl secretLister) List(selector labels.Selector) (ret []*v1.Secret, err error) {
+	return nil, nil
+}
+
+func (sl secretLister) Secrets(namespace string) corev1lister.SecretNamespaceLister {
+	return secretLister{}
+}
+
+func (sl secretLister) Get(name string) (*v1.Secret, error) {
+	return nil, nil
+}
+
+func evalCEL(w io.Writer, expressionPath, httpPath string) error {
+	// Read expression
+	expression, err := readExpression(expressionPath)
+	if err != nil {
+		return fmt.Errorf("error reading HTTP file: %w", err)
+	}
+
+	// Read HTTP request.
+	r, body, err := readHTTP(httpPath)
+	if err != nil {
+		return fmt.Errorf("error reading HTTP file: %w", err)
+	}
+
+	evalContext, err := makeEvalContext(body, r.Header, r.URL.String(), map[string]interface{}{})
+	if err != nil {
+		return fmt.Errorf("error making eval context: %w", err)
+	}
+
+	mapStrDyn := decls.NewMapType(decls.String, decls.Dyn)
+	env, err := cel.NewEnv(
+		triggerscel.Triggers("default", secretLister{}),
+		celext.Strings(),
+		celext.Encoders(),
+		cel.Declarations(
+			decls.NewVar("body", mapStrDyn),
+			decls.NewVar("header", mapStrDyn),
+			decls.NewVar("extensions", mapStrDyn),
+			decls.NewVar("requestURL", decls.String),
+		))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	parsed, issues := env.Parse(expression)
+	if issues != nil && issues.Err() != nil {
+		return fmt.Errorf("failed to parse expression %#v: %w", expression, issues.Err())
+	}
+
+	checked, issues := env.Check(parsed)
+	if issues != nil && issues.Err() != nil {
+		return fmt.Errorf("expression %#v check failed: %w", expression, issues.Err())
+	}
+
+	prg, err := env.Program(checked)
+	if err != nil {
+		return fmt.Errorf("expression %#v failed to create a Program: %w", expression, err)
+	}
+
+	out, _, err := prg.Eval(evalContext)
+	if err != nil {
+		return fmt.Errorf("expression %#v failed to evaluate: %w", expression, err)
+	}
+
+	fmt.Fprint(w, out)
+
+	return nil
+}
+
+func readExpression(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("error opening file: %w", err)
+	}
+	defer f.Close()
+
+	data, err := ioutil.ReadAll(f)
+	if err != nil {
+		return "", fmt.Errorf("error reading from file: %w", err)
+	}
+
+	return string(data), nil
+}
+
+func readHTTP(path string) (*http.Request, []byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error opening file: %w", err)
+	}
+	defer f.Close()
+
+	req, err := http.ReadRequest(bufio.NewReader(f))
+	if err != nil {
+		return nil, nil, fmt.Errorf("error reading request: %w", err)
+	}
+	defer req.Body.Close()
+	body, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error reading HTTP body: %w", err)
+	}
+	return req, body, nil
+}
+
+func makeEvalContext(body []byte, h http.Header, url string, extensions map[string]interface{}) (map[string]interface{}, error) {
+	var jsonMap map[string]interface{}
+	err := json.Unmarshal(body, &jsonMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse the body as JSON: %w", err)
+	}
+	return map[string]interface{}{
+		"body":       jsonMap,
+		"header":     h,
+		"requestURL": url,
+		"extensions": extensions,
+	}, nil
+}
+
+// Execute runs the command.
+func Execute() error {
+	return rootCmd.Execute()
+}

--- a/cmd/cel-eval/cmd/root_test.go
+++ b/cmd/cel-eval/cmd/root_test.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestEvalCEL(t *testing.T) {
+	out := new(bytes.Buffer)
+	if err := evalCEL(out, "../testdata/expression.txt", "../testdata/http.txt"); err != nil {
+		t.Fatalf("evalCEL: %v", err)
+	}
+
+	want := "true"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Errorf("-want +got: %s", diff)
+	}
+}

--- a/cmd/cel-eval/main.go
+++ b/cmd/cel-eval/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/tektoncd/triggers/cmd/cel-eval/cmd"
+)
+
+func main() {
+	if err := cmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/cmd/cel-eval/testdata/expression.txt
+++ b/cmd/cel-eval/testdata/expression.txt
@@ -1,0 +1,1 @@
+body.test.nested == "value"

--- a/cmd/cel-eval/testdata/http.txt
+++ b/cmd/cel-eval/testdata/http.txt
@@ -1,0 +1,6 @@
+POST /foo HTTP/1.1
+Content-Length: 29
+Content-Type: application/json
+X-Header: tacocat
+
+{"test": {"nested": "value"}}

--- a/docs/cel_expressions.md
+++ b/docs/cel_expressions.md
@@ -428,3 +428,31 @@ which can be accessed by indexing.
     </td>
   </tr>
 </table>
+
+## Troubleshooting CEL expressions
+
+You can use the `cel-eval` tool to evaluate your CEL expressions against a specific HTTP request.
+
+To install the `cel-eval` tool use the following command:
+
+```sh
+$ go get -u github.com/tektoncd/triggers/cmd/cel-eval
+```
+
+Below is an example of using the tool to evaluate a CEL expression:
+
+```sh
+$ cat testdata/expression.txt
+body.test.nested == "value"
+
+$ cat testdata/http.txt
+POST /foo HTTP/1.1
+Content-Length: 29
+Content-Type: application/json
+X-Header: tacocat
+
+{"test": {"nested": "value"}}
+
+$ cel-eval -e testdata/expression.txt -r testdata/http.txt
+true
+```


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Adding a tool that can be used to evaluate cel expressions locally. Useful if you have a complex cel expression that you need to debug. Referencing secrets is not supported, I am not sure how I would go about implementing that.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
Add `cel-eval` tool for evaluating cel expressions from HTTP requests.
```
