### PR TITLE
Document that examples expect default namespace

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -12,8 +12,18 @@ To run the examples, you need the following pre-requisites:
 
 1. Ensure you have Tekton Pipelines [installed](https://github.com/tektoncd/pipeline/blob/master/docs/install.md)
 
-2. Create the service account and all associated roles and bindings by running `kubectl apply -f rbac.yaml`
+2. Create the service account and all associated roles and bindings by running `kubectl apply -f rbac.yaml`.
 
+**Note**: `rbac.yaml` assumes that examples are running in the default namespace. If you would like to run examples
+in a different namespace, edit the `triggers-example-eventlistener-clusterbinding` ClusterRoleBinding to refer to
+the namespace where you've deployed the service account, for example:
+
+```yaml
+subjects:
+- kind: ServiceAccount
+  name: tekton-triggers-example-sa
+  namespace: my-favorite-namespace
+```
 
 ## Creating Triggers Resources
 


### PR DESCRIPTION
# Changes
Triggers examples will not work correctly if deployed to a namespace
other than the default namespace. Ideally, the examples would work without
modification when deployed to any namespace. This commit updates the examples
README to explain how to modify the examples for a different namespace.

/kind documentation

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- n/a Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
