### PR TITLE
[Release v0.23 Cherry Pick] Add SecurityContext to Eventlistener containers under el-security-context flag

### DIFF
--- a/pkg/reconciler/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/eventlistener/eventlistener_test.go
@@ -885,6 +885,7 @@ func TestReconcile(t *testing.T) {
 
 	deploymentMissingSecurityContext := makeDeployment(func(d *appsv1.Deployment) {
 		d.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{}
+		d.Spec.Template.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{}
 	})
 
 	deploymentEventListenerEvent := makeDeployment(func(d *appsv1.Deployment) {


### PR DESCRIPTION
# Changes

As part of this PR https://github.com/tektoncd/triggers/pull/1494 we introduced SecurityContext for Eventlistener containers
But for Openshift its not working so adding condition check to set SecurityContext for Eventlistener containers
Reason:
On Openshift cluster when we install Triggers EL container failed to start with below error

```
message: >-
        pods "el-listener-embed-binding-7b6bc5d595-" is forbidden: unable to
        validate against any security context constraint: [provider "anyuid":
        Forbidden: not usable by user or serviceaccount,
        pod.metadata.annotations[container.seccomp.security.alpha.kubernetes.io/event-listener]:
        Forbidden: seccomp may not be set,
        spec.containers[0].securityContext.runAsUser: Invalid value: 65532: must
        be in the ranges: [1001190000, 1001199999], provider "restricted":
        Forbidden: not usable by user or serviceaccount, provider "nonroot-v2":
        Forbidden: not usable by user or serviceaccount, provider "nonroot":
        Forbidden: not usable by user or serviceaccount, provider
        "hostmount-anyuid": Forbidden: not usable by user or serviceaccount,
        provider "machine-api-termination-handler": Forbidden: not usable by
        user or serviceaccount, provider "hostnetwork-v2": Forbidden: not usable
        by user or serviceaccount, provider "hostnetwork": Forbidden: not usable
        by user or serviceaccount, provider "hostaccess": Forbidden: not usable
        by user or serviceaccount, provider "node-exporter": Forbidden: not
        usable by user or serviceaccount, provider "privileged": Forbidden: not
        usable by user or serviceaccount] 
```

It doesn't allow to set that's why added SecurityContext to Eventlistener containers under el-security-context flag which is True by default so it won't create any issue for K8S

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
