### PR TITLE
Moved the TriggerGroups to stable

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -185,9 +185,6 @@ spec:
 [TEP-0053](https://github.com/tektoncd/community/blob/main/teps/0053-nested-triggers.md). `TriggerGroups` allow for
 a common set of interceptors to be defined inline in the `EventListenerSpec` before `Triggers` are invoked.
 
-`TriggerGroups` is currently an `alpha` feature. To use it, you use the v1beta1 API version with the
-`enable-api-fields`  [feature flag set to `alpha`](./install.md#Customizing-the-Triggers-Controller-behavior).
-
 You can optionally specify one or more `Triggers` that define the actions to take when the `EventListener` detects a qualifying event. You can specify *either* a reference to an
 external `Trigger` object *or* reference/define the `TriggerBindings`, `TriggerTemplates`, and `Interceptors` in the `Trigger` definition. A `TriggerGroup` definition specifies the following fields:
 

--- a/pkg/apis/triggers/v1beta1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_validation.go
@@ -80,13 +80,8 @@ func (s *EventListenerSpec) validate(ctx context.Context) (errs *apis.FieldError
 	}
 
 	if len(s.TriggerGroups) > 0 {
-		err := ValidateEnabledAPIFields(ctx, "spec.triggerGroups", config.AlphaAPIFieldValue)
-		if err != nil {
-			errs = errs.Also(err)
-		} else {
-			for i, group := range s.TriggerGroups {
-				errs = errs.Also(group.validate(ctx).ViaField(fmt.Sprintf("spec.triggerGroups[%d]", i)))
-			}
+		for i, group := range s.TriggerGroups {
+			errs = errs.Also(group.validate(ctx).ViaField(fmt.Sprintf("spec.triggerGroups[%d]", i)))
 		}
 	}
 

--- a/pkg/apis/triggers/v1beta1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_validation_test.go
@@ -1216,35 +1216,6 @@ func TestEventListenerValidate_error(t *testing.T) {
 		},
 		wantErr: apis.ErrMultipleOneOf("spec.triggers[0].template or bindings or interceptors", "spec.triggers[0].triggerRef"),
 	}, {
-		name: "triggerGroups is not allowed if alpha fields are not enabled",
-		ctx:  context.Background(), // By default, enable-api-felds is set to stable, not alpha
-		el: &triggersv1beta1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
-			Spec: triggersv1beta1.EventListenerSpec{
-				TriggerGroups: []triggersv1beta1.EventListenerTriggerGroup{{
-					Name: "my-group",
-					TriggerSelector: triggersv1beta1.EventListenerTriggerSelector{
-						NamespaceSelector: triggersv1beta1.NamespaceSelector{
-							MatchNames: []string{"default"},
-						},
-					},
-					Interceptors: []*triggersv1beta1.TriggerInterceptor{{
-						Ref: triggersv1beta1.InterceptorRef{
-							Name: "cel",
-						},
-						Params: []triggersv1beta1.InterceptorParams{{
-							Name:  "filter",
-							Value: test.ToV1JSON(t, "has(body.repository)"),
-						}},
-					}},
-				}},
-			},
-		},
-		wantErr: apis.ErrGeneric("spec.triggerGroups requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
-	}, {
 		name: "cloudEventURI is not allowed if alpha fields are not enabled",
 		ctx:  context.Background(), // By default, enable-api-felds is set to stable, not alpha
 		el: &triggersv1beta1.EventListener{


### PR DESCRIPTION
TriggersGroups has been moved to stable API from alpha api. It will be available by default and no changes in config will be required.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes


```release-note
TriggerGroups will be available by default. No changes in config will be required for running it.
```
