### PR TITLE
Allow trigger eventID to be used as input to TriggerBinding

### DIFF
--- a/cmd/binding-eval/cmd/root.go
+++ b/cmd/binding-eval/cmd/root.go
@@ -80,7 +80,7 @@ func evalBinding(w io.Writer, bindingPath, httpPath string) error {
 		BindingParams: bindingParams,
 	}
 
-	params, err := template.ResolveParams(t, body, r.Header, map[string]interface{}{})
+	params, err := template.ResolveParams(t, body, r.Header, map[string]interface{}{}, template.NewTriggerContext(""))
 	if err != nil {
 		return fmt.Errorf("error resolving params: %w", err)
 	}

--- a/cmd/triggerrun/cmd/root.go
+++ b/cmd/triggerrun/cmd/root.go
@@ -230,7 +230,7 @@ func processTriggerSpec(kubeClient kubernetes.Interface, client triggersclientse
 	if iresp != nil && iresp.Extensions != nil {
 		extensions = iresp.Extensions
 	}
-	params, err := template.ResolveParams(rt, finalPayload, header, extensions)
+	params, err := template.ResolveParams(rt, finalPayload, header, extensions, template.NewTriggerContext(eventID))
 	if err != nil {
 		log.Error("Failed to resolve parameters", err)
 		return nil, err

--- a/docs/triggerbindings.md
+++ b/docs/triggerbindings.md
@@ -185,6 +185,17 @@ spec:
     ref: git-clone-template
 ```
 
+## Accessing EventListener Event Context
+
+The EventListener has a set of internal data points that are maintained for the complete processing
+of a single event. These values are available for use in `TriggerBinding` objects.
+
+This data can be accessed on the `context` parameter, as an example:
+
+```shell
+$(context.eventID) # access the internal eventID of the request
+```
+
 ## Accessing JSON keys containing periods (`.`)
 
 To access a JSON key that contains a period (`.`), you must escape the period with a backslash (`\.`). For example:

--- a/pkg/sink/sink.go
+++ b/pkg/sink/sink.go
@@ -400,7 +400,7 @@ func (r Sink) processTrigger(t triggersv1.Trigger, el *triggersv1.EventListener,
 	if iresp != nil && iresp.Extensions != nil {
 		extensions = iresp.Extensions
 	}
-	params, err := template.ResolveParams(rt, finalPayload, header, extensions)
+	params, err := template.ResolveParams(rt, finalPayload, header, extensions, template.NewTriggerContext(eventID))
 	if err != nil {
 		log.Error(err)
 		return


### PR DESCRIPTION
Resolves #1427

# Changes

Propagate eventID into the TriggerBinding evaluation to allow this value to be used in bindings. Adds TriggerContext object to template package to allow future additions to this data if other inputs are desired.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Add eventID as input to TriggerBinding
```
