### PR TITLE
Add Multiarch Image in Getting Started

### DIFF
--- a/docs/getting-started/create-webhook.yaml
+++ b/docs/getting-started/create-webhook.yaml
@@ -31,7 +31,7 @@ spec:
     default: '[\"push\",\"pull_request\"]'
   steps:
   - name: create-webhook
-    image: pstauffer/curl:latest
+    image: curlimages/curl:latest
     volumeMounts:
     - name: github-secret
       mountPath: /var/secret


### PR DESCRIPTION
Curl in 'create-webhook.yaml' of getting started is quite old and only amd64. Changed it 
to official image 'curlimages/curl:latest' for multiarch support. This enables us to run getting started in Apple's M1 chip. 

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes


```release-note
NONE
```
