### PR TITLE
Make the webhook port number configurable

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -134,7 +134,7 @@ func main() {
 	// Set up a signal context with our webhook options
 	ctx := webhook.WithOptions(signals.NewContext(), webhook.Options{
 		ServiceName: serviceName,
-		Port:        8443,
+		Port:        webhook.PortFromEnv(8443),
 		SecretName:  secretName,
 	})
 


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Previously the webhook listened on a fixed port, 8443, which is
likely to clash with other services when the webhook is run on the
host network in Kubernetes, which is required when using some CNI
implementations, notably Calico on EKS [1].

Enable configuration of the webhook listen port through the environment
variable WEBHOOK_PORT by using the existing API from the KNative SDK.

[1] https://projectcalico.docs.tigera.io/getting-started/kubernetes/managed-public-cloud/eks#install-eks-with-calico-networking

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
The port on which the webhook server listens may be configured via the WEBHOOK_PORT environment variable.
```
