### PR TITLE
chore: use http constants to replace numbers

### DIFF
--- a/cmd/triggerrun/cmd/root_test.go
+++ b/cmd/triggerrun/cmd/root_test.go
@@ -123,7 +123,7 @@ func Test_processTriggerSpec(t *testing.T) {
 		resources test.Resources
 	}
 	eventBody := json.RawMessage(`{"repository": {"links": {"clone": [{"href": "testurl", "name": "ssh"}, {"href": "testurl", "name": "http"}]}}, "changes": [{"ref": {"displayId": "test-branch"}}]}`)
-	r, err := http.NewRequest("POST", "URL", bytes.NewReader(eventBody))
+	r, err := http.NewRequest(http.MethodPost, "URL", bytes.NewReader(eventBody))
 	if err != nil {
 		t.Errorf("Cannot create a new request:%s", err)
 	}

--- a/pkg/interceptors/webhook/webhook_test.go
+++ b/pkg/interceptors/webhook/webhook_test.go
@@ -84,7 +84,7 @@ func TestWebHookInterceptor(t *testing.T) {
 	}
 	i := NewInterceptor(webhook, client, "default", nil)
 
-	incoming, _ := http.NewRequest("POST", "http://doesnotmatter.example.com", payload)
+	incoming, _ := http.NewRequest(http.MethodPost, "http://doesnotmatter.example.com", payload)
 	incoming.Header.Add("Content-type", "application/json")
 	resp, err := i.ExecuteTrigger(incoming)
 	if err != nil {
@@ -136,7 +136,7 @@ func TestWebHookInterceptor_NotOK(t *testing.T) {
 	}
 	i := NewInterceptor(webhook, client, "default", nil)
 
-	incoming, _ := http.NewRequest("POST", "http://doesnotmatter.example.com", payload)
+	incoming, _ := http.NewRequest(http.MethodPost, "http://doesnotmatter.example.com", payload)
 	resp, err := i.ExecuteTrigger(incoming)
 	if err == nil || resp.StatusCode != http.StatusAccepted {
 		got, _ := httputil.DumpResponse(resp, true)

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -1192,7 +1192,7 @@ func TestHandleEvent(t *testing.T) {
 			metricsRecorder := &MetricsHandler{Handler: http.HandlerFunc(sink.HandleEvent)}
 			ts := httptest.NewServer(metricsRecorder.Intercept(sink.NewMetricsRecorderInterceptor()))
 			defer ts.Close()
-			req, err := http.NewRequest("POST", ts.URL, bytes.NewReader(tc.eventBody))
+			req, err := http.NewRequest(http.MethodPost, ts.URL, bytes.NewReader(tc.eventBody))
 			if err != nil {
 				t.Fatalf("error creating request: %s", err)
 			}
@@ -1546,7 +1546,7 @@ func TestExecuteInterceptor_ExtensionChaining(t *testing.T) {
 		},
 	}
 
-	req, err := http.NewRequest("POST", "/", nil)
+	req, err := http.NewRequest(http.MethodPost, "/", nil)
 	if err != nil {
 		t.Fatalf("http.NewRequest: %v", err)
 	}

--- a/test/eventlistener_test.go
+++ b/test/eventlistener_test.go
@@ -484,7 +484,7 @@ func TestEventListenerCreate(t *testing.T) {
 		t.Fatalf("Forwarding stream of data failed:: %v", err)
 	}
 	// Send POST request to EventListener sink
-	req, err := http.NewRequest("POST", fmt.Sprintf("http://127.0.0.1:%s", portString), bytes.NewBuffer(eventBodyJSON))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://127.0.0.1:%s", portString), bytes.NewBuffer(eventBodyJSON))
 	if err != nil {
 		t.Fatalf("Error creating POST request: %s", err)
 	}
@@ -558,7 +558,7 @@ func TestEventListenerCreate(t *testing.T) {
 		t.Fatalf("EventListener not ready after trigger auth update: %s", err)
 	}
 	// Send POST request to EventListener sink
-	req, err = http.NewRequest("POST", fmt.Sprintf("http://127.0.0.1:%s", portString), bytes.NewBuffer(eventBodyJSON))
+	req, err = http.NewRequest(http.MethodPost, fmt.Sprintf("http://127.0.0.1:%s", portString), bytes.NewBuffer(eventBodyJSON))
 	if err != nil {
 		t.Fatalf("Error creating POST request for trigger auth: %s", err)
 	}


### PR DESCRIPTION
# Changes
Use http constants to replace numbers
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
