### PR TITLE
Build tekton triggers with golang 1.17

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -96,7 +96,7 @@ configuring Kubernetes resources.
 Docker for Desktop using an edge version has been proven to work for both
 developing and running Pipelines. The recommended configuration is:
 
-- Kubernetes version 1.16 or later
+- Kubernetes version 1.21 or later
 - 4 vCPU nodes (`n1-standard-4`)
 - Node autoscaling, up to 3 nodes
 - API scopes for cloud-platform
@@ -108,7 +108,7 @@ To setup a cluster with GKE:
    variable (e.g. `PROJECT_ID`).
 
 1. Create a GKE cluster (with `--cluster-version=latest` but you can use any
-   version 1.16 or later):
+   version 1.21 or later):
 
    ```bash
    export PROJECT_ID=my-gcp-project

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -83,7 +83,7 @@ spec:
       cp ${DOCKER_CONFIG} /workspace/docker-config.json
 
   - name: run-ko
-    image: gcr.io/tekton-releases/dogfooding/ko:latest
+    image: gcr.io/tekton-releases/dogfooding/ko@sha256:ec55b9dd6c7af2b237cc7c38a974cc42212d53a026ee2a84f685f02c471c6c9e
     env:
     - name: KO_DOCKER_REPO
       value: $(params.imageRegistry)/$(params.imageRegistryPath)


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Update the tekton triggers build pipeline to build using golang 1.17.7

Controller images are built using ko.
Updating the ko image in the publish task to one that includes
golang 1.17.7 (golang:1.17.7-alpine3.15). Reference the ko image by sha
instead of tag. This will require an extra step to update the image in
future (plumbing first, triggers then) but it's best for attestations
and also it allows updating the image on plumbing side and in the
registry without direct side effect on triggers.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Triggers is now built using golang 1.17.7
```

/kind misc