### PR TITLE
Fix the sink timeout warning

### DIFF
--- a/pkg/reconciler/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/eventlistener/eventlistener_test.go
@@ -260,6 +260,9 @@ func makeDeployment(ops ...func(d *appsv1.Deployment)) *appsv1.Deployment {
 							Name:  "EL_EVENT",
 							Value: "disable",
 						}, {
+							Name:  "K_SINK_TIMEOUT",
+							Value: strconv.FormatInt(resources.DefaultTimeOutHandler, 10),
+						}, {
 							Name: "SYSTEM_NAMESPACE",
 							ValueFrom: &corev1.EnvVarSource{
 								FieldRef: &corev1.ObjectFieldSelector{
@@ -409,6 +412,9 @@ func makeWithPod(ops ...func(d *duckv1.WithPod)) *duckv1.WithPod {
 						}, {
 							Name:  "EL_EVENT",
 							Value: "disable",
+						}, {
+							Name:  "K_SINK_TIMEOUT",
+							Value: strconv.FormatInt(resources.DefaultTimeOutHandler, 10),
 						}, {
 							Name:  "SYSTEM_NAMESPACE",
 							Value: namespace,
@@ -881,6 +887,9 @@ func TestReconcile(t *testing.T) {
 			Name:  "EL_EVENT",
 			Value: "enable",
 		}, {
+			Name:  "K_SINK_TIMEOUT",
+			Value: strconv.FormatInt(resources.DefaultTimeOutHandler, 10),
+		}, {
 			Name: "SYSTEM_NAMESPACE",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
@@ -952,6 +961,9 @@ func TestReconcile(t *testing.T) {
 		}, {
 			Name:  "EL_EVENT",
 			Value: "disable",
+		}, {
+			Name:  "K_SINK_TIMEOUT",
+			Value: strconv.FormatInt(resources.DefaultTimeOutHandler, 10),
 		}, {
 			Name: "key",
 			ValueFrom: &corev1.EnvVarSource{

--- a/pkg/reconciler/eventlistener/resources/container.go
+++ b/pkg/reconciler/eventlistener/resources/container.go
@@ -75,6 +75,9 @@ func MakeContainer(el *v1beta1.EventListener, configAcc reconcilersource.ConfigA
 		}, {
 			Name:  "EL_EVENT",
 			Value: *c.SetEventListenerEvent,
+		}, {
+			Name:  "K_SINK_TIMEOUT",
+			Value: strconv.FormatInt(*c.TimeOutHandler, 10),
 		}}...),
 	}
 

--- a/pkg/reconciler/eventlistener/resources/container_test.go
+++ b/pkg/reconciler/eventlistener/resources/container_test.go
@@ -78,6 +78,9 @@ func TestContainer(t *testing.T) {
 			}, {
 				Name:  "EL_EVENT",
 				Value: "disable",
+			}, {
+				Name:  "K_SINK_TIMEOUT",
+				Value: strconv.FormatInt(DefaultTimeOutHandler, 10),
 			}},
 		},
 	}, {
@@ -136,6 +139,9 @@ func TestContainer(t *testing.T) {
 			}, {
 				Name:  "EL_EVENT",
 				Value: "disable",
+			}, {
+				Name:  "K_SINK_TIMEOUT",
+				Value: strconv.FormatInt(DefaultTimeOutHandler, 10),
 			}},
 		},
 	}, {
@@ -222,6 +228,9 @@ func TestContainer(t *testing.T) {
 			}, {
 				Name:  "EL_EVENT",
 				Value: "disable",
+			}, {
+				Name:  "K_SINK_TIMEOUT",
+				Value: strconv.FormatInt(DefaultTimeOutHandler, 10),
 			}},
 		},
 	}, {
@@ -270,6 +279,9 @@ func TestContainer(t *testing.T) {
 			}, {
 				Name:  "EL_EVENT",
 				Value: "disable",
+			}, {
+				Name:  "K_SINK_TIMEOUT",
+				Value: strconv.FormatInt(DefaultTimeOutHandler, 10),
 			}},
 		},
 	}}

--- a/pkg/reconciler/eventlistener/resources/custom_test.go
+++ b/pkg/reconciler/eventlistener/resources/custom_test.go
@@ -99,6 +99,10 @@ func TestCustomObject(t *testing.T) {
 			"name":  "EL_EVENT",
 			"value": "disable",
 		},
+		map[string]interface{}{
+			"name":  "K_SINK_TIMEOUT",
+			"value": strconv.FormatInt(DefaultTimeOutHandler, 10),
+		},
 	}
 
 	customEnv := []interface{}{


### PR DESCRIPTION
We don't use sink timeout but EL logs has sink timeout warning. Setting this to timeouthandler's value to avoid emitting this error.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes


```release-note
NONE
```
