### PR TITLE
Update Install instructions for binding-eval tool

### DIFF
--- a/docs/triggerbindings.md
+++ b/docs/triggerbindings.md
@@ -298,7 +298,7 @@ to determine the parameters that Tekton generates from that request when your co
 To install the `binding-eval` tool use the following command:
 
 ```sh
-$ go get -u github.com/tektoncd/triggers/cmd/binding-eval
+$ go install github.com/tektoncd/triggers/cmd/binding-eval@{version}
 ```
 
 Below is an example of using the tool to evaluate a `TriggerBinding`:


### PR DESCRIPTION
`go get` doesn't work with the latest versions of go. We need to use `go install`.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes


```release-note
NONE
```
