### PR TITLE
Add v1beta1 specific example in e2e-tests

### DIFF
--- a/examples/v1beta1/triggergroups/eventlistener-triggergroup.yaml
+++ b/examples/v1beta1/triggergroups/eventlistener-triggergroup.yaml
@@ -1,7 +1,7 @@
 apiVersion: triggers.tekton.dev/v1beta1
 kind: EventListener
 metadata:
-  name: listener-triggergroup
+  name: triggergroups-listener
 spec:
   serviceAccountName: tekton-triggers-example-sa
   triggerGroups:

--- a/test/e2e-tests-examples.sh
+++ b/test/e2e-tests-examples.sh
@@ -82,7 +82,7 @@ check_eventlistener() {
   kubectl get eventlisteners
 }
 
-ignoreExamples=( cron trigger-ref v1alpha1-task )
+ignoreExamples=( cron trigger-ref v1alpha1-task triggergroups )
 
 port_forward_and_curl() {
 
@@ -174,12 +174,14 @@ main() {
 
   versions="v1alpha1 v1beta1"
   # List of examples test will run on
-  examples="bitbucket cron embedded-trigger github gitlab label-selector namespace-selector v1alpha1-task trigger-ref"
+  examples_v1alpha1="bitbucket cron embedded-trigger github gitlab label-selector namespace-selector v1alpha1-task trigger-ref"
+  examples_v1beta1="${examples_v1alpha1} triggergroups"
   create_example_pipeline
   for v in ${versions}; do
     current_example_version=${v}
+    examples=examples_$v
     echo "Applying examples for version: ${v}"
-    for e in ${examples}; do
+    for e in ${!examples}; do
       current_example=${e}
       echo "*** Example ${current_example_version}/${current_example} ***";
       apply_files


### PR DESCRIPTION
In addition to common examples in v1alpha1 and v1beta1, changed
the script to add v1beta1 specific examples.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
