### PR TITLE
Fix http based custom interceptor connection issue

### DIFF
--- a/cmd/interceptors/main.go
+++ b/cmd/interceptors/main.go
@@ -17,31 +17,24 @@ limitations under the License.
 package main
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
-	"os"
 	"time"
 
 	triggersclientset "github.com/tektoncd/triggers/pkg/client/clientset/versioned"
+	clusterinterceptorsinformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1alpha1/clusterinterceptor"
 	"github.com/tektoncd/triggers/pkg/interceptors"
 	"github.com/tektoncd/triggers/pkg/interceptors/server"
 	"go.uber.org/zap"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	kubeclientset "k8s.io/client-go/kubernetes"
-	v1 "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/rest"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
-	secretInformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
 	"knative.dev/pkg/injection"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/signals"
-	certresources "knative.dev/pkg/webhook/certificates/resources"
 )
 
 const (
@@ -50,10 +43,6 @@ const (
 	readTimeout  = 5 * time.Second
 	writeTimeout = 20 * time.Second
 	idleTimeout  = 60 * time.Second
-	decade       = 100 * 365 * 24 * time.Hour
-
-	keyFile  = "/tmp/server-key.pem"
-	certFile = "/tmp/server-cert.pem"
 )
 
 func main() {
@@ -82,7 +71,6 @@ func main() {
 		return
 	}
 
-	secretLister := secretInformer.Get(ctx).Lister()
 	service, err := server.NewWithCoreInterceptors(interceptors.NewKubeClientSecretGetter(kubeclient.Get(ctx).CoreV1(), 1024, 5*time.Second), logger)
 	if err != nil {
 		logger.Errorf("failed to initialize core interceptors: %s", err)
@@ -94,12 +82,22 @@ func main() {
 	mux.Handle("/", service)
 	mux.HandleFunc("/ready", handler)
 
-	keyFile, certFile, caCert, err := getCerts(ctx, secretLister, kubeClient, logger)
+	keyFile, certFile, caCert, err := server.CreateCerts(ctx, kubeClient.CoreV1(), logger)
 	if err != nil {
 		return
 	}
 
-	if err := updateCRDWithCaCert(ctx, cfg, caCert); err != nil {
+	tc, err := triggersclientset.NewForConfig(cfg)
+	if err != nil {
+		return
+	}
+
+	clusterInterceptorList, err := clusterinterceptorsinformer.Get(ctx).Lister().List(labels.NewSelector())
+	if err != nil {
+		return
+	}
+
+	if err := service.UpdateCRDWithCaCert(ctx, tc.TriggersV1alpha1(), clusterInterceptorList, caCert); err != nil {
 		return
 	}
 
@@ -120,100 +118,6 @@ func main() {
 
 }
 
-// updateCRDWithCaCert updates clusterinterceptor crd caBundle with caCert
-func updateCRDWithCaCert(ctx context.Context, cfg *rest.Config, caCert []byte) error {
-	tc, err := triggersclientset.NewForConfig(cfg)
-	if err != nil {
-		return err
-	}
-	clusterInterceptorList, err := tc.TriggersV1alpha1().ClusterInterceptors().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	for i := range clusterInterceptorList.Items {
-		if bytes.Equal(clusterInterceptorList.Items[i].Spec.ClientConfig.CaBundle, []byte{}) {
-			clusterInterceptorList.Items[i].Spec.ClientConfig.CaBundle = caCert
-			if _, err := tc.TriggersV1alpha1().ClusterInterceptors().Update(ctx, &clusterInterceptorList.Items[i], metav1.UpdateOptions{}); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
 func handler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
-}
-
-// getCerts uses Knative pkg to generate certs for clusterinterceptor to run as https
-func getCerts(ctx context.Context, secretLister v1.SecretLister, kubeClient *kubeclientset.Clientset, logger *zap.SugaredLogger) (string, string, []byte, error) {
-	interceptorSvcName := os.Getenv("INTERCEPTOR_TLS_SVC_NAME")
-	interceptorSecretName := os.Getenv("INTERCEPTOR_TLS_SECRET_NAME")
-	namespace := os.Getenv("SYSTEM_NAMESPACE")
-
-	secret, err := secretLister.Secrets(namespace).Get(interceptorSecretName)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			// The secret should be created explicitly by a higher-level system
-			// that's responsible for install/updates.  We simply populate the
-			// secret information.
-			logger.Infof("secret %s is missing", interceptorSecretName)
-			return "", "", []byte{}, err
-		}
-		logger.Infof("error accessing certificate secret %q: %v", interceptorSecretName, err)
-		return "", "", []byte{}, err
-	}
-
-	var (
-		serverKey, serverCert, caCert []byte
-		createCerts                   bool
-	)
-	serverKey, haskey := secret.Data[certresources.ServerKey]
-	if !haskey {
-		logger.Infof("secret %q is missing key %q", secret.Name, certresources.ServerKey)
-		createCerts = true
-	}
-	serverCert, haskey = secret.Data[certresources.ServerCert]
-	if !haskey {
-		logger.Infof("secret %q is missing key %q", secret.Name, certresources.ServerCert)
-		createCerts = true
-	}
-	caCert, haskey = secret.Data[certresources.CACert]
-	if !haskey {
-		logger.Infof("secret %q is missing key %q", secret.Name, certresources.CACert)
-		createCerts = true
-	}
-
-	// TODO: Certification validation and rotation is pending
-
-	if createCerts {
-		serverKey, serverCert, caCert, err = certresources.CreateCerts(ctx, interceptorSvcName, namespace, time.Now().Add(decade))
-		if err != nil {
-			logger.Errorf("failed to create certs : %v", err)
-			return "", "", []byte{}, err
-		}
-
-		secret.Data = map[string][]byte{
-			certresources.ServerKey:  serverKey,
-			certresources.ServerCert: serverCert,
-			certresources.CACert:     caCert,
-		}
-		if _, err = kubeClient.CoreV1().Secrets(namespace).Update(ctx, secret, metav1.UpdateOptions{}); err != nil {
-			logger.Errorf("failed to update secret : %v", err)
-			return "", "", []byte{}, err
-		}
-	}
-
-	// write serverKey to file so that it can be passed while running https server.
-	if err = ioutil.WriteFile(keyFile, serverKey, 0600); err != nil {
-		logger.Errorf("failed to write serverKey file %v", err)
-		return "", "", []byte{}, err
-	}
-
-	// write serverCert to file so that it can be passed while running https server.
-	if err = ioutil.WriteFile(certFile, serverCert, 0600); err != nil {
-		logger.Errorf("failed to write serverCert file %v", err)
-		return "", "", []byte{}, err
-	}
-	return keyFile, certFile, caCert, nil
 }

--- a/config/interceptors/core-interceptors.yaml
+++ b/config/interceptors/core-interceptors.yaml
@@ -16,6 +16,8 @@ apiVersion: triggers.tekton.dev/v1alpha1
 kind: ClusterInterceptor
 metadata:
   name: cel
+  labels:
+    server/type: https
 spec:
   clientConfig:
     service:
@@ -28,6 +30,8 @@ apiVersion: triggers.tekton.dev/v1alpha1
 kind: ClusterInterceptor
 metadata:
   name: bitbucket
+  labels:
+    server/type: https
 spec:
   clientConfig:
     service:
@@ -40,6 +44,8 @@ apiVersion: triggers.tekton.dev/v1alpha1
 kind: ClusterInterceptor
 metadata:
   name: github
+  labels:
+    server/type: https
 spec:
   clientConfig:
     service:
@@ -52,6 +58,8 @@ apiVersion: triggers.tekton.dev/v1alpha1
 kind: ClusterInterceptor
 metadata:
   name: gitlab
+  labels:
+    server/type: https
 spec:
   clientConfig:
     service:

--- a/docs/clusterinterceptors.md
+++ b/docs/clusterinterceptors.md
@@ -86,4 +86,11 @@ Triggers uses knative pkg to generate key, cert, cacert and fill caBundle for co
 
 Triggers now support writing custom interceptor for both `http` and `https`. Support of `http` for custom interceptor will be there for 1-2 releases, later it will be removed and only `https` will be supported. 
  
-End user who write `https` custom interceptor need to pass `caBundle` in order to make secure connection with eventlistener
+End user who write `https` custom interceptor need to pass `caBundle` as well as label
+```yaml
+  labels:
+    server/type: https
+```
+to `ClusterInterceptor` in order to make secure connection with eventlistener.
+
+Here is the reference for writing [https server for custom interceptor](https://github.com/tektoncd/triggers/blob/main/cmd/interceptors/main.go). 

--- a/pkg/adapter/adapter_test.go
+++ b/pkg/adapter/adapter_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	v1alpha1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	faketriggersclient "github.com/tektoncd/triggers/pkg/client/injection/client/fake"
 	fakeClusterInterceptorinformer "github.com/tektoncd/triggers/pkg/client/injection/informers/triggers/v1alpha1/clusterinterceptor/fake"
 	"github.com/tektoncd/triggers/pkg/sink"
@@ -42,9 +42,11 @@ func TestGetHTTPClientEmptyCaBundle(t *testing.T) {
 		Logger:    logging.FromContext(ctx),
 		Namespace: "",
 		Args:      sink.Args{},
-		Clients:   sink.Clients{},
-		Recorder:  recorder,
-		injCtx:    ctx,
+		Clients: sink.Clients{
+			TriggersClient: faketriggersclient.Get(ctx),
+		},
+		Recorder: recorder,
+		injCtx:   ctx,
 	}
 
 	c, err := s.getHTTPClient()
@@ -69,9 +71,11 @@ func TestGetHTTPClient(t *testing.T) {
 		Logger:    logging.FromContext(ctx),
 		Namespace: "",
 		Args:      sink.Args{},
-		Clients:   sink.Clients{},
-		Recorder:  recorder,
-		injCtx:    ctx,
+		Clients: sink.Clients{
+			TriggersClient: faketriggersclient.Get(ctx),
+		},
+		Recorder: recorder,
+		injCtx:   ctx,
 	}
 
 	icInformer := fakeClusterInterceptorinformer.Get(ctx)
@@ -80,6 +84,9 @@ func TestGetHTTPClient(t *testing.T) {
 	ci := &v1alpha1.ClusterInterceptor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "github",
+			Labels: map[string]string{
+				"server/type": "https",
+			},
 		},
 		Spec: v1alpha1.ClusterInterceptorSpec{ClientConfig: v1alpha1.ClientConfig{
 			CaBundle: []byte("LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM5ekNDQXAyZ0F3SUJBZ0lSQUtQL1liSlF4Q2M5Y3JhVlBPMkhrK0V3Q2dZSUtvWkl6ajBFQXdJd1Z6RVUKTUJJR0ExVUVDaE1MYTI1aGRHbDJaUzVrWlhZeFB6QTlCZ05WQkFNVE5uUmxhM1J2YmkxMGNtbG5aMlZ5Y3kxagpiM0psTFdsdWRHVnlZMlZ3ZEc5eWN5NTBaV3QwYjI0dGNHbHdaV3hwYm1WekxuTjJZekFnRncweU1qQTJNakl4Ck5qRXhNVFZhR0E4eU1USXlNRFV5T1RFMk1URXhOVm93VnpFVU1CSUdBMVVFQ2hNTGEyNWhkR2wyWlM1a1pYWXgKUHpBOUJnTlZCQU1UTm5SbGEzUnZiaTEwY21sbloyVnljeTFqYjNKbExXbHVkR1Z5WTJWd2RHOXljeTUwWld0MApiMjR0Y0dsd1pXeHBibVZ6TG5OMll6QlpNQk1HQnlxR1NNNDlBZ0VHQ0NxR1NNNDlBd0VIQTBJQUJEdVVwTStEClVuZUozY1FieDc0cEpHTGgyTWkxREc1ZU5hNmRtSG5MeHhhQnZXTUxOOXp3Y2dLd2J2NHVJV0hsK2Rqb2laVWgKNFFRaElGUE8vS0NtUnJhamdnRkdNSUlCUWpBT0JnTlZIUThCQWY4RUJBTUNBb1F3SFFZRFZSMGxCQll3RkFZSQpLd1lCQlFVSEF3RUdDQ3NHQVFVRkJ3TUNNQThHQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGSlcrCjdROVJiZlo3UDFBY0lXdEI2ckNTOWtneE1JSGdCZ05WSFJFRWdkZ3dnZFdDSVhSbGEzUnZiaTEwY21sbloyVnkKY3kxamIzSmxMV2x1ZEdWeVkyVndkRzl5YzRJeWRHVnJkRzl1TFhSeWFXZG5aWEp6TFdOdmNtVXRhVzUwWlhKagpaWEIwYjNKekxuUmxhM1J2Ymkxd2FYQmxiR2x1WlhPQ05uUmxhM1J2YmkxMGNtbG5aMlZ5Y3kxamIzSmxMV2x1CmRHVnlZMlZ3ZEc5eWN5NTBaV3QwYjI0dGNHbHdaV3hwYm1WekxuTjJZNEpFZEdWcmRHOXVMWFJ5YVdkblpYSnoKTFdOdmNtVXRhVzUwWlhKalpYQjBiM0p6TG5SbGEzUnZiaTF3YVhCbGJHbHVaWE11YzNaakxtTnNkWE4wWlhJdQpiRzlqWVd3d0NnWUlLb1pJemowRUF3SURTQUF3UlFJaEFOOE5SMTBJS0h4YUtXa0o0cFV1d3ljNFpmZG4rNTd6CnplN3RnS050b3hWREFpQWRhQlYvMlRDeStnV2tjUFR4cHo3aE91MHZ6bGZmeDhzV0Z3Wk5XdlVYUEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="),

--- a/pkg/apis/triggers/v1alpha1/cluster_interceptor_defaults.go
+++ b/pkg/apis/triggers/v1alpha1/cluster_interceptor_defaults.go
@@ -18,7 +18,19 @@ package v1alpha1
 
 import (
 	"context"
+
+	"github.com/tektoncd/triggers/pkg/apis/triggers/contexts"
 )
 
 // SetDefaults sets the defaults on the object.
-func (it *ClusterInterceptor) SetDefaults(ctx context.Context) {}
+func (it *ClusterInterceptor) SetDefaults(ctx context.Context) {
+	if !contexts.IsUpgradeViaDefaulting(ctx) {
+		return
+	}
+	if _, ok := it.GetLabels()["server/type"]; !ok {
+		// if server type is not set its assumed that running server is http
+		it.Labels = map[string]string{
+			"server/type": "http",
+		}
+	}
+}

--- a/pkg/reconciler/clusterinterceptor/clusterinterceptor_test.go
+++ b/pkg/reconciler/clusterinterceptor/clusterinterceptor_test.go
@@ -53,7 +53,8 @@ func TestReconcileKind(t *testing.T) {
 		},
 		want: &triggersv1.ClusterInterceptor{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "my-interceptor",
+				Name:   "my-interceptor",
+				Labels: map[string]string{"server/type": "http"},
 			},
 			Spec: triggersv1.ClusterInterceptorSpec{
 				ClientConfig: triggersv1.ClientConfig{
@@ -94,7 +95,8 @@ func TestReconcileKind(t *testing.T) {
 		},
 		want: &triggersv1.ClusterInterceptor{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "my-interceptor",
+				Name:   "my-interceptor",
+				Labels: map[string]string{"server/type": "http"},
 			},
 			Spec: triggersv1.ClusterInterceptorSpec{
 				ClientConfig: triggersv1.ClientConfig{
@@ -120,7 +122,8 @@ func TestReconcileKind(t *testing.T) {
 		name: "when provided caBundle",
 		initial: &triggersv1.ClusterInterceptor{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "my-interceptor",
+				Name:   "my-interceptor",
+				Labels: map[string]string{"server/type": "https"},
 			},
 			Spec: triggersv1.ClusterInterceptorSpec{
 				ClientConfig: triggersv1.ClientConfig{
@@ -135,7 +138,8 @@ func TestReconcileKind(t *testing.T) {
 		},
 		want: &triggersv1.ClusterInterceptor{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "my-interceptor",
+				Name:   "my-interceptor",
+				Labels: map[string]string{"server/type": "https"},
 			},
 			Spec: triggersv1.ClusterInterceptorSpec{
 				ClientConfig: triggersv1.ClientConfig{


### PR DESCRIPTION
# Changes
Fixes : https://github.com/tektoncd/triggers/issues/1387

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note

1. By default connection between EventListener and ClusterInterceptor is HTTP
2. By default all core interceptors(GitHub, GitLab, BitBucket, CEL) will be HTTPS and caBundle will be added by Triggers 
3. End user who write `https` custom interceptor need to pass `caBundle` as well as label

  labels:
     server/type: https

to `ClusterInterceptor` spec in order to make secure connection with eventlistener.

```
