### PR TITLE
Prefer SHA256 in Github interceptor

### DIFF
--- a/pkg/interceptors/bitbucket/bitbucket_test.go
+++ b/pkg/interceptors/bitbucket/bitbucket_test.go
@@ -34,7 +34,7 @@ func TestInterceptor_Process_ShouldContinue(t *testing.T) {
 		emptyJSONBody = json.RawMessage(`{}`)
 		secretToken   = "secret"
 	)
-	emptyBodyHMACSignature := test.HMACHeader(t, secretToken, emptyJSONBody)
+	emptyBodyHMACSignature := test.HMACHeader(t, secretToken, emptyJSONBody, "sha1")
 
 	tests := []struct {
 		name              string
@@ -146,7 +146,7 @@ func TestInterceptor_Process_ShouldNotContinue(t *testing.T) {
 		emptyJSONBody = json.RawMessage(`{}`)
 		secretToken   = "secret"
 	)
-	emptyBodyHMACSignature := test.HMACHeader(t, secretToken, emptyJSONBody)
+	emptyBodyHMACSignature := test.HMACHeader(t, secretToken, emptyJSONBody, "sha1")
 
 	tests := []struct {
 		name              string

--- a/pkg/interceptors/github/github.go
+++ b/pkg/interceptors/github/github.go
@@ -73,9 +73,12 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 		if p.SecretRef.SecretKey == "" {
 			return interceptors.Fail(codes.FailedPrecondition, "github interceptor secretRef.secretKey is empty")
 		}
-		header := headers.Get("X-Hub-Signature")
+		header := headers.Get("X-Hub-Signature-256")
 		if header == "" {
-			return interceptors.Fail(codes.FailedPrecondition, "no X-Hub-Signature header set")
+			header = headers.Get("X-Hub-Signature")
+		}
+		if header == "" {
+			return interceptors.Fail(codes.FailedPrecondition, "Must set X-Hub-Signature-256 or X-Hub-Signature header")
 		}
 
 		ns, _ := triggersv1.ParseTriggerID(r.Context.TriggerID)

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -727,7 +727,7 @@ func TestHandleEvent(t *testing.T) {
 		eventBody: eventBody,
 		headers: map[string][]string{
 			"X-GitHub-Event":  {"pull_request"},
-			"X-Hub-Signature": {test.HMACHeader(t, "secret", eventBody)},
+			"X-Hub-Signature": {test.HMACHeader(t, "secret", eventBody, "sha1")},
 		},
 		want: []pipelinev1.TaskRun{gitCloneTaskRun},
 	}, {
@@ -782,7 +782,7 @@ func TestHandleEvent(t *testing.T) {
 		eventBody: eventBody,
 		headers: map[string][]string{
 			"X-Event-Key":     {"repo:refs_changed"},
-			"X-Hub-Signature": {test.HMACHeader(t, "secret", eventBody)},
+			"X-Hub-Signature": {test.HMACHeader(t, "secret", eventBody, "sha1")},
 		},
 		want: []pipelinev1.TaskRun{gitCloneTaskRun},
 	}, {

--- a/test/signature.go
+++ b/test/signature.go
@@ -3,19 +3,27 @@ package test
 import (
 	"crypto/hmac"
 	"crypto/sha1" //nolint
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"hash"
 	"testing"
 )
 
 // HMACHeader generates a X-Hub-Signature header given a secret token and the request body
 // See https://developer.github.com/webhooks/securing/#validating-payloads-from-github
-func HMACHeader(t testing.TB, secret string, body []byte) string {
+// algorithm must be one of (sha1, sha256)
+func HMACHeader(t testing.TB, secret string, body []byte, algorithm string) string {
 	t.Helper()
-	h := hmac.New(sha1.New, []byte(secret))
+	var h hash.Hash
+	if algorithm == "sha1" {
+		h = hmac.New(sha1.New, []byte(secret))
+	} else if algorithm == "sha256" {
+		h = hmac.New(sha256.New, []byte(secret))
+	}
 	_, err := h.Write(body)
 	if err != nil {
 		t.Fatalf("HMACHeader fail: %s", err)
 	}
-	return fmt.Sprintf("sha1=%s", hex.EncodeToString(h.Sum(nil)))
+	return fmt.Sprintf("%s=%s", algorithm, hex.EncodeToString(h.Sum(nil)))
 }

--- a/test/signature_test.go
+++ b/test/signature_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestHMACHeader(t *testing.T) {
-	got := test.HMACHeader(t, "secret", json.RawMessage(`{}`))
+	got := test.HMACHeader(t, "secret", json.RawMessage(`{}`), "sha1")
 	// Generated from https://play.golang.org/p/OlkBawQQPiJ
 	want := "sha1=5d61605c3feea9799210ddcb71307d4ba264225f"
 	if want != got {


### PR DESCRIPTION
# Changes
Github webhooks send both a X-Hub-Signature header (which uses SHA1)
and a X-Hub-Signature-256 header (which uses SHA256).
Since SHA256 is more secure than SHA1, we should prefer using that to verify
the signature.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Prefer SHA256 for validation of Github payloads
```
