### PR TITLE
drop manual use of knative.dev/pkg::injection.Dynamic

### DIFF
--- a/cmd/eventlistenersink/main.go
+++ b/cmd/eventlistenersink/main.go
@@ -47,15 +47,7 @@ func main() {
 	dc = dynamicClientset.New(tekton.WithClient(dc))
 	ctx = context.WithValue(ctx, dynamicclient.Key{}, dc)
 
-	// Set up ctx with the set of things based on the
-	// dynamic client we've set up above.
-	ctx = injection.Dynamic.SetupDynamic(ctx)
-
 	sinkArgs, err := sink.GetArgs()
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-	sinkClients, err := sink.ConfigureClients(ctx, cfg)
 	if err != nil {
 		log.Fatal(err.Error())
 	}
@@ -71,6 +63,11 @@ func main() {
 	ictx, informers := injection.Default.SetupInformers(ctx, cfg)
 	if err := controller.StartInformers(ctx.Done(), informers...); err != nil {
 		log.Fatal("failed to start informers:", err)
+	}
+
+	sinkClients, err := sink.ConfigureClients(ctx, cfg)
+	if err != nil {
+		log.Fatal(err.Error())
 	}
 	ctx = ictx
 

--- a/pkg/reconciler/metrics/injection.go
+++ b/pkg/reconciler/metrics/injection.go
@@ -33,12 +33,6 @@ import (
 func init() {
 	injection.Default.RegisterClient(func(ctx context.Context, _ *rest.Config) context.Context { return WithClient(ctx) })
 	injection.Default.RegisterInformer(WithInformer)
-
-	injection.Dynamic.RegisterDynamicClient(WithClient)
-	injection.Dynamic.RegisterDynamicInformer(func(ctx context.Context) context.Context {
-		ctx, _ = WithInformer(ctx)
-		return ctx
-	})
 }
 
 // RecorderKey is used for associating the Recorder inside the context.Context.

--- a/pkg/sink/cloudevent/cloudeventclient.go
+++ b/pkg/sink/cloudevent/cloudeventclient.go
@@ -30,7 +30,6 @@ func init() {
 	injection.Default.RegisterClient(func(ctx context.Context, _ *rest.Config) context.Context {
 		return withCloudEventClient(ctx)
 	})
-	injection.Dynamic.RegisterDynamicClient(withCloudEventClient)
 }
 
 // CECKey is used to associate the CloudEventClient inside the context.Context


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes: https://github.com/tektoncd/triggers/issues/1593

Upstream Knative is maintaining some codegen to faciliate a k8s `dynamic.Client` being the underlying implementation of a `kubernetes.Interface` 

It turns out it doesn't really have any usage except for this repo.

We're looking to remove this functionality - (discussion https://github.com/knative/pkg/issues/2739#issuecomment-1550452957)

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
