### PR TITLE
Fix nil pointer exception for nil interceptor

### DIFF
--- a/pkg/apis/triggers/v1alpha1/event_listener_defaults.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_defaults.go
@@ -42,12 +42,14 @@ func (el *EventListener) SetDefaults(ctx context.Context) {
 		for i, t := range el.Spec.Triggers {
 			triggerSpecBindingArray(el.Spec.Triggers[i].Bindings).defaultBindings()
 			for _, ti := range t.Interceptors {
-				ti.defaultInterceptorKind()
-				if err := ti.updateCoreInterceptors(); err != nil {
-					// The err only happens due to malformed JSON and should never really happen
-					// We can't return an error here, so print out the error
-					logger := logging.FromContext(ctx)
-					logger.Errorf("failed to setDefaults for trigger: %s; err: %s", t.Name, err)
+				if ti != nil {
+					ti.defaultInterceptorKind()
+					if err := ti.updateCoreInterceptors(); err != nil {
+						// The err only happens due to malformed JSON and should never really happen
+						// We can't return an error here, so print out the error
+						logger := logging.FromContext(ctx)
+						logger.Errorf("failed to setDefaults for trigger: %s; err: %s", t.Name, err)
+					}
 				}
 			}
 		}

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation.go
@@ -286,6 +286,10 @@ func (t *EventListenerTrigger) validate(ctx context.Context) (errs *apis.FieldEr
 
 	// Validate optional Interceptors
 	for i, interceptor := range t.Interceptors {
+		// No continuation if provided interceptor is nil.
+		if interceptor == nil {
+			return errs.Also(apis.ErrInvalidValue(fmt.Sprintf("interceptor '%v' must be a valid value", interceptor), fmt.Sprintf("interceptors[%d]", i)))
+		}
 		errs = errs.Also(interceptor.validate(ctx).ViaField(fmt.Sprintf("interceptors[%d]", i)))
 	}
 

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
@@ -1209,6 +1209,28 @@ func TestEventListenerValidate_error(t *testing.T) {
 				Namespace: "namespace",
 			},
 		},
+	}, {
+		name: "invalid interceptor for eventlistener",
+		el: &v1alpha1.EventListener{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+			Spec: v1alpha1.EventListenerSpec{
+				Triggers: []v1alpha1.EventListenerTrigger{{
+					Name: "test",
+					Interceptors: []*v1alpha1.EventInterceptor{{
+						Ref: v1alpha1.InterceptorRef{
+							Name:       "cel",
+							Kind:       v1alpha1.ClusterInterceptorKind,
+							APIVersion: "triggers.tekton.dev/v1alpha1",
+						},
+					},
+						nil,
+					},
+				}},
+			},
+		},
 	}}
 
 	for _, tc := range tests {

--- a/pkg/apis/triggers/v1beta1/event_listener_defaults.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_defaults.go
@@ -42,7 +42,9 @@ func (el *EventListener) SetDefaults(ctx context.Context) {
 		for i, t := range el.Spec.Triggers {
 			triggerSpecBindingArray(el.Spec.Triggers[i].Bindings).defaultBindings()
 			for _, ti := range t.Interceptors {
-				ti.defaultInterceptorKind()
+				if ti != nil {
+					ti.defaultInterceptorKind()
+				}
 			}
 		}
 	}

--- a/pkg/apis/triggers/v1beta1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_validation.go
@@ -316,6 +316,10 @@ func (t *EventListenerTrigger) validate(ctx context.Context) (errs *apis.FieldEr
 
 	// Validate optional Interceptors
 	for i, interceptor := range t.Interceptors {
+		// No continuation if provided interceptor is nil.
+		if interceptor == nil {
+			return errs.Also(apis.ErrInvalidValue(fmt.Sprintf("interceptor '%v' must be a valid value", interceptor), fmt.Sprintf("interceptors[%d]", i)))
+		}
 		errs = errs.Also(interceptor.validate(ctx).ViaField(fmt.Sprintf("interceptors[%d]", i)))
 	}
 

--- a/pkg/apis/triggers/v1beta1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_validation_test.go
@@ -1317,6 +1317,33 @@ func TestEventListenerValidate_error(t *testing.T) {
 				},
 			},
 			wantErr: apis.ErrMissingOneOf("spec.labelSelector", "spec.namespaceSelector", "spec.triggerGroups", "spec.triggers"),
+		}, {
+			name: "invalid interceptor for eventlistener",
+			el: &triggersv1beta1.EventListener{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "namespace",
+				},
+				Spec: triggersv1beta1.EventListenerSpec{
+					Triggers: []triggersv1beta1.EventListenerTrigger{{
+						Template: &triggersv1beta1.EventListenerTemplate{
+							Ref: ptr.String("tt"),
+						},
+						Name: "test",
+						Interceptors: []*triggersv1beta1.EventInterceptor{{
+							Ref: triggersv1beta1.InterceptorRef{
+								Name: "cel",
+							},
+						},
+							nil,
+						},
+					}},
+				},
+			},
+			wantErr: &apis.FieldError{
+				Message: "invalid value: interceptor '<nil>' must be a valid value",
+				Paths:   []string{"spec.triggers[0].interceptors[1]"},
+			},
 		}}
 
 	for _, tc := range tests {


### PR DESCRIPTION
# Changes
**Issue:** While creating EL if user provide `null` in Interceptors webhook pod will crash
**Root Cause:**  Failure is because of accessing nil object 
```
github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1.(*TriggerInterceptor).defaultInterceptorKind(...)
	github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1/trigger_types.go:139
github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1.(*EventListener).SetDefaults(0xc0004cd500, 0x22586f8, 0xc000b15920)
	github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1/event_listener_defaults.go:45 +0x144
```
https://github.com/tektoncd/triggers/blob/main/pkg/apis/triggers/v1alpha1/trigger_types.go#L139

**Fix:** Added validation to check interceptor is nil or not if nill webhook validation through error 

**More Info:** https://tektoncd.slack.com/archives/CKUSJ2A5D/p1647257237334749

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```