### PR TITLE
Fix SA1019 error by staticcheck due to deprecation

### DIFF
--- a/cmd/triggerrun/cmd/root_test.go
+++ b/cmd/triggerrun/cmd/root_test.go
@@ -27,8 +27,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	triggersclientset "github.com/tektoncd/triggers/pkg/client/clientset/versioned"
 	"github.com/tektoncd/triggers/pkg/sink"
@@ -127,7 +126,7 @@ func Test_processTriggerSpec(t *testing.T) {
 	if err != nil {
 		t.Errorf("Cannot create a new request:%s", err)
 	}
-	taskRunTemplate := pipelinev1beta1.TaskRun{
+	taskRunTemplate := pipelinev1.TaskRun{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "tekton.dev/v1alpha1",
 			Kind:       "TaskRun",
@@ -139,8 +138,8 @@ func Test_processTriggerSpec(t *testing.T) {
 				"someLabel": "$(tt.params.foo)",
 			},
 		},
-		Spec: pipelinev1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
+		Spec: pipelinev1.TaskRunSpec{
+			TaskRef: &pipelinev1.TaskRef{
 				Name: "my-task", // non-existent task; just for testing
 			},
 		},
@@ -178,7 +177,7 @@ func Test_processTriggerSpec(t *testing.T) {
 		},
 	}
 
-	wantTaskRun := pipelinev1beta1.TaskRun{
+	wantTaskRun := pipelinev1.TaskRun{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "tekton.dev/v1alpha1",
 			Kind:       "TaskRun",
@@ -190,7 +189,7 @@ func Test_processTriggerSpec(t *testing.T) {
 				"someLabel": "bar", // replaced with the value of foo from bar
 			},
 		},
-		Spec: pipelinev1beta1.TaskRunSpec{
+		Spec: pipelinev1.TaskRunSpec{
 			TaskRef: taskRunTemplate.Spec.TaskRef, // non-existent task; just for testing
 		},
 	}

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation_test.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/triggers/pkg/apis/triggers"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
@@ -796,10 +795,10 @@ func TestEventListenerValidate_error(t *testing.T) {
 					Template: &v1alpha1.EventListenerTemplate{Ref: ptr.String("tt")},
 					Interceptors: []*v1alpha1.EventInterceptor{{
 						Webhook: &v1alpha1.WebhookInterceptor{
-							Header: []v1beta1.Param{{
+							Header: []pipelinev1.Param{{
 								Name: "non-canonical-header-key",
-								Value: v1beta1.ParamValue{
-									Type:      v1beta1.ParamTypeString,
+								Value: pipelinev1.ParamValue{
+									Type:      pipelinev1.ParamTypeString,
 									StringVal: "valid value",
 								},
 							}},
@@ -827,10 +826,10 @@ func TestEventListenerValidate_error(t *testing.T) {
 					Template: &v1alpha1.EventListenerTemplate{Ref: ptr.String("tt")},
 					Interceptors: []*v1alpha1.EventInterceptor{{
 						Webhook: &v1alpha1.WebhookInterceptor{
-							Header: []v1beta1.Param{{
+							Header: []pipelinev1.Param{{
 								Name: "",
-								Value: v1beta1.ParamValue{
-									Type:      v1beta1.ParamTypeString,
+								Value: pipelinev1.ParamValue{
+									Type:      pipelinev1.ParamTypeString,
 									StringVal: "valid value",
 								},
 							}},
@@ -858,10 +857,10 @@ func TestEventListenerValidate_error(t *testing.T) {
 					Template: &v1alpha1.EventListenerTemplate{Ref: ptr.String("tt")},
 					Interceptors: []*v1alpha1.EventInterceptor{{
 						Webhook: &v1alpha1.WebhookInterceptor{
-							Header: []v1beta1.Param{{
+							Header: []pipelinev1.Param{{
 								Name: "Valid-Header-Key",
-								Value: v1beta1.ParamValue{
-									Type:      v1beta1.ParamTypeString,
+								Value: pipelinev1.ParamValue{
+									Type:      pipelinev1.ParamTypeString,
 									StringVal: "",
 								},
 							}},

--- a/pkg/apis/triggers/v1alpha1/trigger_template_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_template_validation_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	"github.com/tektoncd/triggers/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,7 +33,7 @@ import (
 )
 
 func simpleResourceTemplate(t *testing.T) runtime.RawExtension {
-	return test.RawExtension(t, pipelinev1beta1.PipelineRun{
+	return test.RawExtension(t, pipelinev1.PipelineRun{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "tekton.dev/v1beta1",
 			Kind:       "PipelineRun",
@@ -42,7 +42,7 @@ func simpleResourceTemplate(t *testing.T) runtime.RawExtension {
 }
 
 func v1beta1ResourceTemplate(t *testing.T) runtime.RawExtension {
-	return test.RawExtension(t, pipelinev1beta1.PipelineRun{
+	return test.RawExtension(t, pipelinev1.PipelineRun{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "tekton.dev/v1beta1",
 			Kind:       "PipelineRun",
@@ -51,17 +51,17 @@ func v1beta1ResourceTemplate(t *testing.T) runtime.RawExtension {
 }
 
 func paramResourceTemplate(t *testing.T) runtime.RawExtension {
-	return test.RawExtension(t, pipelinev1beta1.PipelineRun{
+	return test.RawExtension(t, pipelinev1.PipelineRun{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "tekton.dev/v1beta1",
 			Kind:       "PipelineRun",
 		},
-		Spec: pipelinev1beta1.PipelineRunSpec{
-			Params: []pipelinev1beta1.Param{
+		Spec: pipelinev1.PipelineRunSpec{
+			Params: []pipelinev1.Param{
 				{
 					Name: "message",
-					Value: pipelinev1beta1.ParamValue{
-						Type:      pipelinev1beta1.ParamTypeString,
+					Value: pipelinev1.ParamValue{
+						Type:      pipelinev1.ParamTypeString,
 						StringVal: "$(tt.params.foo)",
 					},
 				},
@@ -71,17 +71,17 @@ func paramResourceTemplate(t *testing.T) runtime.RawExtension {
 }
 
 func invalidParamResourceTemplate(t *testing.T) runtime.RawExtension {
-	return test.RawExtension(t, pipelinev1beta1.PipelineRun{
+	return test.RawExtension(t, pipelinev1.PipelineRun{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "tekton.dev/v1beta1",
 			Kind:       "PipelineRun",
 		},
-		Spec: pipelinev1beta1.PipelineRunSpec{
-			Params: []pipelinev1beta1.Param{
+		Spec: pipelinev1.PipelineRunSpec{
+			Params: []pipelinev1.Param{
 				{
 					Name: "message",
-					Value: pipelinev1beta1.ParamValue{
-						Type:      pipelinev1beta1.ParamTypeString,
+					Value: pipelinev1.ParamValue{
+						Type:      pipelinev1.ParamTypeString,
 						StringVal: "$(.foo)",
 					},
 				},
@@ -208,7 +208,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 					Default:     ptr.String("val"),
 				}},
 				ResourceTemplates: []v1alpha1.TriggerResourceTemplate{{
-					RawExtension: test.RawExtension(t, pipelinev1beta1.PipelineRun{
+					RawExtension: test.RawExtension(t, pipelinev1.PipelineRun{
 						TypeMeta: metav1.TypeMeta{
 							APIVersion: "tekton.dev/v1alpha1",
 						},
@@ -234,7 +234,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 					Default:     ptr.String("val"),
 				}},
 				ResourceTemplates: []v1alpha1.TriggerResourceTemplate{{
-					RawExtension: test.RawExtension(t, pipelinev1beta1.PipelineRun{
+					RawExtension: test.RawExtension(t, pipelinev1.PipelineRun{
 						TypeMeta: metav1.TypeMeta{
 							Kind: "PipelineRun",
 						},
@@ -260,7 +260,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 					Default:     ptr.String("val"),
 				}},
 				ResourceTemplates: []v1alpha1.TriggerResourceTemplate{{
-					RawExtension: test.RawExtension(t, pipelinev1beta1.PipelineRun{
+					RawExtension: test.RawExtension(t, pipelinev1.PipelineRun{
 						TypeMeta: metav1.TypeMeta{
 							APIVersion: "foobar",
 							Kind:       "pipelinerun",
@@ -287,7 +287,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 					Default:     ptr.String("val"),
 				}},
 				ResourceTemplates: []v1alpha1.TriggerResourceTemplate{{
-					RawExtension: test.RawExtension(t, pipelinev1beta1.PipelineRun{
+					RawExtension: test.RawExtension(t, pipelinev1.PipelineRun{
 						TypeMeta: metav1.TypeMeta{
 							APIVersion: "foo",
 							Kind:       "tekton.dev/v1alpha1",

--- a/pkg/apis/triggers/v1alpha1/trigger_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_validation_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	"github.com/tektoncd/triggers/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/apis/triggers/v1beta1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_validation_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/triggers/pkg/apis/triggers"
 	triggersv1beta1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
@@ -461,7 +462,7 @@ func Test_EventListenerValidate(t *testing.T) {
 								Default:     ptr.String("val"),
 							}},
 							ResourceTemplates: []triggersv1beta1.TriggerResourceTemplate{{
-								RawExtension: test.RawExtension(t, pipelinev1beta1.PipelineRun{
+								RawExtension: test.RawExtension(t, pipelinev1.PipelineRun{
 									TypeMeta: metav1.TypeMeta{
 										APIVersion: "tekton.dev/v1beta1",
 										Kind:       "TaskRun",

--- a/pkg/apis/triggers/v1beta1/trigger_template_validation_test.go
+++ b/pkg/apis/triggers/v1beta1/trigger_template_validation_test.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"testing"
 
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	pipelinev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
-	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,7 +33,7 @@ import (
 )
 
 func simpleResourceTemplate(t *testing.T) runtime.RawExtension {
-	return test.RawExtension(t, pipelinev1beta1.PipelineRun{
+	return test.RawExtension(t, pipelinev1.PipelineRun{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "tekton.dev/v1beta1",
 			Kind:       "PipelineRun",
@@ -42,7 +42,7 @@ func simpleResourceTemplate(t *testing.T) runtime.RawExtension {
 }
 
 func v1beta1ResourceTemplate(t *testing.T) runtime.RawExtension {
-	return test.RawExtension(t, pipelinev1beta1.PipelineRun{
+	return test.RawExtension(t, pipelinev1.PipelineRun{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "tekton.dev/v1beta1",
 			Kind:       "PipelineRun",
@@ -60,17 +60,17 @@ func v1alpha1ResourceTemplate(t *testing.T) runtime.RawExtension {
 }
 
 func paramResourceTemplate(t *testing.T) runtime.RawExtension {
-	return test.RawExtension(t, pipelinev1beta1.PipelineRun{
+	return test.RawExtension(t, pipelinev1.PipelineRun{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "tekton.dev/v1beta1",
 			Kind:       "PipelineRun",
 		},
-		Spec: pipelinev1beta1.PipelineRunSpec{
-			Params: []pipelinev1beta1.Param{
+		Spec: pipelinev1.PipelineRunSpec{
+			Params: []pipelinev1.Param{
 				{
 					Name: "message",
-					Value: pipelinev1beta1.ParamValue{
-						Type:      pipelinev1beta1.ParamTypeString,
+					Value: pipelinev1.ParamValue{
+						Type:      pipelinev1.ParamTypeString,
 						StringVal: "$(tt.params.foo)",
 					},
 				},
@@ -80,17 +80,17 @@ func paramResourceTemplate(t *testing.T) runtime.RawExtension {
 }
 
 func invalidParamResourceTemplate(t *testing.T) runtime.RawExtension {
-	return test.RawExtension(t, pipelinev1beta1.PipelineRun{
+	return test.RawExtension(t, pipelinev1.PipelineRun{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "tekton.dev/v1beta1",
 			Kind:       "PipelineRun",
 		},
-		Spec: pipelinev1beta1.PipelineRunSpec{
-			Params: []pipelinev1beta1.Param{
+		Spec: pipelinev1.PipelineRunSpec{
+			Params: []pipelinev1.Param{
 				{
 					Name: "message",
-					Value: pipelinev1beta1.ParamValue{
-						Type:      pipelinev1beta1.ParamTypeString,
+					Value: pipelinev1.ParamValue{
+						Type:      pipelinev1.ParamTypeString,
 						StringVal: "$(.foo)",
 					},
 				},
@@ -199,7 +199,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 					Default:     ptr.String("val"),
 				}},
 				ResourceTemplates: []v1beta1.TriggerResourceTemplate{{
-					RawExtension: test.RawExtension(t, pipelinev1beta1.PipelineRun{
+					RawExtension: test.RawExtension(t, pipelinev1.PipelineRun{
 						TypeMeta: metav1.TypeMeta{
 							APIVersion: "tekton.dev/v1beta1",
 						},
@@ -225,7 +225,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 					Default:     ptr.String("val"),
 				}},
 				ResourceTemplates: []v1beta1.TriggerResourceTemplate{{
-					RawExtension: test.RawExtension(t, pipelinev1beta1.PipelineRun{
+					RawExtension: test.RawExtension(t, pipelinev1.PipelineRun{
 						TypeMeta: metav1.TypeMeta{
 							Kind: "PipelineRun",
 						},
@@ -251,7 +251,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 					Default:     ptr.String("val"),
 				}},
 				ResourceTemplates: []v1beta1.TriggerResourceTemplate{{
-					RawExtension: test.RawExtension(t, pipelinev1beta1.PipelineRun{
+					RawExtension: test.RawExtension(t, pipelinev1.PipelineRun{
 						TypeMeta: metav1.TypeMeta{
 							APIVersion: "foobar",
 							Kind:       "pipelinerun",
@@ -278,7 +278,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 					Default:     ptr.String("val"),
 				}},
 				ResourceTemplates: []v1beta1.TriggerResourceTemplate{{
-					RawExtension: test.RawExtension(t, pipelinev1beta1.PipelineRun{
+					RawExtension: test.RawExtension(t, pipelinev1.PipelineRun{
 						TypeMeta: metav1.TypeMeta{
 							APIVersion: "foo",
 							Kind:       "tekton.dev/v1beta1",

--- a/pkg/resources/create_test.go
+++ b/pkg/resources/create_test.go
@@ -24,7 +24,7 @@ import (
 	"go.uber.org/zap/zaptest"
 
 	"github.com/google/go-cmp/cmp"
-	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/triggers/pkg/apis/triggers"
 	dynamicclientset "github.com/tektoncd/triggers/pkg/client/dynamic/clientset"
 	"github.com/tektoncd/triggers/pkg/client/dynamic/clientset/tekton"
@@ -142,11 +142,11 @@ func TestCreateResource(t *testing.T) {
 	tests := []struct {
 		name string
 		json []byte
-		want pipelinev1beta1.TaskRun
+		want pipelinev1.TaskRun
 	}{{
 		name: "TaskRun without namespace",
 		json: json.RawMessage(`{"kind":"TaskRun","apiVersion":"tekton.dev/v1beta1","metadata":{"name":"my-taskrun","creationTimestamp":null,"labels":{"someLabel":"bar"}},"spec":{"serviceAccountName":"","taskRef":{"name":"my-task"}},"status":{"podName": ""}}`),
-		want: pipelinev1beta1.TaskRun{
+		want: pipelinev1.TaskRun{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "tekton.dev/v1beta1",
 				Kind:       "TaskRun",
@@ -160,19 +160,19 @@ func TestCreateResource(t *testing.T) {
 					eventIDLabel:  eventID,
 				},
 			},
-			Spec: pipelinev1beta1.TaskRunSpec{
-				TaskRef: &pipelinev1beta1.TaskRef{
+			Spec: pipelinev1.TaskRunSpec{
+				TaskRef: &pipelinev1.TaskRef{
 					Name: "my-task", // non-existent task; just for testing
 				},
 			},
-			Status: pipelinev1beta1.TaskRunStatus{},
+			Status: pipelinev1.TaskRunStatus{},
 		},
 	},
 
 		{
 			name: "TaskRun with namespace",
 			json: json.RawMessage(`{"kind":"TaskRun","apiVersion":"tekton.dev/v1beta1","metadata":{"name":"my-taskrun","namespace":"bar","creationTimestamp":null,"labels":{"someLabel":"bar"}},"spec":{"serviceAccountName":"","taskRef":{"name":"my-task"}},"status":{"podName":""}}`),
-			want: pipelinev1beta1.TaskRun{
+			want: pipelinev1.TaskRun{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "tekton.dev/v1beta1",
 					Kind:       "TaskRun",
@@ -187,12 +187,12 @@ func TestCreateResource(t *testing.T) {
 						eventIDLabel:  eventID,
 					},
 				},
-				Spec: pipelinev1beta1.TaskRunSpec{
-					TaskRef: &pipelinev1beta1.TaskRef{
+				Spec: pipelinev1.TaskRunSpec{
+					TaskRef: &pipelinev1.TaskRef{
 						Name: "my-task", // non-existent task; just for testing
 					},
 				},
-				Status: pipelinev1beta1.TaskRunStatus{},
+				Status: pipelinev1.TaskRunStatus{},
 			},
 		},
 	}

--- a/pkg/sink/metrics_test.go
+++ b/pkg/sink/metrics_test.go
@@ -39,7 +39,7 @@ func TestRecordResourceCreation(t *testing.T) {
 	}{{
 		name: "single pipelinerun",
 		resources: []json.RawMessage{
-			[]byte(`{"apiVersion": "tekton.dev/v1beta1","kind": "PipelineRun","metadata": {"name": "simple-pipeline-run-lddt9"}}`),
+			[]byte(`{"apiVersion": "tekton.dev/v1","kind": "PipelineRun","metadata": {"name": "simple-pipeline-run-lddt9"}}`),
 		},
 		resourceCounts: map[string]int64{
 			"PipelineRun": 1,
@@ -47,9 +47,9 @@ func TestRecordResourceCreation(t *testing.T) {
 	}, {
 		name: "pipelinerun and taskrun",
 		resources: []json.RawMessage{
-			[]byte(`{"apiVersion": "tekton.dev/v1beta1","kind": "PipelineRun","metadata": {"name": "simple-pipeline-run-lddt9"}}`),
-			[]byte(`{"apiVersion": "tekton.dev/v1beta1","kind": "PipelineRun","metadata": {"name": "simple-pipeline-run-asdf1"}}`),
-			[]byte(`{"apiVersion": "tekton.dev/v1beta1","kind": "TaskRun","metadata": {"name": "simple-pipeline-run-lkjs9"}}`),
+			[]byte(`{"apiVersion": "tekton.dev/v1","kind": "PipelineRun","metadata": {"name": "simple-pipeline-run-lddt9"}}`),
+			[]byte(`{"apiVersion": "tekton.dev/v1","kind": "PipelineRun","metadata": {"name": "simple-pipeline-run-asdf1"}}`),
+			[]byte(`{"apiVersion": "tekton.dev/v1","kind": "TaskRun","metadata": {"name": "simple-pipeline-run-lkjs9"}}`),
 		},
 		resourceCounts: map[string]int64{
 			"PipelineRun": 2,

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -36,7 +36,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gorilla/mux"
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	triggersv1alpha1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 	triggersv1beta1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	dynamicclientset "github.com/tektoncd/triggers/pkg/client/dynamic/clientset"
@@ -262,7 +263,7 @@ func checkSinkResponse(t *testing.T, resp *http.Response, elName string) {
 func trResourceTemplate(t testing.TB) runtime.RawExtension {
 	return test.RawExtension(t, pipelinev1.TaskRun{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "tekton.dev/v1beta1",
+			APIVersion: "tekton.dev/v1",
 			Kind:       "TaskRun",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -332,7 +333,7 @@ func TestHandleEvent(t *testing.T) {
 		// gitCloneTaskRun with values from gitCloneTBSpec
 		gitCloneTaskRun = pipelinev1.TaskRun{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "tekton.dev/v1beta1",
+				APIVersion: "tekton.dev/v1",
 				Kind:       "TaskRun",
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -883,10 +884,10 @@ func TestHandleEvent(t *testing.T) {
 								Kind:       "Service",
 								Name:       "foo",
 							},
-							Header: []pipelinev1.Param{{
+							Header: []pipelinev1beta1.Param{{
 								Name: "Name",
-								Value: pipelinev1.ParamValue{
-									Type:      pipelinev1.ParamTypeString,
+								Value: pipelinev1beta1.ParamValue{
+									Type:      pipelinev1beta1.ParamTypeString,
 									StringVal: "name-from-webhook",
 								},
 							}},
@@ -932,7 +933,7 @@ func TestHandleEvent(t *testing.T) {
 		eventBody: eventBody,
 		want: []pipelinev1.TaskRun{{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "tekton.dev/v1beta1",
+				APIVersion: "tekton.dev/v1",
 				Kind:       "TaskRun",
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -1069,7 +1070,7 @@ func TestHandleEvent(t *testing.T) {
 		want: []pipelinev1.TaskRun{
 			{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: "tekton.dev/v1beta1",
+					APIVersion: "tekton.dev/v1",
 					Kind:       "TaskRun",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -1096,7 +1097,7 @@ func TestHandleEvent(t *testing.T) {
 			},
 			{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: "tekton.dev/v1beta1",
+					APIVersion: "tekton.dev/v1",
 					Kind:       "TaskRun",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -1764,7 +1765,7 @@ func TestCloudEventHandling(t *testing.T) {
 
 	gitCloneTaskRun := pipelinev1.TaskRun{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "tekton.dev/v1beta1",
+			APIVersion: "tekton.dev/v1",
 			Kind:       "TaskRun",
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/template/resource_test.go
+++ b/pkg/template/resource_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"github.com/tektoncd/triggers/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/resources.go
+++ b/test/resources.go
@@ -66,6 +66,17 @@ func AddTektonResources(clientset *fakekubeclientset.Clientset) {
 	})
 
 	clientset.Resources = append(clientset.Resources, &metav1.APIResourceList{
+		GroupVersion: "tekton.dev/v1",
+		APIResources: []metav1.APIResource{{
+			Group:      "tekton.dev",
+			Version:    "v1",
+			Namespaced: true,
+			Name:       "taskruns",
+			Kind:       "TaskRun",
+		}},
+	})
+
+	clientset.Resources = append(clientset.Resources, &metav1.APIResourceList{
 		GroupVersion: "tekton.dev/v1beta1",
 		APIResources: []metav1.APIResource{{
 			Group:      "tekton.dev",
@@ -75,4 +86,5 @@ func AddTektonResources(clientset *fakekubeclientset.Clientset) {
 			Kind:       "TaskRun",
 		}},
 	})
+
 }


### PR DESCRIPTION
Fix SA1019 error given by staticcheck due to deprecation of Pipeline v1beta1.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
