### PR TITLE
Add temporary GOPATH script for codegen

### DIFF
--- a/hack/setup-temporary-gopath.sh
+++ b/hack/setup-temporary-gopath.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+# Conditionally create a temporary GOPATH for codegen
+# and openapigen to execute in. This is only done if
+# the current repo directory is not within GOPATH.
+function shim_gopath() {
+  local REPO_DIR=$(git rev-parse --show-toplevel)
+  local TEMP_GOPATH="${REPO_DIR}/.gopath"
+  local TEMP_TEKTONCD="${TEMP_GOPATH}/src/github.com/tektoncd"
+  local TEMP_TRIGGERS="${TEMP_TEKTONCD}/triggers"
+  local NEEDS_MOVE=1
+
+  # Checks if GOPATH exists without triggering nounset panic.
+  EXISTING_GOPATH=${GOPATH:-}
+
+  # Check if repo is in GOPATH already and return early if so.
+  # Unfortunately this doesn't respect a repo that's symlinked into
+  # GOPATH and will create a temporary anyway. I couldn't figure out
+  # a way to get the absolute path to the symlinked repo root.
+  if [ ! -z $EXISTING_GOPATH ] ; then
+    case $REPO_DIR/ in
+      $EXISTING_GOPATH/*) NEEDS_MOVE=0;;
+      *) NEEDS_MOVE=1;;
+    esac
+  fi
+
+  if [ $NEEDS_MOVE -eq 0 ]; then
+    return
+  fi
+
+  echo "You appear to be running from outside of GOPATH."
+  echo "This script will create a temporary GOPATH at $TEMP_GOPATH for code generation."
+
+  # Ensure that the temporary triggers symlink doesn't exist
+  # before proceeding.
+  delete_triggers_repo_symlink
+
+  mkdir -p "$TEMP_TEKTONCD"
+  # This will create a symlink from
+  # (repo-root)/.gopath/src/github.com/tektoncd/triggers
+  # to the user's triggers checkout.
+  ln -s "$REPO_DIR" "$TEMP_TRIGGERS"
+  echo "Moving to $TEMP_TRIGGERS"
+  cd "$TEMP_TRIGGERS"
+  export GOPATH="$TEMP_GOPATH"
+}
+
+# Helper that wraps deleting the temp triggers repo symlink
+# and prints a message about deleting the temp GOPATH.
+#
+# Why doesn't this func just delete the temp GOPATH outright?
+# Because it might be reused across multiple hack scripts and many
+# packages seem to be installed into GOPATH with read-only
+# permissions, requiring sudo to delete the directory. Rather
+# than surprise the dev with a password entry at the end of the
+# script's execution we just print a message to let them know.
+function shim_gopath_clean() {
+  local REPO_DIR=$(git rev-parse --show-toplevel)
+  local TEMP_GOPATH="${REPO_DIR}/.gopath"
+  if [ -d "$TEMP_GOPATH" ] ; then
+    # Put the user back at the root of the triggers repo
+    # after all the symlink shenanigans.
+    echo "Moving to $REPO_DIR"
+    cd "$REPO_DIR"
+    delete_triggers_repo_symlink
+    echo "When you are finished with codegen you can safely run the following:"
+    echo "sudo rm -rf \".gopath\""
+   fi
+}
+
+# Delete the temp symlink to triggers repo from the temp GOPATH dir.
+function delete_triggers_repo_symlink() {
+  local REPO_DIR=$(git rev-parse --show-toplevel)
+  local TEMP_GOPATH="${REPO_DIR}/.gopath"
+  if [ -d "$TEMP_GOPATH" ] ; then
+    local REPO_SYMLINK="${TEMP_GOPATH}/src/github.com/tektoncd/triggers"
+    if [ -L $REPO_SYMLINK ] ; then
+      echo "Deleting symlink to triggers repo $REPO_SYMLINK"
+      rm -f "${REPO_SYMLINK}"
+    fi
+  fi
+}

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -18,6 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+source $(git rev-parse --show-toplevel)/hack/setup-temporary-gopath.sh
+shim_gopath
+trap shim_gopath_clean EXIT
+
 source $(git rev-parse --show-toplevel)/vendor/github.com/tektoncd/plumbing/scripts/library.sh
 
 PREFIX=${GOBIN:-${GOPATH}/bin}

--- a/hack/update-openapigen.sh
+++ b/hack/update-openapigen.sh
@@ -17,6 +17,10 @@
 set -o errexit
 set -o nounset
 
+source $(git rev-parse --show-toplevel)/hack/setup-temporary-gopath.sh
+shim_gopath
+trap shim_gopath_clean EXIT
+
 source $(git rev-parse --show-toplevel)/vendor/github.com/tektoncd/plumbing/scripts/library.sh
 
 cd "${REPO_ROOT_DIR}"


### PR DESCRIPTION
# Changes
This commit copies the "setup-temporary-gopath.sh" script from Pipelines,
to allow running codegen scripts when your GOPATH isn't set or is different
from the repo root.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- n/a Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- n/a Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
