### PR TITLE
Move CloudEvent to Stable

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -728,8 +728,6 @@ increased administration overhead.
 
 The [cloud event](https://github.com/cloudevents/spec) that is sent to a target `URI` during Trigger processing. The types of events send for now are:
 
-Cloud Events is currently an `alpha` feature. To use it, you use the v1beta1 API version with the `enable-api-fields`  [feature flag set to `alpha`](./install.md#Customizing-the-Triggers-Controller-behavior).
-
 | Type | Description |
 | ---------- | ----------- |
 | dev.tekton.event.triggers.started.v1 | triggers processing started in eventlistener |

--- a/pkg/apis/triggers/v1beta1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_validation.go
@@ -22,8 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/tektoncd/triggers/pkg/apis/config"
-
 	"github.com/tektoncd/triggers/pkg/apis/triggers"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -86,12 +84,6 @@ func (s *EventListenerSpec) validate(ctx context.Context) (errs *apis.FieldError
 		}
 	}
 
-	if s.CloudEventURI != "" {
-		err := ValidateEnabledAPIFields(ctx, "spec.CloudEventURI", config.AlphaAPIFieldValue)
-		if err != nil {
-			errs = errs.Also(err)
-		}
-	}
 	return errs
 }
 

--- a/pkg/apis/triggers/v1beta1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_validation_test.go
@@ -1215,22 +1215,6 @@ func TestEventListenerValidate_error(t *testing.T) {
 			},
 		},
 		wantErr: apis.ErrMultipleOneOf("spec.triggers[0].template or bindings or interceptors", "spec.triggers[0].triggerRef"),
-	}, {
-		name: "cloudEventURI is not allowed if alpha fields are not enabled",
-		ctx:  context.Background(), // By default, enable-api-felds is set to stable, not alpha
-		el: &triggersv1beta1.EventListener{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
-			Spec: triggersv1beta1.EventListenerSpec{
-				Triggers: []triggersv1beta1.EventListenerTrigger{{
-					TriggerRef: "test",
-				}},
-				CloudEventURI: "http://localhost",
-			},
-		},
-		wantErr: apis.ErrGeneric("spec.CloudEventURI requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
 	},
 		{
 			name: "missing label and namespace selector",


### PR DESCRIPTION
Move CloudEvent to Stable from alpha api.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes


For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
cloudEventURI field can be used in stable APIs now.
```
