### PR TITLE
match svc port

### DIFF
--- a/config/interceptors/core-interceptors.yaml
+++ b/config/interceptors/core-interceptors.yaml
@@ -22,6 +22,7 @@ spec:
       name: tekton-triggers-core-interceptors
       namespace: tekton-pipelines
       path: "cel"
+      port: 8443
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: ClusterInterceptor
@@ -33,6 +34,7 @@ spec:
       name: tekton-triggers-core-interceptors
       namespace: tekton-pipelines
       path: "bitbucket"
+      port: 8443
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: ClusterInterceptor
@@ -44,6 +46,7 @@ spec:
       name: tekton-triggers-core-interceptors
       namespace: tekton-pipelines
       path: "github"
+      port: 8443
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: ClusterInterceptor
@@ -55,3 +58,4 @@ spec:
       name: tekton-triggers-core-interceptors
       namespace: tekton-pipelines
       path: "gitlab"
+      port: 8443


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

The EventListener tries to make requests to the core interceptors at port 80 by default, but [the service exposes port 8443](https://github.com/tektoncd/triggers/blob/8ddb09dedc5766f53554510cd3b98b403f6ecdd7/config/interceptors/core-interceptors-deployment.yaml#L109). As a result, deploying using the instructions in the release notes results in EventListeners getting logs like this:

```
{"level":"error","ts":"2022-06-22T08:48:11.213Z","logger":"eventlistener","caller":"sink/sink.go:381","msg":"Post \"http://tekton-triggers-core-interceptors.tekton-pipelines.svc:80/github\": dial tcp 10.20.30.40:80: i/o timeout","eventlistener":"-","namespace":"-","/triggers-eventid":"b5eb0bce-7651-43f4-b978-4a686f6fe6d1","eventlistenerUID":"7c4a390c-ee58-42bb-825f-5ce8c16147e6","/triggers-eventid":"b5eb0bce-7651-43f4-b978-4a686f6fe6d1","/trigger":"-","stacktrace":"github.com/tektoncd/triggers/pkg/sink.Sink.processTrigger\n\tgithub.com/tektoncd/triggers/pkg/sink/sink.go:381\ngithub.com/tektoncd/triggers/pkg/sink.Sink.HandleEvent.func1\n\tgithub.com/tektoncd/triggers/pkg/sink/sink.go:196"}
```

This is my first PR so I apologize if I'm not following the correct procedure.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Fixed ClusterInterceptor port to be consistent with Core Interceptor Service port.

action required: If you've patched the Service tekton-triggers-core-interceptors to serve on a port other than 8443, you will need to now patch the ClusterInterceptor to point to that port as the manifests now point to port 8443 by default.
```
