### PR TITLE
Fix integraion Test by upgrading Knative

### DIFF
--- a/test/e2e-tests-examples.sh
+++ b/test/e2e-tests-examples.sh
@@ -39,18 +39,19 @@ err() {
 
 install_knative_serving() {
   # Install Knative by referring https://knative.dev/docs/admin/install/serving/install-serving-with-yaml/#install-the-knative-serving-component
-  kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.6.0/serving-crds.yaml
-  kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.6.0/serving-core.yaml
+  kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.10.2/serving-crds.yaml
+  kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.10.2/serving-core.yaml
 
   # Wait for pods to be running in the namespaces we are deploying to
   wait_until_pods_running knative-serving || fail_test "Knative Serving did not come up"
 
-  kubectl apply -f https://github.com/knative/net-kourier/releases/download/knative-v1.6.0/kourier.yaml
+  kubectl apply -f https://github.com/knative/net-kourier/releases/download/knative-v1.10.0/kourier.yaml
 
   kubectl patch configmap/config-network \
     --namespace knative-serving \
     --type merge \
-    --patch '{"data":{"ingress.class":"kourier.ingress.networking.knative.dev"}}'
+    --patch '{"data":{"ingress-class":"kourier.ingress.networking.knative.dev"}}'
+
 
   # Wait for pods to be running in the namespaces we are deploying to
   wait_until_pods_running knative-serving || fail_test "Knative Serving & Kourier did not come up"


### PR DESCRIPTION
Knative 1.6 doesn't install on the current cluster. So updated it to the latest version.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
