### PR TITLE
Add support for Affinity and TopologySpreadConstraints

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -270,14 +270,14 @@ Legal values for the `PodSpec` and `Containers` sub-fields for both `kubernetesR
 ServiceAccountName
 NodeSelector
 Tolerations
-Volumes
 Containers
+Affinity
+TopologySpreadConstraints
 ```
 
 Legal values for the `Containers` sub-field are:
 ```
 Resources
-VolumeMounts
 Env
 ```
 

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation.go
@@ -257,7 +257,6 @@ func podSpecMask(in *corev1.PodSpec) *corev1.PodSpec {
 	out.SecurityContext = nil
 	out.Hostname = ""
 	out.Subdomain = ""
-	out.Affinity = nil
 	out.SchedulerName = ""
 	out.HostAliases = nil
 	out.PriorityClassName = ""
@@ -265,6 +264,8 @@ func podSpecMask(in *corev1.PodSpec) *corev1.PodSpec {
 	out.DNSConfig = nil
 	out.ReadinessGates = nil
 	out.RuntimeClassName = nil
+	out.Affinity = nil
+	out.TopologySpreadConstraints = nil
 
 	return out
 }

--- a/pkg/apis/triggers/v1beta1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_validation.go
@@ -254,6 +254,8 @@ func podSpecMask(in *corev1.PodSpec) *corev1.PodSpec {
 	out.Containers = in.Containers
 	out.Tolerations = in.Tolerations
 	out.NodeSelector = in.NodeSelector
+	out.Affinity = in.Affinity
+	out.TopologySpreadConstraints = in.TopologySpreadConstraints
 
 	// Disallowed fields
 	// This list clarifies which all podspec fields are not allowed.
@@ -274,7 +276,6 @@ func podSpecMask(in *corev1.PodSpec) *corev1.PodSpec {
 	out.SecurityContext = nil
 	out.Hostname = ""
 	out.Subdomain = ""
-	out.Affinity = nil
 	out.SchedulerName = ""
 	out.HostAliases = nil
 	out.PriorityClassName = ""

--- a/pkg/apis/triggers/v1beta1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_validation_test.go
@@ -525,7 +525,44 @@ func Test_EventListenerValidate(t *testing.T) {
 					},
 				}},
 			},
-		}}}
+		}},
+		{
+			name: "Valid EventListener with node affinity",
+			el: &triggersv1beta1.EventListener{
+				ObjectMeta: myObjectMeta,
+				Spec: triggersv1beta1.EventListenerSpec{
+					Triggers: []triggersv1beta1.EventListenerTrigger{{
+						Template: &triggersv1beta1.EventListenerTemplate{
+							Ref: ptr.String("tt"),
+						},
+					}},
+					Resources: triggersv1beta1.Resources{
+						KubernetesResource: &triggersv1beta1.KubernetesResource{
+							WithPodSpec: duckv1.WithPodSpec{
+								Template: duckv1.PodSpecable{
+									Spec: corev1.PodSpec{
+										ServiceAccountName: "k8sresource",
+										Affinity: &corev1.Affinity{
+											NodeAffinity: &corev1.NodeAffinity{
+												RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+													NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+														MatchExpressions: []corev1.NodeSelectorRequirement{{
+															Key:      "topology.kubernetes.io/zone",
+															Operator: corev1.NodeSelectorOpIn,
+															Values:   []string{"antarctica-east1"},
+														}},
+													}},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/reconciler/eventlistener/resources/custom.go
+++ b/pkg/reconciler/eventlistener/resources/custom.go
@@ -91,10 +91,12 @@ func MakeCustomObject(ctx context.Context, el *v1beta1.EventListener, configAcc 
 		Annotations: customObjectData.Spec.Template.Annotations,
 	}
 	original.Spec.Template.Spec = corev1.PodSpec{
-		Tolerations:        customObjectData.Spec.Template.Spec.Tolerations,
-		NodeSelector:       customObjectData.Spec.Template.Spec.NodeSelector,
-		ServiceAccountName: customObjectData.Spec.Template.Spec.ServiceAccountName,
-		Containers:         []corev1.Container{container},
+		Tolerations:               customObjectData.Spec.Template.Spec.Tolerations,
+		NodeSelector:              customObjectData.Spec.Template.Spec.NodeSelector,
+		ServiceAccountName:        customObjectData.Spec.Template.Spec.ServiceAccountName,
+		Containers:                []corev1.Container{container},
+		Affinity:                  customObjectData.Spec.Template.Spec.Affinity,
+		TopologySpreadConstraints: customObjectData.Spec.Template.Spec.TopologySpreadConstraints,
 	}
 	marshaledData, err := json.Marshal(original)
 	if err != nil {
@@ -157,6 +159,14 @@ func UpdateCustomObject(originalData, updatedCustomObject *unstructured.Unstruct
 	}
 	if !reflect.DeepEqual(existingObject.Spec.Template.Spec.NodeSelector, originalObject.Spec.Template.Spec.NodeSelector) {
 		existingObject.Spec.Template.Spec.NodeSelector = originalObject.Spec.Template.Spec.NodeSelector
+		updated = true
+	}
+	if !reflect.DeepEqual(existingObject.Spec.Template.Spec.Affinity, originalObject.Spec.Template.Spec.Affinity) {
+		existingObject.Spec.Template.Spec.Affinity = originalObject.Spec.Template.Spec.Affinity
+		updated = true
+	}
+	if !reflect.DeepEqual(existingObject.Spec.Template.Spec.TopologySpreadConstraints, originalObject.Spec.Template.Spec.TopologySpreadConstraints) {
+		existingObject.Spec.Template.Spec.TopologySpreadConstraints = originalObject.Spec.Template.Spec.TopologySpreadConstraints
 		updated = true
 	}
 	if len(existingObject.Spec.Template.Spec.Containers) == 0 ||

--- a/pkg/reconciler/eventlistener/resources/custom_test.go
+++ b/pkg/reconciler/eventlistener/resources/custom_test.go
@@ -327,6 +327,123 @@ func TestCustomObject(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		name: "with Affinity and TopologySpreadConstraints",
+		el: makeEL(func(el *v1beta1.EventListener) {
+			el.Spec.Resources.CustomResource = &v1beta1.CustomResource{
+				RawExtension: runtime.RawExtension{
+					Raw: []byte(`{
+							"apiVersion": "serving.knative.dev/v1",
+							"kind": "Service",
+							"spec": {
+								"template": {
+									"spec": {
+                                        "affinity": {
+	                                       "nodeAffinity": {
+                                             "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                "nodeSelectorTerms": [{
+                                                   "matchExpressions": [{
+                                                      "key": "topology.kubernetes.io/zone",
+                                                      "operator": "In",
+                                                      "values": ["antarctica-east1"]
+                                                    }]
+								                 }]
+                                              }	
+                                           }
+                                        },
+                                        "topologySpreadConstraints": [{
+                                          "maxSkew": 1
+                                        }],
+										"containers": [{
+											"resources": {
+												"limits": {
+													"cpu": "101m"
+												}
+											}
+										}]
+									}
+								}
+							}
+						}`),
+				},
+			}
+		}),
+		want: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "serving.knative.dev/v1",
+				"kind":       "Service",
+				"metadata":   metadata,
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"creationTimestamp": nil,
+						},
+						"spec": map[string]interface{}{
+							"affinity": map[string]interface{}{
+								"nodeAffinity": map[string]interface{}{
+									"requiredDuringSchedulingIgnoredDuringExecution": map[string]interface{}{
+										"nodeSelectorTerms": []interface{}{
+											map[string]interface{}{
+												"matchExpressions": []interface{}{
+													map[string]interface{}{
+														"key":      "topology.kubernetes.io/zone",
+														"operator": "In",
+														"values":   []interface{}{"antarctica-east1"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							"topologySpreadConstraints": []interface{}{
+								map[string]interface{}{
+									"maxSkew":           int64(1),
+									"topologyKey":       "",
+									"whenUnsatisfiable": "",
+								},
+							},
+							"containers": []interface{}{
+								map[string]interface{}{
+									"name":  "event-listener",
+									"image": DefaultImage,
+									"args":  args,
+									"env":   env,
+									"ports": []interface{}{
+										map[string]interface{}{
+											"containerPort": int64(8080),
+											"protocol":      "TCP",
+										},
+									},
+									"resources": map[string]interface{}{
+										"limits": map[string]interface{}{
+											"cpu": "101m",
+										},
+									},
+									"securityContext": map[string]interface{}{
+										"allowPrivilegeEscalation": false,
+										"capabilities": map[string]interface{}{
+											"drop": []interface{}{string("ALL")}},
+										"runAsGroup":     int64(65532),
+										"runAsNonRoot":   bool(true),
+										"runAsUser":      int64(65532),
+										"seccompProfile": map[string]interface{}{"type": string("RuntimeDefault")},
+									},
+									"readinessProbe": map[string]interface{}{
+										"httpGet": map[string]interface{}{
+											"path":   "/live",
+											"port":   int64(0),
+											"scheme": "HTTP",
+										},
+										"successThreshold": int64(1),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}}
 
 	for _, tt := range tests {
@@ -433,6 +550,30 @@ func TestUpdateCustomObject(t *testing.T) {
 									"name": "volume",
 								},
 							},
+							"affinity": map[string]interface{}{
+								"nodeAffinity": map[string]interface{}{
+									"requiredDuringSchedulingIgnoredDuringExecution": map[string]interface{}{
+										"nodeSelectorTerms": []interface{}{
+											map[string]interface{}{
+												"matchExpressions": []interface{}{
+													map[string]interface{}{
+														"key":      "topology.kubernetes.io/zone",
+														"operator": "In",
+														"values":   []interface{}{"antarctica-east1"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							"topologySpreadConstraints": []interface{}{
+								map[string]interface{}{
+									"maxSkew":           int64(1),
+									"topologyKey":       "",
+									"whenUnsatisfiable": "",
+								},
+							},
 							"containers": []interface{}{
 								map[string]interface{}{
 									"name":  "event-listener",
@@ -504,6 +645,30 @@ func TestUpdateCustomObject(t *testing.T) {
 							"volumes": []interface{}{
 								map[string]interface{}{
 									"name1": "volume1",
+								},
+							},
+							"affinity": map[string]interface{}{
+								"nodeAffinity": map[string]interface{}{
+									"requiredDuringSchedulingIgnoredDuringExecution": map[string]interface{}{
+										"nodeSelectorTerms": []interface{}{
+											map[string]interface{}{
+												"matchExpressions": []interface{}{
+													map[string]interface{}{
+														"key":      "topology.kubernetes.io/updatedzone",
+														"operator": "In",
+														"values":   []interface{}{"antarctica-east2"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							"topologySpreadConstraints": []interface{}{
+								map[string]interface{}{
+									"maxSkew":           int64(2),
+									"topologyKey":       "",
+									"whenUnsatisfiable": "",
 								},
 							},
 							"containers": []interface{}{

--- a/pkg/reconciler/eventlistener/resources/deployment.go
+++ b/pkg/reconciler/eventlistener/resources/deployment.go
@@ -59,6 +59,8 @@ func MakeDeployment(ctx context.Context, el *v1beta1.EventListener, configAcc re
 		vol                       []corev1.Volume
 		tolerations               []corev1.Toleration
 		nodeSelector, annotations map[string]string
+		affinity                  *corev1.Affinity
+		topologySpreadConstraints []corev1.TopologySpreadConstraint
 	)
 
 	for _, v := range container.Env {
@@ -88,6 +90,12 @@ func MakeDeployment(ctx context.Context, el *v1beta1.EventListener, configAcc re
 		if el.Spec.Resources.KubernetesResource.Template.Spec.ServiceAccountName != "" {
 			serviceAccountName = el.Spec.Resources.KubernetesResource.Template.Spec.ServiceAccountName
 		}
+		if el.Spec.Resources.KubernetesResource.Template.Spec.Affinity != nil {
+			affinity = el.Spec.Resources.KubernetesResource.Template.Spec.Affinity
+		}
+		if len(el.Spec.Resources.KubernetesResource.Template.Spec.TopologySpreadConstraints) != 0 {
+			topologySpreadConstraints = el.Spec.Resources.KubernetesResource.Template.Spec.TopologySpreadConstraints
+		}
 		annotations = el.Spec.Resources.KubernetesResource.Template.Annotations
 		podlabels = kmeta.UnionMaps(podlabels, el.Spec.Resources.KubernetesResource.Template.Labels)
 	}
@@ -110,12 +118,14 @@ func MakeDeployment(ctx context.Context, el *v1beta1.EventListener, configAcc re
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
-					Tolerations:        tolerations,
-					NodeSelector:       nodeSelector,
-					ServiceAccountName: serviceAccountName,
-					Containers:         []corev1.Container{container},
-					Volumes:            vol,
-					SecurityContext:    &securityContext,
+					Tolerations:               tolerations,
+					NodeSelector:              nodeSelector,
+					ServiceAccountName:        serviceAccountName,
+					Containers:                []corev1.Container{container},
+					Volumes:                   vol,
+					SecurityContext:           &securityContext,
+					Affinity:                  affinity,
+					TopologySpreadConstraints: topologySpreadConstraints,
 				},
 			},
 		},


### PR DESCRIPTION
# Changes
Addressed : https://github.com/tektoncd/triggers/issues/1512

Triggers now support Affinity and TopologySpreadConstraints for podSpec

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
Triggers now support Affinity and TopologySpreadConstraints as part of Kubernetes and Custom resource 
```