### PR TITLE
Remove comparing serviceaccount in tests

### DIFF
--- a/test/eventlistener_test.go
+++ b/test/eventlistener_test.go
@@ -66,6 +66,11 @@ const (
 	examplePRJsonFilename = "pr.json"
 )
 
+var (
+	// ignoreSATaskRunSpec ignores the service account in the TaskRunSpec as it may differ across platforms
+	ignoreSATaskRunSpec = cmpopts.IgnoreFields(pipelinev1.TaskRunSpec{}, "ServiceAccountName")
+)
+
 func loadExamplePREventBytes(t *testing.T) []byte {
 	t.Helper()
 	path := filepath.Join("testdata", examplePRJsonFilename)
@@ -389,7 +394,6 @@ func TestEventListenerCreate(t *testing.T) {
 					Type:      pipelinev1.ParamTypeString,
 					StringVal: defaultValueStr,
 				}}},
-			ServiceAccountName: "default",
 			TaskRef: &pipelinev1.TaskRef{
 				Name: "git-clone",
 				Kind: "Task",
@@ -499,7 +503,7 @@ func TestEventListenerCreate(t *testing.T) {
 		if diff := cmp.Diff(wantTr.Labels, gotTr.Labels); diff != "" {
 			t.Errorf("Diff instantiated TaskRun labels %s: -want +got: %s", wantTr.Name, diff)
 		}
-		if diff := cmp.Diff(wantTr.Spec, gotTr.Spec); diff != "" {
+		if diff := cmp.Diff(wantTr.Spec, gotTr.Spec, ignoreSATaskRunSpec); diff != "" {
 			t.Errorf("Diff instantiated TaskRun spec %s: -want +got: %s", wantTr.Name, diff)
 		}
 	}


### PR DESCRIPTION
This will remove comparing service account in eventlistener create test as the default serviceaccount can be different on different platforms like operator on OpenShift

This remove the serviceaccount field from expected output and also add ignore field in cmp.Diff

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/triggers/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Remove comparing serviceaccount in tests
```