### PR TITLE
Fix the documentation for wildcard in NamespaceSelector EL

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -410,12 +410,12 @@ Below is an example `namespaceSelector` field that configures the `EventListener
     - bar
 ```
 
-If you want your `EventListener` to recognize `Triggers` across your entire cluster, use a wildcard as the only namespace:
+If you want your `EventListener` to recognize `Triggers` across your entire cluster, use a wildcard  between quote as the only namespace:
 
 ```yaml
   namespaceSelector:
     matchNames:
-    - *
+    - "*"
 ```
 
 ## Constraining `EventListeners` to specific labels


### PR DESCRIPTION
Wildcard/* should be quoted in yaml because * is used as anchor and
aliases in yaml. So fix the documentation to put wildcard as "*".

Fixes #1342 1341

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
