### PR TITLE
Add watching mechanism to eventlistener to wait for clusterInterceptor caBundle

### DIFF
--- a/pkg/adapter/adapter_test.go
+++ b/pkg/adapter/adapter_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adapter
+
+import (
+	"log"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1alpha1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	faketriggersclient "github.com/tektoncd/triggers/pkg/client/injection/client/fake"
+	fakeClusterInterceptorinformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1alpha1/clusterinterceptor/fake"
+	"github.com/tektoncd/triggers/pkg/sink"
+	pkgtesting "github.com/tektoncd/triggers/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/logging"
+)
+
+func TestGetHTTPClientEmptyCaBundle(t *testing.T) {
+	recorder, err := sink.NewRecorder()
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	ctx, _ := pkgtesting.SetupFakeContext(t)
+	s := sinker{
+		Logger:    logging.FromContext(ctx),
+		Namespace: "",
+		Args:      sink.Args{},
+		Clients:   sink.Clients{},
+		Recorder:  recorder,
+		injCtx:    ctx,
+	}
+
+	c, err := s.getHTTPClient()
+	if err != nil && !strings.Contains(err.Error(), "empty caBundle in clusterInterceptor spec") {
+		t.Fatal(err)
+	}
+	if err == nil {
+		t.Fatalf("test should fail as clusterinterceptor spec cabundle is empty")
+	}
+	if diff := cmp.Diff(c, &http.Client{}); diff != "" {
+		t.Errorf("Diff: -want +got: %s", cmp.Diff(c, &http.Client{}))
+	}
+}
+
+func TestGetHTTPClient(t *testing.T) {
+	recorder, err := sink.NewRecorder()
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	ctx, _ := pkgtesting.SetupFakeContext(t)
+	s := sinker{
+		Logger:    logging.FromContext(ctx),
+		Namespace: "",
+		Args:      sink.Args{},
+		Clients:   sink.Clients{},
+		Recorder:  recorder,
+		injCtx:    ctx,
+	}
+
+	icInformer := fakeClusterInterceptorinformer.Get(ctx)
+	triggerClient := faketriggersclient.Get(ctx)
+
+	ci := &v1alpha1.ClusterInterceptor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "github",
+		},
+		Spec: v1alpha1.ClusterInterceptorSpec{ClientConfig: v1alpha1.ClientConfig{
+			CaBundle: []byte("LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM5ekNDQXAyZ0F3SUJBZ0lSQUtQL1liSlF4Q2M5Y3JhVlBPMkhrK0V3Q2dZSUtvWkl6ajBFQXdJd1Z6RVUKTUJJR0ExVUVDaE1MYTI1aGRHbDJaUzVrWlhZeFB6QTlCZ05WQkFNVE5uUmxhM1J2YmkxMGNtbG5aMlZ5Y3kxagpiM0psTFdsdWRHVnlZMlZ3ZEc5eWN5NTBaV3QwYjI0dGNHbHdaV3hwYm1WekxuTjJZekFnRncweU1qQTJNakl4Ck5qRXhNVFZhR0E4eU1USXlNRFV5T1RFMk1URXhOVm93VnpFVU1CSUdBMVVFQ2hNTGEyNWhkR2wyWlM1a1pYWXgKUHpBOUJnTlZCQU1UTm5SbGEzUnZiaTEwY21sbloyVnljeTFqYjNKbExXbHVkR1Z5WTJWd2RHOXljeTUwWld0MApiMjR0Y0dsd1pXeHBibVZ6TG5OMll6QlpNQk1HQnlxR1NNNDlBZ0VHQ0NxR1NNNDlBd0VIQTBJQUJEdVVwTStEClVuZUozY1FieDc0cEpHTGgyTWkxREc1ZU5hNmRtSG5MeHhhQnZXTUxOOXp3Y2dLd2J2NHVJV0hsK2Rqb2laVWgKNFFRaElGUE8vS0NtUnJhamdnRkdNSUlCUWpBT0JnTlZIUThCQWY4RUJBTUNBb1F3SFFZRFZSMGxCQll3RkFZSQpLd1lCQlFVSEF3RUdDQ3NHQVFVRkJ3TUNNQThHQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGSlcrCjdROVJiZlo3UDFBY0lXdEI2ckNTOWtneE1JSGdCZ05WSFJFRWdkZ3dnZFdDSVhSbGEzUnZiaTEwY21sbloyVnkKY3kxamIzSmxMV2x1ZEdWeVkyVndkRzl5YzRJeWRHVnJkRzl1TFhSeWFXZG5aWEp6TFdOdmNtVXRhVzUwWlhKagpaWEIwYjNKekxuUmxhM1J2Ymkxd2FYQmxiR2x1WlhPQ05uUmxhM1J2YmkxMGNtbG5aMlZ5Y3kxamIzSmxMV2x1CmRHVnlZMlZ3ZEc5eWN5NTBaV3QwYjI0dGNHbHdaV3hwYm1WekxuTjJZNEpFZEdWcmRHOXVMWFJ5YVdkblpYSnoKTFdOdmNtVXRhVzUwWlhKalpYQjBiM0p6TG5SbGEzUnZiaTF3YVhCbGJHbHVaWE11YzNaakxtTnNkWE4wWlhJdQpiRzlqWVd3d0NnWUlLb1pJemowRUF3SURTQUF3UlFJaEFOOE5SMTBJS0h4YUtXa0o0cFV1d3ljNFpmZG4rNTd6CnplN3RnS050b3hWREFpQWRhQlYvMlRDeStnV2tjUFR4cHo3aE91MHZ6bGZmeDhzV0Z3Wk5XdlVYUEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="),
+		}},
+	}
+	if err := icInformer.Informer().GetIndexer().Add(ci); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := triggerClient.TriggersV1alpha1().ClusterInterceptors().Create(ctx, ci, metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := s.getHTTPClient()
+	if err != nil && !strings.Contains(err.Error(), "unable to parse cert from") {
+		t.Fatal(err)
+	}
+	if err == nil {
+		t.Fatalf("test should fail as its failed to parse cert")
+	}
+	if diff := cmp.Diff(c, &http.Client{}); diff != "" {
+		t.Errorf("Diff: -want +got: %s", cmp.Diff(c, http.Client{}))
+	}
+}


### PR DESCRIPTION
* Added watching mechanism to watch for clusterInterceptor `caBundle` and returns error untill all clusterInterceptor filled with `caBundle` information

Fixes : https://github.com/tektoncd/triggers/issues/1368

**Verification:**
If `caBundle` is empty for interceptor then eventlistener pod keeps on restarting with below error 
```
{"level":"fatal","ts":"2022-06-20T07:54:24.222Z","logger":"eventlistener","caller":"v2/main.go:205","msg":"Start returned an error","error":"Timed out waiting on CaBundle to available for clusterInterceptor: empty caBundle in clusterInterceptor spec","stacktrace":"knative.dev/eventing/pkg/adapter/v2.MainWithInformers\n\tknative.dev/eventing@v0.30.1-0.20220407170245-58865afba92c/pkg/adapter/v2/main.go:205\nknative.dev/eventing/pkg/adapter/v2.MainWithEnv\n\tknative.dev/eventing@v0.30.1-0.20220407170245-58865afba92c/pkg/adapter/v2/main.go:105\nknative.dev/eventing/pkg/adapter/v2.MainWithContext\n\tknative.dev/eventing@v0.30.1-0.20220407170245-58865afba92c/pkg/adapter/v2/main.go:80\nmain.main\n\tgithub.com/tektoncd/triggers/cmd/eventlistenersink/main.go:69\nruntime.main\n\truntime/proc.go:255"}

```


# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```