### PR TITLE
Add SecurityContext to Eventlistener containers

### DIFF
--- a/pkg/reconciler/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/eventlistener/eventlistener_test.go
@@ -273,6 +273,19 @@ func makeDeployment(ops ...func(d *appsv1.Deployment)) *appsv1.Deployment {
 							Name:  "METRICS_PROMETHEUS_PORT",
 							Value: "9000",
 						}},
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							// 65532 is the distroless nonroot user ID
+							RunAsUser:    ptr.Int64(65532),
+							RunAsGroup:   ptr.Int64(65532),
+							RunAsNonRoot: ptr.Bool(true),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}},
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: ptr.Bool(true),
@@ -421,6 +434,19 @@ func makeWithPod(ops ...func(d *duckv1.WithPod)) *duckv1.WithPod {
 							Name:  "METRICS_PROMETHEUS_PORT",
 							Value: "9000",
 						}},
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							// 65532 is the distroless nonroot user ID
+							RunAsUser:    ptr.Int64(65532),
+							RunAsGroup:   ptr.Int64(65532),
+							RunAsNonRoot: ptr.Bool(true),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 						ReadinessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{
 								HTTPGet: &corev1.HTTPGetAction{

--- a/pkg/reconciler/eventlistener/resources/container.go
+++ b/pkg/reconciler/eventlistener/resources/container.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	reconcilersource "knative.dev/eventing/pkg/reconciler/source"
+	"knative.dev/pkg/ptr"
 )
 
 type ContainerOption func(*corev1.Container)
@@ -79,6 +80,19 @@ func MakeContainer(el *v1beta1.EventListener, configAcc reconcilersource.ConfigA
 			Name:  "K_SINK_TIMEOUT",
 			Value: strconv.FormatInt(*c.TimeOutHandler, 10),
 		}}...),
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr.Bool(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+			// 65532 is the distroless nonroot user ID
+			RunAsUser:    ptr.Int64(65532),
+			RunAsGroup:   ptr.Int64(65532),
+			RunAsNonRoot: ptr.Bool(true),
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
+		},
 	}
 
 	for _, opt := range opts {

--- a/pkg/reconciler/eventlistener/resources/container_test.go
+++ b/pkg/reconciler/eventlistener/resources/container_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	reconcilersource "knative.dev/eventing/pkg/reconciler/source"
+	"knative.dev/pkg/ptr"
 )
 
 func TestContainer(t *testing.T) {
@@ -82,6 +83,19 @@ func TestContainer(t *testing.T) {
 				Name:  "K_SINK_TIMEOUT",
 				Value: strconv.FormatInt(DefaultTimeOutHandler, 10),
 			}},
+			SecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: ptr.Bool(false),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
+				// 65532 is the distroless nonroot user ID
+				RunAsUser:    ptr.Int64(65532),
+				RunAsGroup:   ptr.Int64(65532),
+				RunAsNonRoot: ptr.Bool(true),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
 		},
 	}, {
 		name: "with resources option",
@@ -143,6 +157,19 @@ func TestContainer(t *testing.T) {
 				Name:  "K_SINK_TIMEOUT",
 				Value: strconv.FormatInt(DefaultTimeOutHandler, 10),
 			}},
+			SecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: ptr.Bool(false),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
+				// 65532 is the distroless nonroot user ID
+				RunAsUser:    ptr.Int64(65532),
+				RunAsGroup:   ptr.Int64(65532),
+				RunAsNonRoot: ptr.Bool(true),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
 		},
 	}, {
 		name: "with env option",
@@ -183,6 +210,19 @@ func TestContainer(t *testing.T) {
 				Name:  "BAR",
 				Value: "food",
 			}},
+			SecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: ptr.Bool(false),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
+				// 65532 is the distroless nonroot user ID
+				RunAsUser:    ptr.Int64(65532),
+				RunAsGroup:   ptr.Int64(65532),
+				RunAsNonRoot: ptr.Bool(true),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
 		},
 	}, {
 		name: "with namespace selector",
@@ -232,6 +272,19 @@ func TestContainer(t *testing.T) {
 				Name:  "K_SINK_TIMEOUT",
 				Value: strconv.FormatInt(DefaultTimeOutHandler, 10),
 			}},
+			SecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: ptr.Bool(false),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
+				// 65532 is the distroless nonroot user ID
+				RunAsUser:    ptr.Int64(65532),
+				RunAsGroup:   ptr.Int64(65532),
+				RunAsNonRoot: ptr.Bool(true),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
 		},
 	}, {
 		name: "without payload validation",
@@ -283,6 +336,19 @@ func TestContainer(t *testing.T) {
 				Name:  "K_SINK_TIMEOUT",
 				Value: strconv.FormatInt(DefaultTimeOutHandler, 10),
 			}},
+			SecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: ptr.Bool(false),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
+				// 65532 is the distroless nonroot user ID
+				RunAsUser:    ptr.Int64(65532),
+				RunAsGroup:   ptr.Int64(65532),
+				RunAsNonRoot: ptr.Bool(true),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
 		},
 	}}
 

--- a/pkg/reconciler/eventlistener/resources/custom_test.go
+++ b/pkg/reconciler/eventlistener/resources/custom_test.go
@@ -150,6 +150,15 @@ func TestCustomObject(t *testing.T) {
 											"protocol":      "TCP",
 										},
 									},
+									"securityContext": map[string]interface{}{
+										"allowPrivilegeEscalation": false,
+										"capabilities": map[string]interface{}{
+											"drop": []interface{}{string("ALL")}},
+										"runAsGroup":     int64(65532),
+										"runAsNonRoot":   bool(true),
+										"runAsUser":      int64(65532),
+										"seccompProfile": map[string]interface{}{"type": string("RuntimeDefault")},
+									},
 									"resources": map[string]interface{}{},
 									"readinessProbe": map[string]interface{}{
 										"httpGet": map[string]interface{}{
@@ -216,6 +225,15 @@ func TestCustomObject(t *testing.T) {
 											"containerPort": int64(8080),
 											"protocol":      "TCP",
 										},
+									},
+									"securityContext": map[string]interface{}{
+										"allowPrivilegeEscalation": false,
+										"capabilities": map[string]interface{}{
+											"drop": []interface{}{string("ALL")}},
+										"runAsGroup":     int64(65532),
+										"runAsNonRoot":   bool(true),
+										"runAsUser":      int64(65532),
+										"seccompProfile": map[string]interface{}{"type": string("RuntimeDefault")},
 									},
 									"resources": map[string]interface{}{},
 									"readinessProbe": map[string]interface{}{
@@ -284,6 +302,15 @@ func TestCustomObject(t *testing.T) {
 										"limits": map[string]interface{}{
 											"cpu": "101m",
 										},
+									},
+									"securityContext": map[string]interface{}{
+										"allowPrivilegeEscalation": false,
+										"capabilities": map[string]interface{}{
+											"drop": []interface{}{string("ALL")}},
+										"runAsGroup":     int64(65532),
+										"runAsNonRoot":   bool(true),
+										"runAsUser":      int64(65532),
+										"seccompProfile": map[string]interface{}{"type": string("RuntimeDefault")},
 									},
 									"readinessProbe": map[string]interface{}{
 										"httpGet": map[string]interface{}{


### PR DESCRIPTION

# Changes

The security context is the same one that is applied to other Tekton workloads such as the Triggers and Pipeline controller pods. Eventlisteners already run as non-root, non-privileged containers. Adding this setting allows them to run in environments with pod security admission set to "restricted" (such as the tekton-pipelines namespace)

Fixes #1490


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:



For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
Eventlistener containers now contain the right security context to allow running with restricted pod security admission
```

/kind bug