### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -81,12 +80,8 @@ func TestGetFeatureFlagsConfigName(t *testing.T) {
 		expected:            "feature-flags-test",
 	}} {
 		t.Run(tc.description, func(t *testing.T) {
-			original := os.Getenv("CONFIG_FEATURE_FLAGS_NAME")
-			defer t.Cleanup(func() {
-				os.Setenv("CONFIG_FEATURE_FLAGS_NAME", original)
-			})
 			if tc.featureFlagEnvValue != "" {
-				os.Setenv("CONFIG_FEATURE_FLAGS_NAME", tc.featureFlagEnvValue)
+				t.Setenv("CONFIG_FEATURE_FLAGS_NAME", tc.featureFlagEnvValue)
 			}
 			got := config.GetFeatureFlagsConfigName()
 			want := tc.expected

--- a/pkg/interceptors/server/server_test.go
+++ b/pkg/interceptors/server/server_test.go
@@ -215,15 +215,9 @@ func Test_SecretNotExist(t *testing.T) {
 }
 
 func createSecret(t *testing.T, noAfter time.Time) (v1.CoreV1Interface, []byte, []byte, error) {
-	if err := os.Setenv(interceptorTLSSvcKey, testsvc); err != nil {
-		return nil, []byte{}, []byte{}, err
-	}
-	if err := os.Setenv(interceptorTLSSecretKey, testsecrets); err != nil {
-		return nil, []byte{}, []byte{}, err
-	}
-	if err := os.Setenv("SYSTEM_NAMESPACE", testns); err != nil {
-		return nil, []byte{}, []byte{}, err
-	}
+	t.Setenv(interceptorTLSSvcKey, testsvc)
+	t.Setenv(interceptorTLSSecretKey, testsecrets)
+	t.Setenv("SYSTEM_NAMESPACE", testns)
 	namespace := system.Namespace()
 
 	logger := zaptest.NewLogger(t)
@@ -299,9 +293,7 @@ func Test_CreateAndValidateCerts(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	clientSet := fakekubeclient.Get(ctx).CoreV1()
 	tc := faketriggersclient.Get(ctx)
-	if err := os.Setenv(interceptorTLSSecretKey, testsecrets); err != nil {
-		t.Error(err)
-	}
+	t.Setenv(interceptorTLSSecretKey, testsecrets)
 
 	createSecretWithData(ctx, t, clientSet)
 
@@ -376,9 +368,7 @@ func Test_GetTLSData(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := os.Setenv(interceptorTLSSecretKey, tc.secretName); err != nil {
-				t.Error(err)
-			}
+			t.Setenv(interceptorTLSSecretKey, tc.secretName)
 			if err := clientSet.Secrets(namespace).Delete(ctx, tc.secretName, metav1.DeleteOptions{}); err != nil && !apiErrors.IsNotFound(err) {
 				t.Error(err)
 			}
@@ -411,9 +401,7 @@ func Test_UpdateCACertToClusterInterceptorCRD(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	secretInformer := fakesecretinformer.Get(ctx)
 	clientSet := fakekubeclient.Get(ctx).CoreV1()
-	if err := os.Setenv(interceptorTLSSecretKey, testsecrets); err != nil {
-		t.Error(err)
-	}
+	t.Setenv(interceptorTLSSecretKey, testsecrets)
 
 	s := createSecretWithData(ctx, t, clientSet)
 	if err := secretInformer.Informer().GetIndexer().Add(s); err != nil {
@@ -439,12 +427,8 @@ func Test_UpdateCACertToClusterInterceptorCRD(t *testing.T) {
 }
 
 func getCerts(ctx context.Context, t *testing.T) ([]byte, []byte, []byte, string) {
-	if err := os.Setenv(interceptorTLSSvcKey, testsvc); err != nil {
-		t.Error(err)
-	}
-	if err := os.Setenv("SYSTEM_NAMESPACE", testns); err != nil {
-		t.Error(err)
-	}
+	t.Setenv(interceptorTLSSvcKey, testsvc)
+	t.Setenv("SYSTEM_NAMESPACE", testns)
 	namespace := system.Namespace()
 
 	serverKey, serverCert, caCert, err := certresources.CreateCerts(ctx, os.Getenv(interceptorTLSSvcKey), namespace, time.Now().Add(second))

--- a/pkg/reconciler/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/eventlistener/eventlistener_test.go
@@ -19,7 +19,6 @@ package eventlistener
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -557,14 +556,8 @@ func withDeletionTimestamp(el *v1beta1.EventListener) {
 }
 
 func TestReconcile(t *testing.T) {
-	err := os.Setenv("METRICS_PROMETHEUS_PORT", "9000")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = os.Setenv("SYSTEM_NAMESPACE", "tekton-pipelines")
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv("METRICS_PROMETHEUS_PORT", "9000")
+	t.Setenv("SYSTEM_NAMESPACE", "tekton-pipelines")
 
 	customPort := 80
 
@@ -1490,10 +1483,7 @@ func TestReconcile(t *testing.T) {
 }
 
 func TestReconcile_InvalidForCustomResource(t *testing.T) {
-	err := os.Setenv("SYSTEM_NAMESPACE", "tekton-pipelines")
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv("SYSTEM_NAMESPACE", "tekton-pipelines")
 
 	elWithCustomResource := makeEL(withStatus, withKnativeStatus, func(el *v1beta1.EventListener) {
 		el.Spec.Resources.CustomResource = &v1beta1.CustomResource{

--- a/pkg/reconciler/eventlistener/resources/custom_test.go
+++ b/pkg/reconciler/eventlistener/resources/custom_test.go
@@ -18,7 +18,6 @@ package resources
 
 import (
 	"context"
-	"os"
 	"strconv"
 	"testing"
 
@@ -30,14 +29,8 @@ import (
 )
 
 func TestCustomObject(t *testing.T) {
-	err := os.Setenv("METRICS_PROMETHEUS_PORT", "9000")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = os.Setenv("SYSTEM_NAMESPACE", "tekton-pipelines")
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv("METRICS_PROMETHEUS_PORT", "9000")
+	t.Setenv("SYSTEM_NAMESPACE", "tekton-pipelines")
 
 	config := *MakeConfig()
 	metadata := map[string]interface{}{
@@ -323,14 +316,8 @@ func TestCustomObject(t *testing.T) {
 }
 
 func TestCustomObjectError(t *testing.T) {
-	err := os.Setenv("METRICS_PROMETHEUS_PORT", "9000")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = os.Setenv("SYSTEM_NAMESPACE", "tekton-pipelines")
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv("METRICS_PROMETHEUS_PORT", "9000")
+	t.Setenv("SYSTEM_NAMESPACE", "tekton-pipelines")
 
 	config := *MakeConfig()
 

--- a/pkg/reconciler/eventlistener/resources/deployment_test.go
+++ b/pkg/reconciler/eventlistener/resources/deployment_test.go
@@ -18,7 +18,6 @@ package resources
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -33,14 +32,8 @@ import (
 )
 
 func TestDeployment(t *testing.T) {
-	err := os.Setenv("METRICS_PROMETHEUS_PORT", "9000")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = os.Setenv("SYSTEM_NAMESPACE", "tekton-pipelines")
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv("METRICS_PROMETHEUS_PORT", "9000")
+	t.Setenv("SYSTEM_NAMESPACE", "tekton-pipelines")
 
 	config := *MakeConfig()
 	labels := map[string]string{
@@ -304,10 +297,7 @@ func TestDeployment(t *testing.T) {
 }
 
 func TestDeploymentError(t *testing.T) {
-	err := os.Setenv("METRICS_PROMETHEUS_PORT", "bad")
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv("METRICS_PROMETHEUS_PORT", "bad")
 	got, err := MakeDeployment(context.Background(), makeEL(), &reconcilersource.EmptyVarsGenerator{}, *MakeConfig())
 	if err == nil {
 		t.Fatalf("MakeDeployment() = %v, wanted error", got)


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

A testing cleanup.

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

```go
func TestFoo(t *testing.T) {
	// before
	key := "ENV"
	originalEnv := os.Getenv(key)
	
	if err := os.Setenv(key, "new value"); err != nil {
		t.Fatal(err)
	}
	defer func() {
		if err := os.Setenv(key, originalEnv); err != nil {
			t.Logf("failed to set env %s back to original value: %v", key, err)
		}
	}()
	
	// after
	t.Setenv(key, "new value")
}
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
NONE
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
NONE
```