### PR TITLE
Add Nil Check for context in the core interceptors

### DIFF
--- a/pkg/interceptors/bitbucket/bitbucket.go
+++ b/pkg/interceptors/bitbucket/bitbucket.go
@@ -71,6 +71,11 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 		if header == "" {
 			return interceptors.Fail(codes.InvalidArgument, "no X-Hub-Signature header set")
 		}
+
+		if r.Context == nil {
+			return interceptors.Failf(codes.InvalidArgument, "no request context passed")
+		}
+
 		ns, _ := triggersv1.ParseTriggerID(r.Context.TriggerID)
 		secretToken, err := w.SecretGetter.Get(ctx, ns, p.SecretRef)
 		if err != nil {

--- a/pkg/interceptors/cel/cel.go
+++ b/pkg/interceptors/cel/cel.go
@@ -120,6 +120,10 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 		return interceptors.Failf(codes.InvalidArgument, "failed to parse interceptor params: %v", err)
 	}
 
+	if r.Context == nil {
+		return interceptors.Failf(codes.InvalidArgument, "no request context passed")
+	}
+
 	ns, _ := triggersv1.ParseTriggerID(r.Context.TriggerID)
 	env, err := makeCelEnv(ctx, ns, w.SecretGetter)
 	if err != nil {

--- a/pkg/interceptors/github/github.go
+++ b/pkg/interceptors/github/github.go
@@ -81,6 +81,10 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 			return interceptors.Fail(codes.FailedPrecondition, "Must set X-Hub-Signature-256 or X-Hub-Signature header")
 		}
 
+		if r.Context == nil {
+			return interceptors.Failf(codes.InvalidArgument, "no request context passed")
+		}
+
 		ns, _ := triggersv1.ParseTriggerID(r.Context.TriggerID)
 		secretToken, err := w.SecretGetter.Get(ctx, ns, p.SecretRef)
 		if err != nil {

--- a/pkg/interceptors/gitlab/gitlab.go
+++ b/pkg/interceptors/gitlab/gitlab.go
@@ -71,6 +71,10 @@ func (w *Interceptor) Process(ctx context.Context, r *triggersv1.InterceptorRequ
 			return interceptors.Fail(codes.InvalidArgument, "no X-GitLab-Token header set")
 		}
 
+		if r.Context == nil {
+			return interceptors.Failf(codes.InvalidArgument, "no request context passed")
+		}
+
 		ns, _ := triggersv1.ParseTriggerID(r.Context.TriggerID)
 		secretToken, err := w.SecretGetter.Get(ctx, ns, p.SecretRef)
 		if err != nil {


### PR DESCRIPTION
Add Nil Check for context in the core interceptors. While this security vulnerability doesn't affect Triggers in End to End scenario because we explicitly set the context and then make a request.
Fixes #1431 
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes


```release-note
NONE
```
