### PR TITLE
Fix Knative e2e-tests flakiness & update to v1.6.0

### DIFF
--- a/test/e2e-tests-examples.sh
+++ b/test/e2e-tests-examples.sh
@@ -39,10 +39,13 @@ err() {
 
 install_knative_serving() {
   # Install Knative by referring https://knative.dev/docs/admin/install/serving/install-serving-with-yaml/#install-the-knative-serving-component
-  kubectl apply -f https://github.com/knative/serving/releases/download/v0.26.0/serving-crds.yaml
-  kubectl apply -f https://github.com/knative/serving/releases/download/v0.26.0/serving-core.yaml
+  kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.6.0/serving-crds.yaml
+  kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.6.0/serving-core.yaml
 
-  kubectl apply -f https://github.com/knative/net-kourier/releases/download/v0.26.0/kourier.yaml
+  # Wait for pods to be running in the namespaces we are deploying to
+  wait_until_pods_running knative-serving || fail_test "Knative Serving did not come up"
+
+  kubectl apply -f https://github.com/knative/net-kourier/releases/download/knative-v1.6.0/kourier.yaml
 
   kubectl patch configmap/config-network \
     --namespace knative-serving \
@@ -50,7 +53,7 @@ install_knative_serving() {
     --patch '{"data":{"ingress.class":"kourier.ingress.networking.knative.dev"}}'
 
   # Wait for pods to be running in the namespaces we are deploying to
-  wait_until_pods_running knative-serving || fail_test "Knative Serving did not come up"
+  wait_until_pods_running knative-serving || fail_test "Knative Serving & Kourier did not come up"
   # Changing port of kourier service to use 8888 instead of 80 so that port-forward can be done easily
   # Because with 80 its giving permission deneid and in Knative all traffic goes via gateway which is kourier here.
   kubectl -n kourier-system patch service/kourier --type=json -p="[{"op": "add", "path": "/spec/ports/0/port", "value": $forwardingPort}]"


### PR DESCRIPTION
Added a wait in between installation of serving and kourier to remove flakiness in this test. And also upgraded Knative serving to v1.6.0

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
