### PR TITLE
Deprecate Trigger as well as Namespace-Selector in EventListener Spec

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -414,6 +414,7 @@ If you want your `EventListener` to recognize `Triggers` across your entire clus
     matchNames:
     - "*"
 ```
+At present, if an EventListeners has `Triggers` inside its own spec as well as `namespace-selector`, `Triggers` in spec as well as in selected namespaces will be processed for a request. `Triggers` inside EventListener spec when using `namespace-selector` mode is deprecated and ability to specify both will be removed.
 
 ## Constraining `EventListeners` to specific labels
 


### PR DESCRIPTION
Deprecate having Trigger as well as Namespace-Selector in EventListener Spec
at the same time. Removing this will resolve #1400

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Deprecation Warning: Having both Triggers as well as Namespace-Selector in EventListener Spec is deprecated.
```
