### PR TITLE
Fix triggers e2e failure by replacing pipeline resources by task

### DIFF
--- a/docs/getting-started/pipeline.yaml
+++ b/docs/getting-started/pipeline.yaml
@@ -10,34 +10,49 @@ metadata:
   name: getting-started-pipeline
   namespace: getting-started
 spec:
-  resources:
-    - name: source-repo
-      type: git
-    - name: image-source
-      type: image
+  params:
+    - name: git-url
+    - name: git-revision
+    - name: url
+  workspaces:
+    - name: git-source
   tasks:
+    - name: fetch-from-git
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/tektoncd/catalog.git
+          - name: pathInRepo
+            value: /task/git-clone/0.9/git-clone.yaml
+          - name: revision
+            value: main
+      params:
+        - name: url
+          value: $(params.git-url)
+        - name: revision
+          value: $(params.git-revision)
+      workspaces:
+        - name: output
+          workspace: git-source
     - name: build-docker-image
       taskRef:
         name: build-docker-image
       params:
-        - name: pathToContext
-          value: /workspace/source-repo
-      resources:
-        inputs:
-          - name: source-repo
-            resource: source-repo
-        outputs:
-          - name: builtImage
-            resource: image-source
+        - name: IMAGE
+          value: $(params.url)
+      runAfter: [fetch-from-git]
+      workspaces:
+        - name: source
+          workspace: git-source
     - name: deploy-locally
       taskRef:
         name: deploy-locally
-      resources:
-        inputs:
-          - name: image-source
-            resource: image-source
-            from:
-              - build-docker-image
+      params:
+        - name: IMAGE
+          value: $(params.url)
+      runAfter:
+        - build-docker-image
     - name: send-cloud-event
       taskRef:
         resolver: hub
@@ -59,10 +74,9 @@ metadata:
   name: deploy-locally
   namespace: getting-started
 spec:
-  resources:
-    inputs:
-      - name: image-source
-        type: image
+  params:
+    - name: IMAGE
+      description: Name (reference) of the image to build.
   steps:
     - name: run-kubectl
       image: lachlanevenson/k8s-kubectl
@@ -71,7 +85,7 @@ spec:
         - "run"
         - "tekton-triggers-built-me"
         - "--image"
-        - "$(resources.inputs.image-source.url)"
+        - "$(params.IMAGE)"
         - "--env=PORT=8080"
 ---
 apiVersion: tekton.dev/v1beta1
@@ -81,30 +95,28 @@ metadata:
   namespace: getting-started
 spec:
   params:
-  - name: pathToContext
-    description:
-      The build directory used by img
-    default: /workspace/source-repo
-  - name: pathToDockerFile
-    type: string
-    description: The path to the dockerfile to build
-    default: $(resources.inputs.source-repo.path)/Dockerfile
-  resources:
-    inputs:
-      - name: source-repo
-        type: git
-    outputs:
-      - name: builtImage
-        type: image
+    - name: IMAGE
+      description: Name (reference) of the image to build.
+    - name: pathToContext
+      description:
+        The build directory used by img
+      default: ./
+    - name: pathToDockerFile
+      type: string
+      description: The path to the dockerfile to build
+      default: ./Dockerfile
+  workspaces:
+    - name: source
   steps:
     - name: build-and-push
+      workingDir: $(workspaces.source.path)
       image: gcr.io/kaniko-project/executor:v0.16.0
       command:
         - /kaniko/executor
       args:
         - --dockerfile=$(params.pathToDockerFile)
-        - --destination=$(resources.outputs.builtImage.url)
-        - --context=$(params.pathToContext)
+        - --destination=$(params.IMAGE)
+        - --context=$(workspaces.source.path)/$(params.pathToContext)
 ---
 # Finally, we need something to receive our cloudevent announcing success!
 # That is this services only purpose

--- a/docs/getting-started/triggers.yaml
+++ b/docs/getting-started/triggers.yaml
@@ -22,21 +22,22 @@ spec:
         serviceAccountName: tekton-triggers-example-sa
         pipelineRef:
           name: getting-started-pipeline
-        resources:
-          - name: source-repo
-            resourceSpec:
-              type: git
-              params:
-              - name: revision
-                value: $(tt.params.gitrevision)
-              - name: url
-                value: $(tt.params.gitrepositoryurl)
-          - name: image-source
-            resourceSpec:
-              type: image
-              params:
-                - name: url
-                  value: DOCKERREPO-REPLACEME # docker-repo-location.com/repo:getting-started
+        params:
+        - name: git-revision
+          value: $(tt.params.gitrevision)
+        - name: git-url
+          value: $(tt.params.gitrepositoryurl)
+        - name: url
+          value: DOCKERREPO-REPLACEME # docker-repo-location.com/repo:getting-started
+        workspaces:
+        - name: git-source
+          volumeClaimTemplate:
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 1Gi
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation.go
@@ -23,11 +23,13 @@ import (
 	"fmt"
 
 	"github.com/tektoncd/triggers/pkg/apis/triggers"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/webhook/resourcesemantics"
 )
 
 var (
@@ -36,6 +38,13 @@ var (
 		"TLS_KEY",
 	)
 )
+
+var _ resourcesemantics.VerbLimited = (*EventListener)(nil)
+
+// SupportedVerbs returns the operations that validation should be called for
+func (e *EventListener) SupportedVerbs() []admissionregistrationv1.OperationType {
+	return []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update}
+}
 
 // Validate EventListener.
 func (e *EventListener) Validate(ctx context.Context) *apis.FieldError {

--- a/test/eventlistener_test.go
+++ b/test/eventlistener_test.go
@@ -31,6 +31,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/tektoncd/triggers/pkg/apis/triggers"
 	"knative.dev/pkg/ptr"
@@ -39,7 +40,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	eventReconciler "github.com/tektoncd/triggers/pkg/reconciler/eventlistener"
 	"github.com/tektoncd/triggers/pkg/reconciler/eventlistener/resources"
@@ -132,53 +133,35 @@ func TestEventListenerCreate(t *testing.T) {
 	t.Log("Start EventListener e2e test")
 
 	// TemplatedPipelineResources
-	pr1 := v1alpha1.PipelineResource{
+	tr1 := pipelinev1.TaskRun{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "PipelineResource",
-			APIVersion: "tekton.dev/v1alpha1",
+			APIVersion: "tekton.dev/v1",
+			Kind:       "TaskRun",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pr1",
+			Name:      "tr1",
 			Namespace: namespace,
 			Labels: map[string]string{
 				"$(tt.params.oneparam)": "$(tt.params.oneparam)",
 			},
 		},
-		Spec: v1alpha1.PipelineResourceSpec{
-			Type: "git",
-		},
-	}
-	pr1Bytes, err := json.Marshal(pr1)
-	if err != nil {
-		t.Fatalf("Error marshalling PipelineResource 1: %s", err)
-	}
-	// This is a templated resource, which does not have a namespace.
-	// This is defaulted to the EventListener namespace.
-	pr2 := v1alpha1.PipelineResource{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "PipelineResource",
-			APIVersion: "tekton.dev/v1alpha1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "pr2",
-			Labels: map[string]string{
-				"$(tt.params.twoparamname)": "$(tt.params.twoparamvalue)",
+		Spec: pipelinev1.TaskRunSpec{
+			Params: []pipelinev1.Param{{
+				Name: "url",
+				Value: pipelinev1.ParamValue{
+					Type:      pipelinev1.ParamTypeString,
+					StringVal: "$(tt.params.url)",
+				}}},
+			TaskRef: &pipelinev1.TaskRef{
+				Name: "git-clone",
 			},
 		},
-		Spec: v1alpha1.PipelineResourceSpec{
-			Type: "git",
-			Params: []v1alpha1.ResourceParam{
-				{Name: "license", Value: "$(tt.params.license)"},
-				{Name: "header", Value: "$(tt.params.header)"},
-				{Name: "prmessage", Value: "$(tt.params.prmessage)"},
-			},
-		},
-	}
-	pr2Bytes, err := json.Marshal(pr2)
-	if err != nil {
-		t.Fatalf("Error marshalling ResourceTemplate PipelineResource 2: %s", err)
 	}
 
+	tr1Bytes, err := json.Marshal(tr1)
+	if err != nil {
+		t.Fatalf("Error marshalling TaskRun 1: %s", err)
+	}
 	defaultValueStr := "defaultvalue"
 
 	// TriggerTemplate
@@ -199,7 +182,7 @@ func TestEventListenerCreate(t *testing.T) {
 						Name: "twoparamname",
 					},
 					{
-						Name:    "twoparamvalue",
+						Name:    "url",
 						Default: &defaultValueStr,
 					},
 					{
@@ -214,10 +197,7 @@ func TestEventListenerCreate(t *testing.T) {
 				},
 				ResourceTemplates: []triggersv1.TriggerResourceTemplate{
 					{
-						RawExtension: runtime.RawExtension{Raw: pr1Bytes},
-					},
-					{
-						RawExtension: runtime.RawExtension{Raw: pr2Bytes},
+						RawExtension: runtime.RawExtension{Raw: tr1Bytes},
 					},
 				},
 			},
@@ -294,7 +274,7 @@ func TestEventListenerCreate(t *testing.T) {
 				Verbs:     []string{"get", "list", "watch"},
 			}, {
 				APIGroups: []string{"tekton.dev"},
-				Resources: []string{"pipelineresources"},
+				Resources: []string{"taskruns"},
 				Verbs:     []string{"create"},
 			}, {
 				APIGroups: []string{""},
@@ -385,46 +365,36 @@ func TestEventListenerCreate(t *testing.T) {
 	// Load the example pull request event data
 	eventBodyJSON := loadExamplePREventBytes(t)
 
+	timeout := metav1.Duration{Duration: time.Hour}
 	// Event body & Expected ResourceTemplates after instantiation
-	wantPr1 := v1alpha1.PipelineResource{
+	wantTr1 := pipelinev1.TaskRun{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "PipelineResource",
-			APIVersion: "tekton.dev/v1alpha1",
+			APIVersion: "tekton.dev/v1",
+			Kind:       "TaskRun",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pr1",
+			Name:      "tr1",
 			Namespace: namespace,
 			Labels: map[string]string{
-				resourceLabel: "my-eventlistener",
-				triggerLabel:  el.Spec.Triggers[0].Name,
-				"edited":      "edited",
+				"app.kubernetes.io/managed-by": "tekton-pipelines",
+				resourceLabel:                  "my-eventlistener",
+				triggerLabel:                   el.Spec.Triggers[0].Name,
+				"edited":                       "edited",
 			},
 		},
-		Spec: v1alpha1.PipelineResourceSpec{
-			Type: "git",
-		},
-	}
-	wantPr2 := v1alpha1.PipelineResource{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "PipelineResource",
-			APIVersion: "tekton.dev/v1alpha1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pr2",
-			Namespace: namespace,
-			Labels: map[string]string{
-				resourceLabel: "my-eventlistener",
-				triggerLabel:  el.Spec.Triggers[0].Name,
-				"open":        "defaultvalue",
+		Spec: pipelinev1.TaskRunSpec{
+			Params: []pipelinev1.Param{{
+				Name: "url",
+				Value: pipelinev1.ParamValue{
+					Type:      pipelinev1.ParamTypeString,
+					StringVal: defaultValueStr,
+				}}},
+			ServiceAccountName: "default",
+			TaskRef: &pipelinev1.TaskRef{
+				Name: "git-clone",
+				Kind: "Task",
 			},
-		},
-		Spec: v1alpha1.PipelineResourceSpec{
-			Type: "git",
-			Params: []v1alpha1.ResourceParam{
-				{Name: "license", Value: `{"key":"apache-2.0","name":"Apache License 2.0","spdx_id":"Apache-2.0","url":"https://api.github.com/licenses/apache-2.0","node_id":"MDc6TGljZW5zZTI="}`},
-				{Name: "header", Value: `{"Accept-Encoding":"gzip","Content-Length":"2154","Content-Type":"application/json","User-Agent":"Go-http-client/1.1"}`},
-				{Name: "prmessage", Value: "Git admission control\r\n\r\nNow with new lines!\r\n\r\n# :sunglasses: \r\n\r\naw yis"},
-			},
+			Timeout: &timeout,
 		},
 	}
 
@@ -513,24 +483,24 @@ func TestEventListenerCreate(t *testing.T) {
 		t.Errorf("sink response no eventID")
 	}
 
-	for _, wantPr := range []v1alpha1.PipelineResource{wantPr1, wantPr2} {
-		if err = WaitFor(pipelineResourceExist(t, c, namespace, wantPr.Name)); err != nil {
-			t.Fatalf("Failed to create ResourceTemplate %s: %s", wantPr.Name, err)
+	for _, wantTr := range []pipelinev1.TaskRun{wantTr1} {
+		if err = WaitFor(taskrunExist(t, c, namespace, wantTr.Name)); err != nil {
+			t.Fatalf("Failed to create TaskRun %s: %s", wantTr.Name, err)
 		}
-		gotPr, err := c.ResourceClient.TektonV1alpha1().PipelineResources(namespace).Get(context.Background(), wantPr.Name, metav1.GetOptions{})
+		gotTr, err := c.PipelineClient.TektonV1().TaskRuns(namespace).Get(context.Background(), wantTr.Name, metav1.GetOptions{})
 		if err != nil {
-			t.Errorf("Error getting ResourceTemplate: %s: %s", wantPr.Name, err)
+			t.Errorf("Error getting TaskRun: %s: %s", wantTr.Name, err)
 		}
-		if gotPr.Labels[eventIDLabel] == "" {
-			t.Errorf("Instantiated ResourceTemplate missing EventId")
+		if gotTr.Labels[eventIDLabel] == "" {
+			t.Errorf("Instantiated TaskRun missing EventId")
 		} else {
-			delete(gotPr.Labels, eventIDLabel)
+			delete(gotTr.Labels, eventIDLabel)
 		}
-		if diff := cmp.Diff(wantPr.Labels, gotPr.Labels); diff != "" {
-			t.Errorf("Diff instantiated ResourceTemplate labels %s: -want +got: %s", wantPr.Name, diff)
+		if diff := cmp.Diff(wantTr.Labels, gotTr.Labels); diff != "" {
+			t.Errorf("Diff instantiated TaskRun labels %s: -want +got: %s", wantTr.Name, diff)
 		}
-		if diff := cmp.Diff(wantPr.Spec, gotPr.Spec, cmp.Comparer(compareParamsWithLicenseJSON)); diff != "" {
-			t.Errorf("Diff instantiated ResourceTemplate spec %s: -want +got: %s", wantPr.Name, diff)
+		if diff := cmp.Diff(wantTr.Spec, gotTr.Spec); diff != "" {
+			t.Errorf("Diff instantiated TaskRun spec %s: -want +got: %s", wantTr.Name, diff)
 		}
 	}
 
@@ -571,43 +541,6 @@ func TestEventListenerCreate(t *testing.T) {
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		t.Errorf("sink returned 401/403 response: %d", resp.StatusCode)
 	}
-}
-
-// The structure of this field corresponds to values for the `license` key in
-// testdata/pr.json, and can be used to unmarshal the dat.
-type license struct {
-	Key    string `json:"key"`
-	Name   string `json:"name"`
-	SpdxID string `json:"spdx_id"`
-	URL    string `json:"url"`
-	NodeID string `json:"node_id"`
-}
-
-// compareParamsWithLicenseJSON will compare the passed in ResourceParams by further checking
-// when the values aren't equal if they can be unmarshalled into the license object and if they are
-// then equal. This is because the order of values in a dictionary is not deterministic and dictionary
-// values passed through an event listener may change order.
-func compareParamsWithLicenseJSON(x, y v1alpha1.ResourceParam) bool {
-	xData := license{}
-	yData := license{}
-	if x.Name == y.Name {
-		if x.Value != y.Value {
-			// In order to compare these values, we are first unmarshalling them into the expected
-			// structures because differences in the dictionary order of keys can cause
-			// a string comparison to fail.
-			if err := json.Unmarshal([]byte(x.Value), &xData); err != nil {
-				return false
-			}
-			if err := json.Unmarshal([]byte(y.Value), &yData); err != nil {
-				return false
-			}
-			if diff := cmp.Diff(xData, yData); diff != "" {
-				return false
-			}
-		}
-		return true
-	}
-	return false
 }
 
 func cleanup(t *testing.T, c *clients, namespace, elName string) {

--- a/test/wait.go
+++ b/test/wait.go
@@ -104,10 +104,10 @@ func serviceNotExist(t *testing.T, c *clients, namespace, name string) wait.Cond
 	}
 }
 
-// pipelineResourceExist returns a function that checks if the specified PipelineResource exists
-func pipelineResourceExist(t *testing.T, c *clients, namespace, name string) wait.ConditionFunc {
+// taskrunexist returns a function that checks if the specified TaskRun exists
+func taskrunExist(t *testing.T, c *clients, namespace, name string) wait.ConditionFunc {
 	return func() (bool, error) {
-		_, err := c.ResourceClient.TektonV1alpha1().PipelineResources(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		_, err := c.PipelineClient.TektonV1beta1().TaskRuns(namespace).Get(context.Background(), name, metav1.GetOptions{})
 		if err != nil && errors.IsNotFound(err) {
 			return false, nil
 		}


### PR DESCRIPTION
# Changes
Fixes : https://github.com/tektoncd/triggers/issues/1515

Issue: Triggers integration tests are failing for below reason
```
Error from server (BadRequest): error when creating "/home/prow/go/src/github.com/tektoncd/triggers/docs/getting-started/pipeline.yaml": admission webhook "webhook.pipeline.tekton.dev" denied the request: mutation failed: cannot decode incoming new object: json: unknown field "resources"
Error from server (BadRequest): error when creating "/home/prow/go/src/github.com/tektoncd/triggers/docs/getting-started/pipeline.yaml": admission webhook "webhook.pipeline.tekton.dev" denied the request: mutation failed: cannot decode incoming new object: json: unknown field "resources"
Error from server (BadRequest): error when creating "/home/prow/go/src/github.com/tektoncd/triggers/docs/getting-started/pipeline.yaml": admission webhook "webhook.pipeline.tekton.dev" denied the request: mutation failed: cannot decode incoming new object: json: unknown field "resources"
```
Because latest Pipeline release has removed support of `Resources`

Changes: Removed all resources from getting-started example and replaced by Task resolver

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
Removed Pipeline resources from Triggers
```