### PR TITLE
Restore v1alpha1.Runs as valid resources

### DIFF
--- a/pkg/apis/config/allowed_types.go
+++ b/pkg/apis/config/allowed_types.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	customrunsv1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	pipelineresourcev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -13,11 +14,12 @@ var Decoder runtime.Decoder
 // TODO(dibyom): We should have a way of configuring this instead of an init function?
 func init() {
 	scheme := runtime.NewScheme()
+	utilruntime.Must(customrunsv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(pipelineresourcev1alpha1.AddToScheme(scheme))
 	utilruntime.Must(pipelinev1beta1.AddToScheme(scheme))
 	codec := serializer.NewCodecFactory(scheme)
 	Decoder = codec.UniversalDecoder(
-		pipelineresourcev1alpha1.SchemeGroupVersion,
+		pipelineresourcev1alpha1.SchemeGroupVersion, // customrunsv1alpha1 share the same SchemeGroupVersion
 		pipelinev1beta1.SchemeGroupVersion,
 	)
 }

--- a/pkg/apis/triggers/v1beta1/trigger_template_validation_test.go
+++ b/pkg/apis/triggers/v1beta1/trigger_template_validation_test.go
@@ -21,7 +21,8 @@ import (
 	"strings"
 	"testing"
 
-	pipelinev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelinev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,7 +34,7 @@ import (
 )
 
 func simpleResourceTemplate(t *testing.T) runtime.RawExtension {
-	return test.RawExtension(t, pipelinev1alpha1.PipelineRun{
+	return test.RawExtension(t, pipelinev1beta1.PipelineRun{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "tekton.dev/v1beta1",
 			Kind:       "PipelineRun",
@@ -42,7 +43,7 @@ func simpleResourceTemplate(t *testing.T) runtime.RawExtension {
 }
 
 func v1beta1ResourceTemplate(t *testing.T) runtime.RawExtension {
-	return test.RawExtension(t, pipelinev1alpha1.PipelineRun{
+	return test.RawExtension(t, pipelinev1beta1.PipelineRun{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "tekton.dev/v1beta1",
 			Kind:       "PipelineRun",
@@ -50,18 +51,27 @@ func v1beta1ResourceTemplate(t *testing.T) runtime.RawExtension {
 	})
 }
 
+func v1alpha1ResourceTemplate(t *testing.T) runtime.RawExtension {
+	return test.RawExtension(t, pipelinev1alpha1.Run{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "tekton.dev/v1alpha1",
+			Kind:       "Run",
+		},
+	})
+}
+
 func paramResourceTemplate(t *testing.T) runtime.RawExtension {
-	return test.RawExtension(t, pipelinev1alpha1.PipelineRun{
+	return test.RawExtension(t, pipelinev1beta1.PipelineRun{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "tekton.dev/v1beta1",
 			Kind:       "PipelineRun",
 		},
-		Spec: pipelinev1alpha1.PipelineRunSpec{
-			Params: []pipelinev1alpha1.Param{
+		Spec: pipelinev1beta1.PipelineRunSpec{
+			Params: []pipelinev1beta1.Param{
 				{
 					Name: "message",
-					Value: pipelinev1alpha1.ArrayOrString{
-						Type:      pipelinev1alpha1.ParamTypeString,
+					Value: pipelinev1beta1.ArrayOrString{
+						Type:      pipelinev1beta1.ParamTypeString,
 						StringVal: "$(tt.params.foo)",
 					},
 				},
@@ -71,17 +81,17 @@ func paramResourceTemplate(t *testing.T) runtime.RawExtension {
 }
 
 func invalidParamResourceTemplate(t *testing.T) runtime.RawExtension {
-	return test.RawExtension(t, pipelinev1alpha1.PipelineRun{
+	return test.RawExtension(t, pipelinev1beta1.PipelineRun{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "tekton.dev/v1beta1",
 			Kind:       "PipelineRun",
 		},
-		Spec: pipelinev1alpha1.PipelineRunSpec{
-			Params: []pipelinev1alpha1.Param{
+		Spec: pipelinev1beta1.PipelineRunSpec{
+			Params: []pipelinev1beta1.Param{
 				{
 					Name: "message",
-					Value: pipelinev1alpha1.ArrayOrString{
-						Type:      pipelinev1alpha1.ParamTypeString,
+					Value: pipelinev1beta1.ArrayOrString{
+						Type:      pipelinev1beta1.ParamTypeString,
 						StringVal: "$(.foo)",
 					},
 				},
@@ -152,6 +162,8 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 				}},
 				ResourceTemplates: []v1beta1.TriggerResourceTemplate{{
 					RawExtension: simpleResourceTemplate(t),
+				}, {
+					RawExtension: v1alpha1ResourceTemplate(t),
 				}},
 			},
 		},
@@ -208,7 +220,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 					Default:     ptr.String("val"),
 				}},
 				ResourceTemplates: []v1beta1.TriggerResourceTemplate{{
-					RawExtension: test.RawExtension(t, pipelinev1alpha1.PipelineRun{
+					RawExtension: test.RawExtension(t, pipelinev1beta1.PipelineRun{
 						TypeMeta: metav1.TypeMeta{
 							APIVersion: "tekton.dev/v1beta1",
 						},
@@ -234,7 +246,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 					Default:     ptr.String("val"),
 				}},
 				ResourceTemplates: []v1beta1.TriggerResourceTemplate{{
-					RawExtension: test.RawExtension(t, pipelinev1alpha1.PipelineRun{
+					RawExtension: test.RawExtension(t, pipelinev1beta1.PipelineRun{
 						TypeMeta: metav1.TypeMeta{
 							Kind: "PipelineRun",
 						},
@@ -260,7 +272,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 					Default:     ptr.String("val"),
 				}},
 				ResourceTemplates: []v1beta1.TriggerResourceTemplate{{
-					RawExtension: test.RawExtension(t, pipelinev1alpha1.PipelineRun{
+					RawExtension: test.RawExtension(t, pipelinev1beta1.PipelineRun{
 						TypeMeta: metav1.TypeMeta{
 							APIVersion: "foobar",
 							Kind:       "pipelinerun",
@@ -287,7 +299,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 					Default:     ptr.String("val"),
 				}},
 				ResourceTemplates: []v1beta1.TriggerResourceTemplate{{
-					RawExtension: test.RawExtension(t, pipelinev1alpha1.PipelineRun{
+					RawExtension: test.RawExtension(t, pipelinev1beta1.PipelineRun{
 						TypeMeta: metav1.TypeMeta{
 							APIVersion: "foo",
 							Kind:       "tekton.dev/v1beta1",


### PR DESCRIPTION
# Changes

When triggers migrated to pipeline v0.39 in PR #1444 Runs were dropped from the list of supported resources.

Adding Runs back including a tests for them.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Restore support for `Runs` in `TriggerTemplates`
```