### PR TITLE
refactor interceptors logger and secret getter

### DIFF
--- a/cmd/interceptors/main.go
+++ b/cmd/interceptors/main.go
@@ -71,7 +71,7 @@ func main() {
 		return
 	}
 
-	service, err := server.NewWithCoreInterceptors(interceptors.NewKubeClientSecretGetter(kubeclient.Get(ctx).CoreV1(), 1024, 5*time.Second), logger)
+	service, err := server.NewWithCoreInterceptors(interceptors.DefaultSecretGetter(kubeclient.Get(ctx).CoreV1()), logger)
 	if err != nil {
 		logger.Errorf("failed to initialize core interceptors: %s", err)
 		return

--- a/pkg/interceptors/bitbucket/bitbucket.go
+++ b/pkg/interceptors/bitbucket/bitbucket.go
@@ -23,7 +23,6 @@ import (
 	gh "github.com/google/go-github/v31/github"
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/pkg/interceptors"
-	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 )
 
@@ -33,7 +32,7 @@ type Interceptor struct {
 	SecretGetter interceptors.SecretGetter
 }
 
-func NewInterceptor(sg interceptors.SecretGetter, l *zap.SugaredLogger) *Interceptor {
+func NewInterceptor(sg interceptors.SecretGetter) *Interceptor {
 	return &Interceptor{
 		SecretGetter: sg,
 	}

--- a/pkg/interceptors/bitbucket/bitbucket.go
+++ b/pkg/interceptors/bitbucket/bitbucket.go
@@ -31,13 +31,11 @@ var _ triggersv1.InterceptorInterface = (*Interceptor)(nil)
 
 type Interceptor struct {
 	SecretGetter interceptors.SecretGetter
-	Logger       *zap.SugaredLogger
 }
 
 func NewInterceptor(sg interceptors.SecretGetter, l *zap.SugaredLogger) *Interceptor {
 	return &Interceptor{
 		SecretGetter: sg,
-		Logger:       l,
 	}
 }
 

--- a/pkg/interceptors/bitbucket/bitbucket_test.go
+++ b/pkg/interceptors/bitbucket/bitbucket_test.go
@@ -25,7 +25,6 @@ import (
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/pkg/interceptors"
 	"github.com/tektoncd/triggers/test"
-	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
@@ -104,7 +103,6 @@ func TestInterceptor_Process_ShouldContinue(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, _ := test.SetupFakeContext(t)
-			logger := zaptest.NewLogger(t)
 			clientset := fakekubeclient.Get(ctx)
 			if tt.secret != nil {
 				tt.secret.Namespace = metav1.NamespaceDefault
@@ -112,7 +110,6 @@ func TestInterceptor_Process_ShouldContinue(t *testing.T) {
 			}
 			w := &Interceptor{
 				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second),
-				Logger:       logger.Sugar(),
 			}
 
 			req := &triggersv1.InterceptorRequest{
@@ -262,7 +259,6 @@ func TestInterceptor_Process_ShouldNotContinue(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, _ := test.SetupFakeContext(t)
-			logger := zaptest.NewLogger(t)
 			clientset := fakekubeclient.Get(ctx)
 			if tt.secret != nil {
 				tt.secret.Namespace = metav1.NamespaceDefault
@@ -270,7 +266,6 @@ func TestInterceptor_Process_ShouldNotContinue(t *testing.T) {
 			}
 			w := &Interceptor{
 				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second),
-				Logger:       logger.Sugar(),
 			}
 
 			req := &triggersv1.InterceptorRequest{
@@ -305,11 +300,9 @@ func TestInterceptor_Process_ShouldNotContinue(t *testing.T) {
 
 func TestInterceptor_Process_InvalidParams(t *testing.T) {
 	ctx, _ := test.SetupFakeContext(t)
-	logger := zaptest.NewLogger(t)
 
 	w := &Interceptor{
 		SecretGetter: interceptors.NewKubeClientSecretGetter(fakekubeclient.Get(ctx).CoreV1(), 1024, 5*time.Second),
-		Logger:       logger.Sugar(),
 	}
 
 	req := &triggersv1.InterceptorRequest{

--- a/pkg/interceptors/bitbucket/bitbucket_test.go
+++ b/pkg/interceptors/bitbucket/bitbucket_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
-	"time"
 
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/pkg/interceptors"
@@ -109,7 +108,7 @@ func TestInterceptor_Process_ShouldContinue(t *testing.T) {
 				ctx, clientset = fakekubeclient.With(ctx, tt.secret)
 			}
 			w := &Interceptor{
-				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second),
+				SecretGetter: interceptors.DefaultSecretGetter(clientset.CoreV1()),
 			}
 
 			req := &triggersv1.InterceptorRequest{
@@ -265,7 +264,7 @@ func TestInterceptor_Process_ShouldNotContinue(t *testing.T) {
 				ctx, clientset = fakekubeclient.With(ctx, tt.secret)
 			}
 			w := &Interceptor{
-				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second),
+				SecretGetter: interceptors.DefaultSecretGetter(clientset.CoreV1()),
 			}
 
 			req := &triggersv1.InterceptorRequest{
@@ -302,7 +301,7 @@ func TestInterceptor_Process_InvalidParams(t *testing.T) {
 	ctx, _ := test.SetupFakeContext(t)
 
 	w := &Interceptor{
-		SecretGetter: interceptors.NewKubeClientSecretGetter(fakekubeclient.Get(ctx).CoreV1(), 1024, 5*time.Second),
+		SecretGetter: interceptors.DefaultSecretGetter(fakekubeclient.Get(ctx).CoreV1()),
 	}
 
 	req := &triggersv1.InterceptorRequest{

--- a/pkg/interceptors/cel/cel.go
+++ b/pkg/interceptors/cel/cel.go
@@ -34,7 +34,6 @@ import (
 	celext "github.com/google/cel-go/ext"
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tidwall/sjson"
-	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -58,7 +57,7 @@ var (
 )
 
 // NewInterceptor creates a prepopulated Interceptor.
-func NewInterceptor(sg interceptors.SecretGetter, l *zap.SugaredLogger) *Interceptor {
+func NewInterceptor(sg interceptors.SecretGetter) *Interceptor {
 	return &Interceptor{
 		SecretGetter: sg,
 	}

--- a/pkg/interceptors/cel/cel.go
+++ b/pkg/interceptors/cel/cel.go
@@ -47,7 +47,6 @@ var _ triggersv1.InterceptorInterface = (*Interceptor)(nil)
 // a true value, then the interception is "successful".
 type Interceptor struct {
 	SecretGetter     interceptors.SecretGetter
-	Logger           *zap.SugaredLogger
 	CEL              *triggersv1.CELInterceptor
 	TriggerNamespace string
 }
@@ -62,7 +61,6 @@ var (
 func NewInterceptor(sg interceptors.SecretGetter, l *zap.SugaredLogger) *Interceptor {
 	return &Interceptor{
 		SecretGetter: sg,
-		Logger:       l,
 	}
 }
 

--- a/pkg/interceptors/cel/cel_test.go
+++ b/pkg/interceptors/cel/cel_test.go
@@ -26,7 +26,6 @@ import (
 	"regexp"
 	"strings"
 	"testing"
-	"time"
 
 	"google.golang.org/grpc/codes"
 
@@ -282,7 +281,7 @@ func TestInterceptor_Process(t *testing.T) {
 			var clientset *fake.Clientset
 			ctx, clientset = fakekubeclient.With(ctx, makeSecret())
 			w := &Interceptor{
-				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second),
+				SecretGetter: interceptors.DefaultSecretGetter(clientset.CoreV1()),
 			}
 			res := w.Process(ctx, &triggersv1.InterceptorRequest{
 				Body: string(tt.body),
@@ -652,7 +651,7 @@ func TestExpressionEvaluation(t *testing.T) {
 			if tt.secret != nil {
 				_, clientset = fakekubeclient.With(ctx, tt.secret)
 			}
-			env, err := makeCelEnv(context.Background(), testNS, interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second))
+			env, err := makeCelEnv(context.Background(), testNS, interceptors.DefaultSecretGetter(clientset.CoreV1()))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -781,7 +780,7 @@ func TestExpressionEvaluation_Error(t *testing.T) {
 				_, clientset = fakekubeclient.With(ctx, makeSecret())
 				ns = tt.secretNS
 			}
-			env, err := makeCelEnv(context.Background(), ns, interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second))
+			env, err := makeCelEnv(context.Background(), ns, interceptors.DefaultSecretGetter(clientset.CoreV1()))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/interceptors/cel/cel_test.go
+++ b/pkg/interceptors/cel/cel_test.go
@@ -28,7 +28,6 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/zap/zaptest"
 	"google.golang.org/grpc/codes"
 
 	"github.com/google/cel-go/common/types"
@@ -279,13 +278,11 @@ func TestInterceptor_Process(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(rt *testing.T) {
-			logger := zaptest.NewLogger(t)
 			ctx, _ := test.SetupFakeContext(t)
 			var clientset *fake.Clientset
 			ctx, clientset = fakekubeclient.With(ctx, makeSecret())
 			w := &Interceptor{
 				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second),
-				Logger:       logger.Sugar(),
 			}
 			res := w.Process(ctx, &triggersv1.InterceptorRequest{
 				Body: string(tt.body),
@@ -380,10 +377,7 @@ func TestInterceptor_Process_Error(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger := zaptest.NewLogger(t)
-			w := &Interceptor{
-				Logger: logger.Sugar(),
-			}
+			w := &Interceptor{}
 			res := w.Process(context.Background(), &triggersv1.InterceptorRequest{
 				Body: string(tt.body),
 				Header: http.Header{
@@ -416,10 +410,7 @@ func TestInterceptor_Process_Error(t *testing.T) {
 }
 
 func TestInterceptor_Process_InvalidParams(t *testing.T) {
-	logger := zaptest.NewLogger(t)
-	w := &Interceptor{
-		Logger: logger.Sugar(),
-	}
+	w := &Interceptor{}
 	res := w.Process(context.Background(), &triggersv1.InterceptorRequest{
 		Body:   `{}`,
 		Header: http.Header{},

--- a/pkg/interceptors/github/github.go
+++ b/pkg/interceptors/github/github.go
@@ -34,13 +34,11 @@ var ErrInvalidContentType = errors.New("form parameter encoding not supported, p
 
 type Interceptor struct {
 	SecretGetter interceptors.SecretGetter
-	Logger       *zap.SugaredLogger
 }
 
 func NewInterceptor(sg interceptors.SecretGetter, l *zap.SugaredLogger) *Interceptor {
 	return &Interceptor{
 		SecretGetter: sg,
-		Logger:       l,
 	}
 }
 

--- a/pkg/interceptors/github/github.go
+++ b/pkg/interceptors/github/github.go
@@ -23,7 +23,6 @@ import (
 	gh "github.com/google/go-github/v31/github"
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/pkg/interceptors"
-	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 )
 
@@ -36,7 +35,7 @@ type Interceptor struct {
 	SecretGetter interceptors.SecretGetter
 }
 
-func NewInterceptor(sg interceptors.SecretGetter, l *zap.SugaredLogger) *Interceptor {
+func NewInterceptor(sg interceptors.SecretGetter) *Interceptor {
 	return &Interceptor{
 		SecretGetter: sg,
 	}

--- a/pkg/interceptors/github/github_test.go
+++ b/pkg/interceptors/github/github_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
-	"time"
 
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/pkg/interceptors"
@@ -137,7 +136,7 @@ func TestInterceptor_ExecuteTrigger_Signature(t *testing.T) {
 			}
 
 			w := &Interceptor{
-				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second),
+				SecretGetter: interceptors.DefaultSecretGetter(clientset.CoreV1()),
 			}
 			res := w.Process(ctx, req)
 
@@ -296,7 +295,7 @@ func TestInterceptor_ExecuteTrigger_ShouldNotContinue(t *testing.T) {
 			}
 
 			w := &Interceptor{
-				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second),
+				SecretGetter: interceptors.DefaultSecretGetter(clientset.CoreV1()),
 			}
 			res := w.Process(ctx, req)
 
@@ -323,7 +322,7 @@ func TestInterceptor_ExecuteTrigger_with_invalid_content_type(t *testing.T) {
 		},
 	}
 	w := &Interceptor{
-		SecretGetter: interceptors.NewKubeClientSecretGetter(fakekubeclient.Get(ctx).CoreV1(), 1024, 5*time.Second),
+		SecretGetter: interceptors.DefaultSecretGetter(fakekubeclient.Get(ctx).CoreV1()),
 	}
 	res := w.Process(ctx, req)
 	if res.Continue {
@@ -338,7 +337,7 @@ func TestInterceptor_Process_InvalidParams(t *testing.T) {
 	ctx, _ := test.SetupFakeContext(t)
 
 	w := &Interceptor{
-		SecretGetter: interceptors.NewKubeClientSecretGetter(fakekubeclient.Get(ctx).CoreV1(), 1024, 5*time.Second),
+		SecretGetter: interceptors.DefaultSecretGetter(fakekubeclient.Get(ctx).CoreV1()),
 	}
 
 	req := &triggersv1.InterceptorRequest{

--- a/pkg/interceptors/github/github_test.go
+++ b/pkg/interceptors/github/github_test.go
@@ -25,7 +25,6 @@ import (
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/pkg/interceptors"
 	"github.com/tektoncd/triggers/test"
-	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
@@ -108,7 +107,6 @@ func TestInterceptor_ExecuteTrigger_Signature(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, _ := test.SetupFakeContext(t)
-			logger := zaptest.NewLogger(t)
 
 			req := &triggersv1.InterceptorRequest{
 				Body: string(tt.payload),
@@ -140,7 +138,6 @@ func TestInterceptor_ExecuteTrigger_Signature(t *testing.T) {
 
 			w := &Interceptor{
 				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second),
-				Logger:       logger.Sugar(),
 			}
 			res := w.Process(ctx, req)
 
@@ -269,7 +266,6 @@ func TestInterceptor_ExecuteTrigger_ShouldNotContinue(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, _ := test.SetupFakeContext(t)
-			logger := zaptest.NewLogger(t)
 
 			req := &triggersv1.InterceptorRequest{
 				Body: string(tt.payload),
@@ -301,7 +297,6 @@ func TestInterceptor_ExecuteTrigger_ShouldNotContinue(t *testing.T) {
 
 			w := &Interceptor{
 				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second),
-				Logger:       logger.Sugar(),
 			}
 			res := w.Process(ctx, req)
 
@@ -314,7 +309,6 @@ func TestInterceptor_ExecuteTrigger_ShouldNotContinue(t *testing.T) {
 
 func TestInterceptor_ExecuteTrigger_with_invalid_content_type(t *testing.T) {
 	ctx, _ := test.SetupFakeContext(t)
-	logger := zaptest.NewLogger(t)
 	req := &triggersv1.InterceptorRequest{
 		Body: `{}`,
 		Header: http.Header{
@@ -330,7 +324,6 @@ func TestInterceptor_ExecuteTrigger_with_invalid_content_type(t *testing.T) {
 	}
 	w := &Interceptor{
 		SecretGetter: interceptors.NewKubeClientSecretGetter(fakekubeclient.Get(ctx).CoreV1(), 1024, 5*time.Second),
-		Logger:       logger.Sugar(),
 	}
 	res := w.Process(ctx, req)
 	if res.Continue {
@@ -343,11 +336,9 @@ func TestInterceptor_ExecuteTrigger_with_invalid_content_type(t *testing.T) {
 
 func TestInterceptor_Process_InvalidParams(t *testing.T) {
 	ctx, _ := test.SetupFakeContext(t)
-	logger := zaptest.NewLogger(t)
 
 	w := &Interceptor{
 		SecretGetter: interceptors.NewKubeClientSecretGetter(fakekubeclient.Get(ctx).CoreV1(), 1024, 5*time.Second),
-		Logger:       logger.Sugar(),
 	}
 
 	req := &triggersv1.InterceptorRequest{

--- a/pkg/interceptors/gitlab/gitlab.go
+++ b/pkg/interceptors/gitlab/gitlab.go
@@ -30,13 +30,11 @@ var _ triggersv1.InterceptorInterface = (*Interceptor)(nil)
 
 type Interceptor struct {
 	SecretGetter interceptors.SecretGetter
-	Logger       *zap.SugaredLogger
 }
 
 func NewInterceptor(sg interceptors.SecretGetter, l *zap.SugaredLogger) *Interceptor {
 	return &Interceptor{
 		SecretGetter: sg,
-		Logger:       l,
 	}
 }
 

--- a/pkg/interceptors/gitlab/gitlab.go
+++ b/pkg/interceptors/gitlab/gitlab.go
@@ -22,7 +22,6 @@ import (
 
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/pkg/interceptors"
-	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 )
 
@@ -32,7 +31,7 @@ type Interceptor struct {
 	SecretGetter interceptors.SecretGetter
 }
 
-func NewInterceptor(sg interceptors.SecretGetter, l *zap.SugaredLogger) *Interceptor {
+func NewInterceptor(sg interceptors.SecretGetter) *Interceptor {
 	return &Interceptor{
 		SecretGetter: sg,
 	}

--- a/pkg/interceptors/gitlab/gitlab_test.go
+++ b/pkg/interceptors/gitlab/gitlab_test.go
@@ -19,7 +19,6 @@ package gitlab
 import (
 	"net/http"
 	"testing"
-	"time"
 
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/pkg/interceptors"
@@ -121,7 +120,7 @@ func TestInterceptor_ExecuteTrigger_ShouldContinue(t *testing.T) {
 				ctx, clientset = fakekubeclient.With(ctx, tt.secret)
 			}
 			w := &Interceptor{
-				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second),
+				SecretGetter: interceptors.DefaultSecretGetter(clientset.CoreV1()),
 			}
 			res := w.Process(ctx, req)
 			if !res.Continue {
@@ -272,7 +271,7 @@ func TestInterceptor_ExecuteTrigger_ShouldNotContinue(t *testing.T) {
 				ctx, clientset = fakekubeclient.With(ctx, tt.secret)
 			}
 			w := &Interceptor{
-				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second),
+				SecretGetter: interceptors.DefaultSecretGetter(clientset.CoreV1()),
 			}
 			res := w.Process(ctx, req)
 			if res.Continue {
@@ -286,7 +285,7 @@ func TestInterceptor_Process_InvalidParams(t *testing.T) {
 	ctx, _ := test.SetupFakeContext(t)
 
 	w := &Interceptor{
-		SecretGetter: interceptors.NewKubeClientSecretGetter(fakekubeclient.Get(ctx).CoreV1(), 1024, 5*time.Second),
+		SecretGetter: interceptors.DefaultSecretGetter(fakekubeclient.Get(ctx).CoreV1()),
 	}
 
 	req := &triggersv1.InterceptorRequest{

--- a/pkg/interceptors/gitlab/gitlab_test.go
+++ b/pkg/interceptors/gitlab/gitlab_test.go
@@ -24,7 +24,6 @@ import (
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/pkg/interceptors"
 	"github.com/tektoncd/triggers/test"
-	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
@@ -95,7 +94,6 @@ func TestInterceptor_ExecuteTrigger_ShouldContinue(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, _ := test.SetupFakeContext(t)
-			logger := zaptest.NewLogger(t)
 			req := &triggersv1.InterceptorRequest{
 				Body: string(tt.payload),
 				Header: http.Header{
@@ -124,7 +122,6 @@ func TestInterceptor_ExecuteTrigger_ShouldContinue(t *testing.T) {
 			}
 			w := &Interceptor{
 				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second),
-				Logger:       logger.Sugar(),
 			}
 			res := w.Process(ctx, req)
 			if !res.Continue {
@@ -248,7 +245,6 @@ func TestInterceptor_ExecuteTrigger_ShouldNotContinue(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, _ := test.SetupFakeContext(t)
-			logger := zaptest.NewLogger(t)
 			req := &triggersv1.InterceptorRequest{
 				Body: string(tt.payload),
 				Header: http.Header{
@@ -277,7 +273,6 @@ func TestInterceptor_ExecuteTrigger_ShouldNotContinue(t *testing.T) {
 			}
 			w := &Interceptor{
 				SecretGetter: interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second),
-				Logger:       logger.Sugar(),
 			}
 			res := w.Process(ctx, req)
 			if res.Continue {
@@ -289,11 +284,9 @@ func TestInterceptor_ExecuteTrigger_ShouldNotContinue(t *testing.T) {
 
 func TestInterceptor_Process_InvalidParams(t *testing.T) {
 	ctx, _ := test.SetupFakeContext(t)
-	logger := zaptest.NewLogger(t)
 
 	w := &Interceptor{
 		SecretGetter: interceptors.NewKubeClientSecretGetter(fakekubeclient.Get(ctx).CoreV1(), 1024, 5*time.Second),
-		Logger:       logger.Sugar(),
 	}
 
 	req := &triggersv1.InterceptorRequest{

--- a/pkg/interceptors/interceptors_test.go
+++ b/pkg/interceptors/interceptors_test.go
@@ -26,7 +26,6 @@ import (
 	"net/url"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -38,10 +37,8 @@ import (
 	"go.uber.org/zap/zaptest"
 	"google.golang.org/grpc/codes"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
-	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 )
 
 func TestGetInterceptorParams(t *testing.T) {
@@ -511,45 +508,5 @@ func TestExecute_Error(t *testing.T) {
 				t.Fatalf("Execute() did not get expected error. Response was %+v", got)
 			}
 		})
-	}
-}
-
-func TestCacheSecrets(t *testing.T) {
-	ctx, _ := test.SetupFakeContext(t)
-	_, clientset := fakekubeclient.With(ctx, &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
-			Namespace: "ns",
-		},
-		Data: map[string][]byte{
-			"key": []byte("foobar"),
-		},
-	})
-	getter := interceptors.NewKubeClientSecretGetter(clientset.CoreV1(), 1024, 5*time.Second)
-
-	bin, err := getter.Get(context.Background(), "ns", &triggersv1.SecretRef{
-		SecretKey:  "key",
-		SecretName: "name",
-	})
-	if err != nil {
-		t.Fatalf("Get() unexpected error: %s", err)
-	}
-	if string(bin) != "foobar" {
-		t.Fatalf("Unexpected payload. Got: %s", string(bin))
-	}
-
-	if err := clientset.CoreV1().Secrets("ns").Delete(context.Background(), "name", metav1.DeleteOptions{}); err != nil {
-		t.Fatalf("Cannot delete secret: %s", err)
-	}
-
-	bin, err = getter.Get(context.Background(), "ns", &triggersv1.SecretRef{
-		SecretKey:  "key",
-		SecretName: "name",
-	})
-	if err != nil {
-		t.Fatalf("Get() unexpected error: %s", err)
-	}
-	if string(bin) != "foobar" {
-		t.Fatalf("Unexpected payload. Got: %s", string(bin))
 	}
 }

--- a/pkg/interceptors/secret_getter.go
+++ b/pkg/interceptors/secret_getter.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package interceptors
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	triggersv1beta1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/cache"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+const (
+	// cacheSize is the size of the LRU secrets cache
+	cacheSize = 1024
+	// ttl is the time to live for a cache entry
+	ttl = 5 * time.Second
+)
+
+type SecretGetter interface {
+	Get(ctx context.Context, triggerNS string, sr *triggersv1beta1.SecretRef) ([]byte, error)
+}
+
+type kubeclientSecretGetter struct {
+	getter corev1.SecretsGetter
+	cache  *cache.LRUExpireCache
+	ttl    time.Duration
+}
+
+type cacheKey struct {
+	triggerNS string
+	sr        triggersv1beta1.SecretRef
+}
+
+func DefaultSecretGetter(getter corev1.SecretsGetter) SecretGetter {
+	return &kubeclientSecretGetter{
+		getter: getter,
+		cache:  cache.NewLRUExpireCache(cacheSize),
+		ttl:    ttl,
+	}
+}
+
+// Get queries Kubernetes for the given secret reference. We use this function
+// to resolve secret material like GitHub webhook secrets, and call it once for every
+// trigger that references it.
+//
+// As we may have many triggers that all use the same secret, we cache the secret values
+// in the request cache.
+func (g *kubeclientSecretGetter) Get(ctx context.Context, triggerNS string, sr *triggersv1beta1.SecretRef) ([]byte, error) {
+	key := cacheKey{
+		triggerNS: triggerNS,
+		sr:        *sr,
+	}
+	val, ok := g.cache.Get(key)
+	if ok {
+		return val.([]byte), nil
+	}
+	secret, err := g.getter.Secrets(triggerNS).Get(ctx, sr.SecretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	secretValue, ok := secret.Data[sr.SecretKey]
+	if !ok {
+		return nil, fmt.Errorf("cannot find %s key in secret %s/%s", sr.SecretKey, triggerNS, sr.SecretName)
+	}
+	g.cache.Add(key, secretValue, g.ttl)
+	return secretValue, nil
+}

--- a/pkg/interceptors/secret_getter_test.go
+++ b/pkg/interceptors/secret_getter_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package interceptors_test
+
+import (
+	"context"
+	"testing"
+
+	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
+	"github.com/tektoncd/triggers/pkg/interceptors"
+	"github.com/tektoncd/triggers/test"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
+)
+
+func TestCacheSecrets(t *testing.T) {
+	ctx, _ := test.SetupFakeContext(t)
+	_, clientset := fakekubeclient.With(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "ns",
+		},
+		Data: map[string][]byte{
+			"key": []byte("foobar"),
+		},
+	})
+	getter := interceptors.DefaultSecretGetter(clientset.CoreV1())
+
+	bin, err := getter.Get(context.Background(), "ns", &triggersv1.SecretRef{
+		SecretKey:  "key",
+		SecretName: "name",
+	})
+	if err != nil {
+		t.Fatalf("Get() unexpected error: %s", err)
+	}
+	if string(bin) != "foobar" {
+		t.Fatalf("Unexpected payload. Got: %s", string(bin))
+	}
+
+	if err := clientset.CoreV1().Secrets("ns").Delete(context.Background(), "name", metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("Cannot delete secret: %s", err)
+	}
+
+	bin, err = getter.Get(context.Background(), "ns", &triggersv1.SecretRef{
+		SecretKey:  "key",
+		SecretName: "name",
+	})
+	if err != nil {
+		t.Fatalf("Get() unexpected error: %s", err)
+	}
+	if string(bin) != "foobar" {
+		t.Fatalf("Unexpected payload. Got: %s", string(bin))
+	}
+}

--- a/pkg/interceptors/server/server.go
+++ b/pkg/interceptors/server/server.go
@@ -48,12 +48,12 @@ func (is *Server) RegisterInterceptor(path string, interceptor triggersv1.Interc
 	is.interceptors[path] = interceptor
 }
 
-func NewWithCoreInterceptors(sg interceptors.SecretGetter, l *zap.SugaredLogger) (*Server, error) {
+func NewWithCoreInterceptors(sg interceptors.SecretGetter, logger *zap.SugaredLogger) (*Server, error) {
 	i := map[string]triggersv1.InterceptorInterface{
-		"bitbucket": bitbucket.NewInterceptor(sg, l),
-		"cel":       cel.NewInterceptor(sg, l),
-		"github":    github.NewInterceptor(sg, l),
-		"gitlab":    gitlab.NewInterceptor(sg, l),
+		"bitbucket": bitbucket.NewInterceptor(sg),
+		"cel":       cel.NewInterceptor(sg),
+		"github":    github.NewInterceptor(sg),
+		"gitlab":    gitlab.NewInterceptor(sg),
 	}
 
 	for k, v := range i {
@@ -62,7 +62,7 @@ func NewWithCoreInterceptors(sg interceptors.SecretGetter, l *zap.SugaredLogger)
 		}
 	}
 	s := Server{
-		Logger:       l,
+		Logger:       logger,
 		interceptors: i,
 	}
 	return &s, nil

--- a/pkg/interceptors/server/server_test.go
+++ b/pkg/interceptors/server/server_test.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
@@ -81,7 +80,7 @@ func TestServer_ServeHTTP(t *testing.T) {
 			logger := zaptest.NewLogger(t)
 			ctx, _ := test.SetupFakeContext(t)
 
-			server, err := NewWithCoreInterceptors(interceptors.NewKubeClientSecretGetter(fakekubeclient.Get(ctx).CoreV1(), 1024, 5*time.Second), logger.Sugar())
+			server, err := NewWithCoreInterceptors(interceptors.DefaultSecretGetter(fakekubeclient.Get(ctx).CoreV1()), logger.Sugar())
 			if err != nil {
 				t.Fatalf("error initializing core interceptors: %v", err)
 			}
@@ -140,7 +139,7 @@ func TestServer_ServeHTTP_Error(t *testing.T) {
 			logger := zaptest.NewLogger(t)
 			ctx, _ := test.SetupFakeContext(t)
 
-			server, err := NewWithCoreInterceptors(interceptors.NewKubeClientSecretGetter(fakekubeclient.Get(ctx).CoreV1(), 1024, 5*time.Second), logger.Sugar())
+			server, err := NewWithCoreInterceptors(interceptors.DefaultSecretGetter(fakekubeclient.Get(ctx).CoreV1()), logger.Sugar())
 			if err != nil {
 				t.Fatalf("error initializing core interceptors: %v", err)
 			}
@@ -247,7 +246,7 @@ func Test_UpdateCRDWithCaCert(t *testing.T) {
 	if key == "" && sKey == "" && len(crt) == 0 {
 		t.Error("expected key, server and crt to be created")
 	}
-	server, err := NewWithCoreInterceptors(interceptors.NewKubeClientSecretGetter(fakekubeclient.Get(ctx).CoreV1(), 1024, 5*time.Second), logger.Sugar())
+	server, err := NewWithCoreInterceptors(interceptors.DefaultSecretGetter(fakekubeclient.Get(ctx).CoreV1()), logger.Sugar())
 	if err != nil {
 		t.Fatalf("error initializing core interceptors: %v", err)
 	}

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	cloudeventstest "github.com/cloudevents/sdk-go/v2/client/test"
 	"github.com/google/go-cmp/cmp"
@@ -170,7 +169,7 @@ func getSinkAssets(t *testing.T, res test.Resources, elName string, webhookInter
 func setupInterceptors(t *testing.T, k kubernetes.Interface, l *zap.SugaredLogger, webhookInterceptor http.Handler) *http.Client {
 	t.Helper()
 	// Setup a handler for core interceptors using httptest
-	coreInterceptors, err := server.NewWithCoreInterceptors(interceptors.NewKubeClientSecretGetter(k.CoreV1(), 1024, 5*time.Second), l)
+	coreInterceptors, err := server.NewWithCoreInterceptors(interceptors.DefaultSecretGetter(k.CoreV1()), l)
 	if err != nil {
 		t.Fatalf("failed to initialize core interceptors: %v", err)
 	}


### PR DESCRIPTION
# Changes

This is a refactoring PR that does two things:
1. It removes the unused logger from the core interceptors
2. It adds a DefaultSecretGetter with default values for the cache size and ttl (we were using the same cache args in a bunch of places)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```