### PR TITLE
Remove Validation on Delete

### DIFF
--- a/pkg/apis/triggers/v1alpha1/cluster_interceptor_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/cluster_interceptor_validation_test.go
@@ -2,6 +2,7 @@ package v1alpha1_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -14,7 +15,7 @@ import (
 func TestClusterInterceptorValidate_OnDelete(t *testing.T) {
 	ci := triggersv1.ClusterInterceptor{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "github",
+			Name: strings.Repeat("foo", 64), // Length should be lower than 63,
 		},
 		Spec: triggersv1.ClusterInterceptorSpec{
 			ClientConfig: triggersv1.ClientConfig{

--- a/pkg/apis/triggers/v1alpha1/cluster_trigger_binding_validation.go
+++ b/pkg/apis/triggers/v1alpha1/cluster_trigger_binding_validation.go
@@ -24,11 +24,12 @@ import (
 )
 
 func (ctb *ClusterTriggerBinding) Validate(ctx context.Context) *apis.FieldError {
-	if err := validate.ObjectMetadata(ctb.GetObjectMeta()); err != nil {
-		return err.ViaField("metadata")
-	}
 	if apis.IsInDelete(ctx) {
 		return nil
+	}
+
+	if err := validate.ObjectMetadata(ctb.GetObjectMeta()); err != nil {
+		return err.ViaField("metadata")
 	}
 	return ctb.Spec.Validate(ctx)
 }

--- a/pkg/apis/triggers/v1alpha1/cluster_trigger_binding_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/cluster_trigger_binding_validation_test.go
@@ -18,6 +18,7 @@ package v1alpha1_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
@@ -28,7 +29,7 @@ import (
 func Test_ClusterTriggerBindingValidate_OnDelete(t *testing.T) {
 	tb := &v1alpha1.ClusterTriggerBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "name",
+			Name: strings.Repeat("foo", 64), // Length should be lower than 63
 		},
 		Spec: v1alpha1.TriggerBindingSpec{
 			Params: []v1alpha1.Param{{

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation.go
@@ -39,6 +39,10 @@ var (
 
 // Validate EventListener.
 func (e *EventListener) Validate(ctx context.Context) *apis.FieldError {
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
+
 	var errs *apis.FieldError
 	if len(e.ObjectMeta.Name) > 60 {
 		// Since `el-` is added as the prefix of EventListener services, the name of EventListener must be no more than 60 characters long.
@@ -49,9 +53,6 @@ func (e *EventListener) Validate(ctx context.Context) *apis.FieldError {
 		errs = errs.Also(triggers.ValidateAnnotations(e.ObjectMeta.Annotations))
 	}
 
-	if apis.IsInDelete(ctx) {
-		return nil
-	}
 	return errs.Also(e.Spec.validate(ctx))
 }
 

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
@@ -18,6 +18,7 @@ package v1alpha1_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -37,7 +38,7 @@ import (
 func Test_EventListenerValidate_OnDelete(t *testing.T) {
 	el := &v1alpha1.EventListener{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
+			Name:      strings.Repeat("foo", 64), // Length should be lower than 63
 			Namespace: "namespace",
 		},
 		Spec: v1alpha1.EventListenerSpec{

--- a/pkg/apis/triggers/v1alpha1/trigger_binding_validation.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_binding_validation.go
@@ -29,11 +29,11 @@ import (
 
 // Validate TriggerBinding.
 func (tb *TriggerBinding) Validate(ctx context.Context) (errs *apis.FieldError) {
-	errs = validate.ObjectMetadata(tb.GetObjectMeta()).ViaField("metadata")
-
 	if apis.IsInDelete(ctx) {
 		return nil
 	}
+
+	errs = validate.ObjectMetadata(tb.GetObjectMeta()).ViaField("metadata")
 	return errs.Also(tb.Spec.Validate(ctx).ViaField("spec"))
 }
 

--- a/pkg/apis/triggers/v1alpha1/trigger_binding_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_binding_validation_test.go
@@ -18,6 +18,7 @@ package v1alpha1_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -29,7 +30,7 @@ import (
 func Test_TriggerBindingValidate_OnDelete(t *testing.T) {
 	tb := &v1alpha1.TriggerBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
+			Name:      strings.Repeat("foo", 64), // Length should be lower than 63,
 			Namespace: "namespace",
 		},
 		Spec: v1alpha1.TriggerBindingSpec{

--- a/pkg/apis/triggers/v1alpha1/trigger_template_validation.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_template_validation.go
@@ -35,10 +35,11 @@ var paramsRegexp = regexp.MustCompile(`\$\(tt.params.(?P<var>[_a-zA-Z][_a-zA-Z0-
 
 // Validate validates a TriggerTemplate.
 func (t *TriggerTemplate) Validate(ctx context.Context) *apis.FieldError {
-	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
 	if apis.IsInDelete(ctx) {
 		return nil
 	}
+
+	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
 	return errs.Also(t.Spec.validate(ctx).ViaField("spec"))
 }
 

--- a/pkg/apis/triggers/v1alpha1/trigger_template_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_template_validation_test.go
@@ -18,6 +18,7 @@ package v1alpha1_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	pipelinev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -92,7 +93,7 @@ func invalidParamResourceTemplate(t *testing.T) runtime.RawExtension {
 func TestTriggerTemplate_Validate_OnDelete(t *testing.T) {
 	tt := &v1alpha1.TriggerTemplate{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "tt",
+			Name:      strings.Repeat("foo", 64), // Length should be lower than 63
 			Namespace: "foo",
 		},
 		Spec: v1alpha1.TriggerTemplateSpec{

--- a/pkg/apis/triggers/v1alpha1/trigger_validation.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_validation.go
@@ -29,10 +29,11 @@ import (
 
 // Validate validates a Trigger
 func (t *Trigger) Validate(ctx context.Context) *apis.FieldError {
-	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
 	if apis.IsInDelete(ctx) {
 		return nil
 	}
+
+	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
 	return errs.Also(t.Spec.validate(ctx).ViaField("spec"))
 }
 

--- a/pkg/apis/triggers/v1alpha1/trigger_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_validation_test.go
@@ -18,6 +18,7 @@ package v1alpha1_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -31,7 +32,7 @@ import (
 func Test_TriggerValidate_OnDelete(t *testing.T) {
 	tr := &v1alpha1.Trigger{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
+			Name:      strings.Repeat("foo", 64), // Length should be lower than 63
 			Namespace: "namespace",
 		},
 		Spec: v1alpha1.TriggerSpec{

--- a/pkg/apis/triggers/v1beta1/cluster_trigger_binding_validation.go
+++ b/pkg/apis/triggers/v1beta1/cluster_trigger_binding_validation.go
@@ -24,11 +24,11 @@ import (
 )
 
 func (ctb *ClusterTriggerBinding) Validate(ctx context.Context) *apis.FieldError {
-	if err := validate.ObjectMetadata(ctb.GetObjectMeta()); err != nil {
-		return err.ViaField("metadata")
-	}
 	if apis.IsInDelete(ctx) {
 		return nil
+	}
+	if err := validate.ObjectMetadata(ctb.GetObjectMeta()); err != nil {
+		return err.ViaField("metadata")
 	}
 	return ctb.Spec.Validate(ctx)
 }

--- a/pkg/apis/triggers/v1beta1/cluster_trigger_binding_validation_test.go
+++ b/pkg/apis/triggers/v1beta1/cluster_trigger_binding_validation_test.go
@@ -18,6 +18,7 @@ package v1beta1_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
@@ -28,7 +29,7 @@ import (
 func Test_ClusterTriggerBindingValidate_OnDelete(t *testing.T) {
 	tb := &v1beta1.ClusterTriggerBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "name",
+			Name: strings.Repeat("foo", 64), // Length should be lower than 63
 		},
 		Spec: v1beta1.TriggerBindingSpec{
 			Params: []v1beta1.Param{{

--- a/pkg/apis/triggers/v1beta1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_validation.go
@@ -41,6 +41,10 @@ var (
 
 // Validate EventListener.
 func (e *EventListener) Validate(ctx context.Context) *apis.FieldError {
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
+
 	var errs *apis.FieldError
 	if len(e.ObjectMeta.Name) > 60 {
 		// Since `el-` is added as the prefix of EventListener services, the name of EventListener must be no more than 60 characters long.
@@ -51,9 +55,6 @@ func (e *EventListener) Validate(ctx context.Context) *apis.FieldError {
 		errs = errs.Also(triggers.ValidateAnnotations(e.GetObjectMeta().GetAnnotations()))
 	}
 
-	if apis.IsInDelete(ctx) {
-		return nil
-	}
 	return errs.Also(e.Spec.validate(ctx))
 }
 

--- a/pkg/apis/triggers/v1beta1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_validation_test.go
@@ -18,6 +18,7 @@ package v1beta1_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -43,7 +44,7 @@ var myObjectMeta = metav1.ObjectMeta{
 func Test_EventListenerValidate_OnDelete(t *testing.T) {
 	el := &triggersv1beta1.EventListener{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
+			Name:      strings.Repeat("foo", 64), // Length should be lower than 63
 			Namespace: "namespace",
 		},
 		Spec: triggersv1beta1.EventListenerSpec{

--- a/pkg/apis/triggers/v1beta1/trigger_binding_validation.go
+++ b/pkg/apis/triggers/v1beta1/trigger_binding_validation.go
@@ -29,10 +29,11 @@ import (
 
 // Validate TriggerBinding.
 func (tb *TriggerBinding) Validate(ctx context.Context) *apis.FieldError {
-	errs := validate.ObjectMetadata(tb.GetObjectMeta()).ViaField("metadata")
 	if apis.IsInDelete(ctx) {
 		return nil
 	}
+
+	errs := validate.ObjectMetadata(tb.GetObjectMeta()).ViaField("metadata")
 	return errs.Also(tb.Spec.Validate(ctx).ViaField("spec"))
 }
 

--- a/pkg/apis/triggers/v1beta1/trigger_binding_validation_test.go
+++ b/pkg/apis/triggers/v1beta1/trigger_binding_validation_test.go
@@ -18,6 +18,7 @@ package v1beta1_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -29,7 +30,7 @@ import (
 func Test_TriggerBindingValidate_OnDelete(t *testing.T) {
 	tb := &v1beta1.TriggerBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
+			Name:      strings.Repeat("foo", 64), // Length should be lower than 63
 			Namespace: "namespace",
 		},
 		Spec: v1beta1.TriggerBindingSpec{

--- a/pkg/apis/triggers/v1beta1/trigger_template_validation.go
+++ b/pkg/apis/triggers/v1beta1/trigger_template_validation.go
@@ -35,10 +35,11 @@ var paramsRegexp = regexp.MustCompile(`\$\(tt.params.(?P<var>[_a-zA-Z][_a-zA-Z0-
 
 // Validate validates a TriggerTemplate.
 func (t *TriggerTemplate) Validate(ctx context.Context) *apis.FieldError {
-	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
 	if apis.IsInDelete(ctx) {
 		return nil
 	}
+
+	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
 	return errs.Also(t.Spec.validate(ctx).ViaField("spec"))
 }
 

--- a/pkg/apis/triggers/v1beta1/trigger_template_validation_test.go
+++ b/pkg/apis/triggers/v1beta1/trigger_template_validation_test.go
@@ -18,6 +18,7 @@ package v1beta1_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	pipelinev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -92,7 +93,7 @@ func invalidParamResourceTemplate(t *testing.T) runtime.RawExtension {
 func TestTriggerTemplate_Validate_OnDelete(t *testing.T) {
 	tt := &v1beta1.TriggerTemplate{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "tt",
+			Name:      strings.Repeat("foo", 64), // Length should be lower than 63
 			Namespace: "foo",
 		},
 		Spec: v1beta1.TriggerTemplateSpec{

--- a/pkg/apis/triggers/v1beta1/trigger_validation.go
+++ b/pkg/apis/triggers/v1beta1/trigger_validation.go
@@ -28,10 +28,11 @@ import (
 
 // Validate validates a Trigger
 func (t *Trigger) Validate(ctx context.Context) *apis.FieldError {
-	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
 	if apis.IsInDelete(ctx) {
 		return nil
 	}
+
+	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
 	return errs.Also(t.Spec.validate(ctx).ViaField("spec"))
 }
 

--- a/pkg/apis/triggers/v1beta1/trigger_validation_test.go
+++ b/pkg/apis/triggers/v1beta1/trigger_validation_test.go
@@ -18,6 +18,7 @@ package v1beta1_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -31,7 +32,7 @@ import (
 func Test_TriggerValidate_OnDelete(t *testing.T) {
 	tr := &v1beta1.Trigger{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
+			Name:      strings.Repeat("foo", 64), // Length should be lower than 63
 			Namespace: "namespace",
 		},
 		Spec: v1beta1.TriggerSpec{

--- a/pkg/apis/triggers/v1beta1/version_validation.go
+++ b/pkg/apis/triggers/v1beta1/version_validation.go
@@ -28,6 +28,10 @@ import (
 // to the wantVersion value and, if not, returns an error stating which feature
 // is dependent on the version and what the current version actually is.
 func ValidateEnabledAPIFields(ctx context.Context, featureName, wantVersion string) *apis.FieldError {
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
+
 	currentVersion := config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields
 	if currentVersion != wantVersion {
 		var errs *apis.FieldError

--- a/pkg/apis/triggers/v1beta1/version_validation_test.go
+++ b/pkg/apis/triggers/v1beta1/version_validation_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/tektoncd/triggers/pkg/apis/config"
+	"knative.dev/pkg/apis"
 )
 
 func TestValidateEnabledAPIFields(t *testing.T) {
@@ -53,5 +54,22 @@ func TestValidateEnabledAPIFieldsError(t *testing.T) {
 	ctx := config.ToContext(context.Background(), cfg)
 	if err := ValidateEnabledAPIFields(ctx, "test feature", "alpha"); err == nil {
 		t.Errorf("error expected for incompatible feature gates")
+	}
+}
+
+func TestValidateEnabledAPIFields_OnDelete(t *testing.T) {
+	flags, err := config.NewFeatureFlagsFromMap(map[string]string{
+		"enable-api-fields": "stable",
+	})
+	if err != nil {
+		t.Fatalf("error creating feature flags from map: %v", err)
+	}
+	cfg := &config.Config{
+		FeatureFlags: flags,
+	}
+	ctx := config.ToContext(context.Background(), cfg)
+	ctx = apis.WithinDelete(ctx)
+	if err := ValidateEnabledAPIFields(ctx, "test feature", "alpha"); err != nil {
+		t.Errorf("error not expected during delete apis")
 	}
 }


### PR DESCRIPTION
Remove validation on delete to avoid blocking of outdated or wrong objects.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes


```release-note
Remove Validation on Deleting Objects
```
