### PR TITLE
Modify e2e test scripts to support running on kind

### DIFF
--- a/test/e2e-tests-kind-prow.env
+++ b/test/e2e-tests-kind-prow.env
@@ -1,0 +1,2 @@
+SKIP_INITIALIZE=true
+KO_DOCKER_REPO=registry.local:5000

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -20,8 +20,14 @@
 source $(dirname $0)/e2e-common.sh
 # Script entry point.
 
-initialize $@
+# Setting defaults
 failed=0
+SKIP_INITIALIZE=${SKIP_INITIALIZE:="false"}
+
+
+if [ "${SKIP_INITIALIZE}" != "true" ]; then
+  initialize $@
+fi
 
 header "Setting up environment"
 install_pipeline_crd


### PR DESCRIPTION

# Changes

In our Prow based CI environment, the e2e tests currently run on GKE clusters provisioned using Boskos. This change enables them to run against a kind cluster following the steps outlined in
https://github.com/tektoncd/plumbing/blob/main/docs/kind-e2e.md

Part of #1475


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
