### PR TITLE
Pass Content-Type Header to Interceptor

### DIFF
--- a/pkg/interceptors/interceptors.go
+++ b/pkg/interceptors/interceptors.go
@@ -32,6 +32,7 @@ import (
 
 const (
 	CoreInterceptorsHost = "tekton-triggers-core-interceptors"
+	ContentType          = "application/json"
 )
 
 // Interceptor is the interface that all interceptors implement.
@@ -124,6 +125,9 @@ func Execute(ctx context.Context, client *http.Client, req *triggersv1beta1.Inte
 	if err != nil {
 		return nil, err
 	}
+
+	r.Header.Set("Content-Type", ContentType)
+
 	res, err := client.Do(r)
 	if err != nil {
 		return nil, err

--- a/pkg/interceptors/interceptors_test.go
+++ b/pkg/interceptors/interceptors_test.go
@@ -354,6 +354,21 @@ func TestResolveToURL(t *testing.T) {
 	})
 }
 
+type localT struct {
+	T *testing.T
+}
+
+func (t localT) testHeader(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		contentType := r.Header.Get("Content-Type")
+		if contentType != interceptors.ContentType {
+			t.T.Fatalf("Header expected to be: %s but got :%s",
+				interceptors.ContentType, contentType)
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // testServer creates a httptest server with the passed in handler and returns a http.Client that
 // can be used to talk to these interceptors
 func testServer(t testing.TB, handler http.Handler, d ...*http.Transport) *http.Client {
@@ -427,7 +442,13 @@ func TestExecute(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to initialize core interceptors: %v", err)
 			}
-			httpClient := testServer(t, coreInterceptors)
+
+			lT := localT{
+				T: t,
+			}
+
+			handler := lT.testHeader(coreInterceptors)
+			httpClient := testServer(t, handler)
 			got, err := interceptors.Execute(context.Background(), httpClient, tc.req, tc.url)
 			if err != nil {
 				t.Fatalf("Execute() unexpected error: %s", err)
@@ -446,7 +467,7 @@ func TestExecute_Error(t *testing.T) {
 			"Content-Type": {"application/json"},
 		}),
 		Context: &triggersv1.TriggerContext{
-			EventURL:  "http://someurl.com",
+			EventURL:  "http://somurel.com",
 			EventID:   "abcde",
 			TriggerID: "namespaces/default/triggers/test-trigger",
 		},


### PR DESCRIPTION
`Content-Type` should be passed to the interceptor while making the POST Request. Some frameworks in different languages like Java require this. So interceptor request fails with 415 in those.

Fixes #1614
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Now `Content-Type: application/json` is passed to the interceptor while making the request. 
```
