### PR TITLE
Set default `Interceptor.Kind` for `EventListener` `TriggerGroups`

### DIFF
--- a/pkg/apis/triggers/v1beta1/event_listener_defaults.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_defaults.go
@@ -47,5 +47,13 @@ func (el *EventListener) SetDefaults(ctx context.Context) {
 				}
 			}
 		}
+
+		for _, tg := range el.Spec.TriggerGroups {
+			for _, ti := range tg.Interceptors {
+				if ti != nil {
+					ti.defaultInterceptorKind()
+				}
+			}
+		}
 	}
 }

--- a/pkg/apis/triggers/v1beta1/event_listener_defaults_test.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_defaults_test.go
@@ -188,6 +188,33 @@ func TestEventListenerSetDefaults(t *testing.T) {
 			})
 			return contexts.WithUpgradeViaDefaulting(s.ToContext(ctx))
 		},
+	}, {
+		name: "adds TriggerGroup interceptorkind when not specified",
+		in: &v1beta1.EventListener{
+			Spec: v1beta1.EventListenerSpec{
+				TriggerGroups: []v1beta1.EventListenerTriggerGroup{{
+					Interceptors: []*v1beta1.EventInterceptor{{
+						Ref: v1beta1.InterceptorRef{
+							Name: "cel",
+						},
+					}},
+				}},
+			},
+		},
+		wc: contexts.WithUpgradeViaDefaulting,
+		want: &v1beta1.EventListener{
+			Spec: v1beta1.EventListenerSpec{
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				TriggerGroups: []v1beta1.EventListenerTriggerGroup{{
+					Interceptors: []*v1beta1.EventInterceptor{{
+						Ref: v1beta1.InterceptorRef{
+							Name: "cel",
+							Kind: v1beta1.ClusterInterceptorKind,
+						},
+					}},
+				}},
+			},
+		},
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
# Changes

Fixes #1499

While `Kind` is getting defaulted properly for interceptors in `EventListener.Spec.Triggers`, it also needs to be defaulted for interceptors in `EventListener.Spec.TriggerGroups`.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Sets a default interceptor kind for interceptors in event listener trigger groups.
```
