### PR TITLE
Add Example for GKE Autopilot

### DIFF
--- a/examples/v1beta1/eventlisteners/eventlistener-gke-autopilot.yaml
+++ b/examples/v1beta1/eventlisteners/eventlistener-gke-autopilot.yaml
@@ -1,0 +1,68 @@
+# This example shows how to deploy EventListener to GKE Autopilot.
+# It's necessary to specify resource request for EL in GKE Autopilot.
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: listener-podtemplate
+spec:
+  serviceAccountName: tekton-triggers-example-sa
+  resources:
+    kubernetesResource:
+      spec:
+        template:
+          spec:
+            containers:
+            - resources:
+                requests:
+                  memory: "128Mi"
+                  cpu: "250m"
+                limits:
+                  memory: "256Mi"
+                  cpu: "500m"
+  triggers:
+    - name: foo-trig
+      bindings:
+        - name: message
+          value: Hello from the Triggers EventListener!
+        - name: gitrevision
+          value: $(body.head_commit.id)
+        - name: gitrepositoryurl
+          value: $(body.repository.url)
+        - name: contenttype
+          value: $(header.Content-Type)
+      template:
+        spec:
+          params:
+          - name: gitrevision
+            description: The git revision
+            default: main
+          - name: gitrepositoryurl
+            description: The git repository url
+          - name: message
+            description: The message to print
+            default: This is the default message
+          - name: contenttype
+            description: The Content-Type of the event
+          resourcetemplates:
+          - apiVersion: tekton.dev/v1beta1
+            kind: PipelineRun
+            metadata:
+              generateName: simple-pipeline-run-
+            spec:
+              pipelineRef:
+                name: simple-pipeline
+              params:
+              - name: message
+                value: $(tt.params.message)
+              - name: contenttype
+                value: $(tt.params.contenttype)
+              resources:
+              - name: git-source
+                resourceSpec:
+                  type: git
+                  params:
+                    - name: revision
+                      value: $(tt.params.gitrevision)
+                    - name: url
+                      value: $(tt.params.gitrepositoryurl)


### PR DESCRIPTION
Autopilot requires resource requests in EL deployments. Otherwise,
there's a contention between the controller and GKE autopilot for changing
deployment.

Fixes #1318

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes
```release-note
Add an example for deploying EventListener in GKE autopilot.
```
