### PR TITLE
Skip webhook validation on delete for v1beta1

### DIFF
--- a/docs/triggers-api.md
+++ b/docs/triggers-api.md
@@ -1,11 +1,3 @@
-<!--
----
-title: Triggers API
-linkTitle: Triggers API
-weight: 1000
----
--->
-
 <p>Packages:</p>
 <ul>
 <li>

--- a/pkg/apis/triggers/v1beta1/cluster_trigger_binding_validation.go
+++ b/pkg/apis/triggers/v1beta1/cluster_trigger_binding_validation.go
@@ -20,13 +20,19 @@ import (
 	"context"
 
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/webhook/resourcesemantics"
 )
 
+var _ resourcesemantics.VerbLimited = (*ClusterTriggerBinding)(nil)
+
+// SupportedVerbs returns the operations that validation should be called for
+func (ctb *ClusterTriggerBinding) SupportedVerbs() []admissionregistrationv1.OperationType {
+	return []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update}
+}
+
 func (ctb *ClusterTriggerBinding) Validate(ctx context.Context) *apis.FieldError {
-	if apis.IsInDelete(ctx) {
-		return nil
-	}
 	if err := validate.ObjectMetadata(ctb.GetObjectMeta()); err != nil {
 		return err.ViaField("metadata")
 	}

--- a/pkg/apis/triggers/v1beta1/cluster_trigger_binding_validation_test.go
+++ b/pkg/apis/triggers/v1beta1/cluster_trigger_binding_validation_test.go
@@ -18,34 +18,11 @@ package v1beta1_test
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/apis"
 )
-
-func Test_ClusterTriggerBindingValidate_OnDelete(t *testing.T) {
-	tb := &v1beta1.ClusterTriggerBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: strings.Repeat("foo", 64), // Length should be lower than 63
-		},
-		Spec: v1beta1.TriggerBindingSpec{
-			Params: []v1beta1.Param{{
-				Name:  "param1",
-				Value: "$(body.input1)",
-			}, {
-				Name:  "param2",
-				Value: "$(body.input2)",
-			}},
-		},
-	}
-	err := tb.Validate(apis.WithinDelete(context.Background()))
-	if err != nil {
-		t.Errorf("TriggerBinding.Validate() on Delete expected no error, but got one, TriggerBinding: %v, error: %v", tb, err)
-	}
-}
 
 func Test_ClusterTriggerBindingValidate(t *testing.T) {
 	tests := []struct {

--- a/pkg/apis/triggers/v1beta1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_validation.go
@@ -23,11 +23,13 @@ import (
 	"fmt"
 
 	"github.com/tektoncd/triggers/pkg/apis/triggers"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/webhook/resourcesemantics"
 )
 
 var (
@@ -37,12 +39,15 @@ var (
 	)
 )
 
+var _ resourcesemantics.VerbLimited = (*EventListener)(nil)
+
+// SupportedVerbs returns the operations that validation should be called for
+func (e *EventListener) SupportedVerbs() []admissionregistrationv1.OperationType {
+	return []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update}
+}
+
 // Validate EventListener.
 func (e *EventListener) Validate(ctx context.Context) *apis.FieldError {
-	if apis.IsInDelete(ctx) {
-		return nil
-	}
-
 	var errs *apis.FieldError
 	if len(e.ObjectMeta.Name) > 60 {
 		// Since `el-` is added as the prefix of EventListener services, the name of EventListener must be no more than 60 characters long.

--- a/pkg/apis/triggers/v1beta1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_validation_test.go
@@ -18,7 +18,6 @@ package v1beta1_test
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -38,26 +37,6 @@ import (
 var myObjectMeta = metav1.ObjectMeta{
 	Name:      "name",
 	Namespace: "namespace",
-}
-
-func Test_EventListenerValidate_OnDelete(t *testing.T) {
-	el := &triggersv1beta1.EventListener{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      strings.Repeat("foo", 64), // Length should be lower than 63
-			Namespace: "namespace",
-		},
-		Spec: triggersv1beta1.EventListenerSpec{
-			Triggers: []triggersv1beta1.EventListenerTrigger{{
-				Template: &triggersv1beta1.EventListenerTemplate{
-					Ref: ptr.String(""),
-				},
-			}},
-		},
-	}
-	err := el.Validate(apis.WithinDelete(context.Background()))
-	if err != nil {
-		t.Errorf("EventListener.Validate() on Delete expected no error, but got one, EventListener: %v, error: %v", el, err)
-	}
 }
 
 func Test_EventListenerValidate(t *testing.T) {

--- a/pkg/apis/triggers/v1beta1/trigger_binding_validation.go
+++ b/pkg/apis/triggers/v1beta1/trigger_binding_validation.go
@@ -22,17 +22,22 @@ import (
 	"strings"
 
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/webhook/resourcesemantics"
 )
+
+var _ resourcesemantics.VerbLimited = (*TriggerBinding)(nil)
+
+// SupportedVerbs returns the operations that validation should be called for
+func (tb *TriggerBinding) SupportedVerbs() []admissionregistrationv1.OperationType {
+	return []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update}
+}
 
 // Validate TriggerBinding.
 func (tb *TriggerBinding) Validate(ctx context.Context) *apis.FieldError {
-	if apis.IsInDelete(ctx) {
-		return nil
-	}
-
 	errs := validate.ObjectMetadata(tb.GetObjectMeta()).ViaField("metadata")
 	return errs.Also(tb.Spec.Validate(ctx).ViaField("spec"))
 }

--- a/pkg/apis/triggers/v1beta1/trigger_binding_validation_test.go
+++ b/pkg/apis/triggers/v1beta1/trigger_binding_validation_test.go
@@ -18,36 +18,12 @@ package v1beta1_test
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/apis"
 )
-
-func Test_TriggerBindingValidate_OnDelete(t *testing.T) {
-	tb := &v1beta1.TriggerBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      strings.Repeat("foo", 64), // Length should be lower than 63
-			Namespace: "namespace",
-		},
-		Spec: v1beta1.TriggerBindingSpec{
-			Params: []v1beta1.Param{{
-				Name:  "param1",
-				Value: "$(body.input1)",
-			}, {
-				Name:  "param1",
-				Value: "$(body.input2)",
-			}},
-		},
-	}
-	err := tb.Validate(apis.WithinDelete(context.Background()))
-	if err != nil {
-		t.Errorf("TriggerBinding.Validate() on Delete expected no error, but got one, TriggerBinding: %v, error: %v", tb, err)
-	}
-}
 
 func Test_TriggerBindingValidate(t *testing.T) {
 	tests := []struct {

--- a/pkg/apis/triggers/v1beta1/trigger_template_validation_test.go
+++ b/pkg/apis/triggers/v1beta1/trigger_template_validation_test.go
@@ -18,7 +18,6 @@ package v1beta1_test
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	pipelinev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -98,26 +97,6 @@ func invalidParamResourceTemplate(t *testing.T) runtime.RawExtension {
 			},
 		},
 	})
-}
-
-func TestTriggerTemplate_Validate_OnDelete(t *testing.T) {
-	tt := &v1beta1.TriggerTemplate{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      strings.Repeat("foo", 64), // Length should be lower than 63
-			Namespace: "foo",
-		},
-		Spec: v1beta1.TriggerTemplateSpec{
-			Params: []v1beta1.ParamSpec{{
-				Name:        "foo",
-				Description: "desc",
-				Default:     ptr.String("val"),
-			}},
-		},
-	}
-	err := tt.Validate(apis.WithinDelete(context.Background()))
-	if err != nil {
-		t.Errorf("TriggerTemplate.Validate() on Delete expected no error, but got one, TriggerTemplate: %v, error: %v", tt, err)
-	}
 }
 
 func TestTriggerTemplate_Validate(t *testing.T) {

--- a/pkg/apis/triggers/v1beta1/trigger_validation.go
+++ b/pkg/apis/triggers/v1beta1/trigger_validation.go
@@ -23,15 +23,20 @@ import (
 
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/webhook/resourcesemantics"
 )
+
+var _ resourcesemantics.VerbLimited = (*Trigger)(nil)
+
+// SupportedVerbs returns the operations that validation should be called for
+func (t *Trigger) SupportedVerbs() []admissionregistrationv1.OperationType {
+	return []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update}
+}
 
 // Validate validates a Trigger
 func (t *Trigger) Validate(ctx context.Context) *apis.FieldError {
-	if apis.IsInDelete(ctx) {
-		return nil
-	}
-
 	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
 	return errs.Also(t.Spec.validate(ctx).ViaField("spec"))
 }

--- a/pkg/apis/triggers/v1beta1/trigger_validation_test.go
+++ b/pkg/apis/triggers/v1beta1/trigger_validation_test.go
@@ -18,34 +18,14 @@ package v1beta1_test
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
 )
-
-func Test_TriggerValidate_OnDelete(t *testing.T) {
-	tr := &v1beta1.Trigger{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      strings.Repeat("foo", 64), // Length should be lower than 63
-			Namespace: "namespace",
-		},
-		Spec: v1beta1.TriggerSpec{
-			// Binding with no spec is invalid, but shouldn't block the delete
-			Bindings: []*v1beta1.TriggerSpecBinding{{Name: "", Kind: v1beta1.NamespacedTriggerBindingKind, Ref: "", APIVersion: "v1beta1"}},
-			Template: v1beta1.TriggerSpecTemplate{Ref: ptr.String("tt")},
-		},
-	}
-	err := tr.Validate(apis.WithinDelete(context.Background()))
-	if err != nil {
-		t.Errorf("Trigger.Validate() on Delete expected no error, but got one, Trigger: %v, error: %v", tr, err)
-	}
-}
 
 func Test_TriggerValidate(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
# Changes
This commit implements SupportedVerbs for each Triggers API type, specifying which API operations validation should be performed for. Instead of Knative's default (create, update, and delete), this commit updates validation to be performed only for create and update. This allows resources to be deleted from the cluster even if they are no longer valid.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- n/a Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Resource validation is skipped on deletion
```
