### PR TITLE
Replace cloudevents resource with task from hub

### DIFF
--- a/docs/getting-started/pipeline.yaml
+++ b/docs/getting-started/pipeline.yaml
@@ -15,8 +15,6 @@ spec:
       type: git
     - name: image-source
       type: image
-    - name: event-to-sink
-      type: cloudEvent
   tasks:
     - name: build-docker-image
       taskRef:
@@ -40,9 +38,20 @@ spec:
             resource: image-source
             from:
               - build-docker-image
-        outputs:
-          - name: event-to-sink
-            resource: event-to-sink
+    - name: send-cloud-event
+      taskRef:
+        resolver: hub
+        params:
+        - name: name
+          value: cloudevent
+        - name: version
+          value: 0.1
+      params:
+      - name: sink
+      # URL of the Service we create below
+        value: http://event-display.getting-started.svc.cluster.local
+      - name: eventID
+        value: $(context.taskRun.name)
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -54,9 +63,6 @@ spec:
     inputs:
       - name: image-source
         type: image
-    outputs:
-    - name: event-to-sink
-      type: cloudEvent
   steps:
     - name: run-kubectl
       image: lachlanevenson/k8s-kubectl

--- a/docs/getting-started/triggers.yaml
+++ b/docs/getting-started/triggers.yaml
@@ -37,12 +37,6 @@ spec:
               params:
                 - name: url
                   value: DOCKERREPO-REPLACEME # docker-repo-location.com/repo:getting-started
-          - name: event-to-sink
-            resourceSpec:
-              type: cloudEvent
-              params:
-                - name: targetURI
-                  value: http://event-display.getting-started.svc.cluster.local
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding


### PR DESCRIPTION
Cloud events pipeline resource was removed from pipelines recently. Our E2E tests run against the main branch of pipelines and that the getting-started tutorial still uses this resource, our e2e tests have been failing.

Fixes #1522
Fixes https://github.com/tektoncd/triggers/pull/1529#issuecomment-1437984486

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
