### PR TITLE
Add support for v1 pipeline types and customruns

### DIFF
--- a/pkg/apis/config/allowed_types.go
+++ b/pkg/apis/config/allowed_types.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	customrunsv1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	pipelineresourcev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
@@ -17,10 +18,12 @@ func init() {
 	utilruntime.Must(customrunsv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(pipelineresourcev1alpha1.AddToScheme(scheme))
 	utilruntime.Must(pipelinev1beta1.AddToScheme(scheme))
+	utilruntime.Must(pipelinev1.AddToScheme(scheme))
 	codec := serializer.NewCodecFactory(scheme)
 	Decoder = codec.UniversalDecoder(
 		pipelineresourcev1alpha1.SchemeGroupVersion, // customrunsv1alpha1 share the same SchemeGroupVersion
 		pipelinev1beta1.SchemeGroupVersion,
+		pipelinev1.SchemeGroupVersion,
 	)
 }
 
@@ -30,3 +33,15 @@ func EnsureAllowedType(rt runtime.RawExtension) error {
 	_, err := runtime.Decode(Decoder, rt.Raw)
 	return err
 }
+
+var (
+	AllowedPipelineTypes = map[string][]string{
+		"v1alpha1": {"pipelineresources", "pipelineruns", "taskruns", "pipelines", "clustertasks", "tasks", "conditions", "runs"},
+		"v1beta1":  {"pipelineruns", "taskruns", "pipelines", "clustertasks", "tasks", "customruns"},
+		"v1":       {"pipelineruns", "taskruns", "pipelines", "tasks"},
+	}
+	AllowedTriggersTypes = map[string][]string{
+		"v1alpha1": {"clusterinterceptors", "interceptors"},
+		"v1beta1":  {"clustertriggerbindings", "eventlisteners", "triggerbindings", "triggers", "triggertemplates"},
+	}
+)

--- a/pkg/client/dynamic/clientset/tekton/tekton.go
+++ b/pkg/client/dynamic/clientset/tekton/tekton.go
@@ -18,27 +18,17 @@ package tekton
 
 import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	"github.com/tektoncd/triggers/pkg/apis/config"
 	"github.com/tektoncd/triggers/pkg/apis/triggers"
 	"github.com/tektoncd/triggers/pkg/client/dynamic/clientset"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 )
 
-var (
-	allowedPipelineTypes = map[string][]string{
-		"v1alpha1": {"pipelineresources", "pipelineruns", "taskruns", "pipelines", "clustertasks", "tasks", "conditions", "runs"},
-		"v1beta1":  {"pipelineruns", "taskruns", "pipelines", "clustertasks", "tasks"},
-	}
-	allowedTriggersTypes = map[string][]string{
-		"v1alpha1": {"clusterinterceptors", "interceptors"},
-		"v1beta1":  {"clustertriggerbindings", "eventlisteners", "triggerbindings", "triggers", "triggertemplates"},
-	}
-)
-
 // WithClient adds Tekton related clients to the Dynamic client.
 func WithClient(client dynamic.Interface) clientset.Option {
 	return func(cs *clientset.Clientset) {
-		for version, resources := range allowedPipelineTypes {
+		for version, resources := range config.AllowedPipelineTypes {
 			for _, resource := range resources {
 				r := schema.GroupVersionResource{
 					Group:    pipeline.GroupName,
@@ -48,7 +38,7 @@ func WithClient(client dynamic.Interface) clientset.Option {
 				cs.Add(r, client)
 			}
 		}
-		for version, resources := range allowedTriggersTypes {
+		for version, resources := range config.AllowedTriggersTypes {
 			for _, resource := range resources {
 				r := schema.GroupVersionResource{
 					Group:    triggers.GroupName,


### PR DESCRIPTION

# Changes

Allow triggers to create v1 pipeline types
Also allow triggers to create v1beta1 customruns
Finally, move the allowlisted types to a single file (fixes #494)

TODO:

- [ ] Update docs to mention v1 support
- [ ] Add tests for v1 support

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Triggers now allows creating v1 PipelineRuns, TaskRuns, Tasks, and Pipelines as well as v1beta1 CustomRuns
```

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
