### PR TITLE
Fix CEL example: Wrong Param Name

### DIFF
--- a/examples/v1alpha1/eventlisteners/cel-eventlistener-interceptor.yaml
+++ b/examples/v1alpha1/eventlisteners/cel-eventlistener-interceptor.yaml
@@ -40,7 +40,7 @@ spec:
                   - image: ubuntu
                     script: |
                       #!/usr/bin/env bash
-                      echo "$(params.sha)"
+                      echo "$(params.git_sha)"
     - name: cel-trig-with-canonical
       interceptors:
         - cel:

--- a/examples/v1beta1/eventlisteners/cel-eventlistener-interceptor.yaml
+++ b/examples/v1beta1/eventlisteners/cel-eventlistener-interceptor.yaml
@@ -40,7 +40,7 @@ spec:
                   - image: ubuntu
                     script: |
                       #!/usr/bin/env bash
-                      echo "$(params.sha)"
+                      echo "$(params.git_sha)"
     - name: cel-trig-with-canonical
       interceptors:
         - ref:


### PR DESCRIPTION
Fix the param name in cel-eventlistener-interceptor.yaml example.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
