### PR TITLE
Fix tkn command in troubleshooting

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -14,7 +14,7 @@ You can gather `EventListener` logs using the Tekton `tkn` CLI tool or the Kuber
 Use the following `tkn` command to gather `EventListener` logs:
 
 ```shell
-$ tkn eventlistener logs
+$ tkn eventlistener logs <eventlistener-name>
 ```
 See the `tkn` CLI tool [documentation page](https://github.com/tektoncd/cli/blob/main/docs/cmd/tkn_eventlistener_logs.md) for this config for more information.
 


### PR DESCRIPTION
# Changes
The existing tkn command for eventlistener logs does not work
(error message "Error: accepts 1 arg(s), received 0").
This commit updates the logs command to show correct example usage.

/kind documentation

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- n/a Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
