### PR TITLE
Fix marshalJSON for lists of objects

### DIFF
--- a/pkg/interceptors/cel/cel_test.go
+++ b/pkg/interceptors/cel/cel_test.go
@@ -433,6 +433,13 @@ func TestExpressionEvaluation(t *testing.T) {
 		"jsonArray": []string{
 			"one", "two",
 		},
+		"jsonObjects": []map[string]interface{}{
+			{
+				"testing1": map[string]interface{}{
+					"testing": []string{"test1", "test2"},
+				},
+			},
+		},
 	}
 
 	refParts := strings.Split(testRef, "/")
@@ -588,6 +595,11 @@ func TestExpressionEvaluation(t *testing.T) {
 			name: "marshal JSON array to string",
 			expr: "body.jsonArray.marshalJSON()",
 			want: types.String(`["one","two"]`),
+		},
+		{
+			name: "marshal JSON objects to string",
+			expr: "body.jsonObjects.marshalJSON()",
+			want: types.String(`[{"testing1":{"testing":["test1","test2"]}}]`),
 		},
 		{
 			name: "extension base64 decoding",

--- a/pkg/interceptors/cel/triggers.go
+++ b/pkg/interceptors/cel/triggers.go
@@ -157,7 +157,7 @@ type triggersLib struct {
 
 func (t triggersLib) CompileOptions() []cel.EnvOption {
 	mapStrDyn := cel.MapType(cel.StringType, cel.DynType)
-	listStrDyn := cel.ListType(cel.StringType)
+	listStrDyn := cel.ListType(cel.DynType)
 	return []cel.EnvOption{
 		cel.Function("match",
 			cel.MemberOverload("match_map_string_string", []*cel.Type{mapStrDyn, cel.StringType, cel.StringType}, cel.BoolType,


### PR DESCRIPTION
# Changes
Fix marshalJSON for lists of objects

This fixes a bug in the CEL interceptor where the binding to marshalJSON was only for lists of strings.

The fix is to open up the binding to lists of any JSON objects.

Fixes #1538 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [X] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes
```release-note
Fix a bug in CEL interceptor's `marshalJSON` binding to allow marshaling of maps.
```