### PR TITLE
Disable stack traces in error logs

### DIFF
--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -26,6 +26,7 @@ data:
     {
       "level": "info",
       "development": false,
+      "disableStacktrace": true,
       "sampling": {
         "initial": 100,
         "thereafter": 100


### PR DESCRIPTION

# Changes

For the vast majority of errors (e.g. missing roles, invalid format), this just adds extra junk while burying the actual error message. The log line still contains the function file name and line number for debugging purposes.

See https://pkg.go.dev/go.uber.org/zap#Config

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
EventListener error logs will no longer contain a stacktrace as part of the structured log by default.
```
