### PR TITLE
Fix EL Status URL for kubernetesresource.serviceport

### DIFF
--- a/pkg/reconciler/eventlistener/resources/service.go
+++ b/pkg/reconciler/eventlistener/resources/service.go
@@ -77,7 +77,7 @@ func ServicePort(el *v1beta1.EventListener, c Config) corev1.ServicePort {
 	var elCert, elKey string
 
 	servicePortName := eventListenerServicePortName
-	servicePortPort := *c.Port
+	servicePort := *c.Port
 
 	certEnv := map[string]*corev1.EnvVarSource{}
 	if el.Spec.Resources.KubernetesResource != nil {
@@ -86,6 +86,9 @@ func ServicePort(el *v1beta1.EventListener, c Config) corev1.ServicePort {
 				certEnv[el.Spec.Resources.KubernetesResource.Template.Spec.Containers[0].Env[i].Name] =
 					el.Spec.Resources.KubernetesResource.Template.Spec.Containers[0].Env[i].ValueFrom
 			}
+		}
+		if el.Spec.Resources.KubernetesResource.ServicePort != nil {
+			servicePort = int(*el.Spec.Resources.KubernetesResource.ServicePort)
 		}
 	}
 
@@ -105,14 +108,14 @@ func ServicePort(el *v1beta1.EventListener, c Config) corev1.ServicePort {
 		if *c.Port == DefaultPort {
 			// We return port 8443 if TLS is enabled and the default HTTP port is set.
 			// This effectively makes 8443 the default HTTPS port unless a user explicitly sets a different port.
-			servicePortPort = 8443
+			servicePort = 8443
 		}
 	}
 
 	return corev1.ServicePort{
 		Name:     servicePortName,
 		Protocol: corev1.ProtocolTCP,
-		Port:     int32(servicePortPort),
+		Port:     int32(servicePort),
 		TargetPort: intstr.IntOrString{
 			IntVal: int32(eventListenerContainerPort),
 		},

--- a/pkg/reconciler/eventlistener/resources/service_test.go
+++ b/pkg/reconciler/eventlistener/resources/service_test.go
@@ -138,6 +138,9 @@ func TestService(t *testing.T) {
 }
 
 func TestServicePort(t *testing.T) {
+
+	k8sResSvcPort := int32(80)
+
 	tests := []struct {
 		name                string
 		el                  *v1beta1.EventListener
@@ -196,6 +199,22 @@ func TestServicePort(t *testing.T) {
 			Name:     eventListenerServiceTLSPortName,
 			Protocol: corev1.ProtocolTCP,
 			Port:     int32(8443),
+			TargetPort: intstr.IntOrString{
+				IntVal: int32(eventListenerContainerPort),
+			},
+		},
+	}, {
+		name: "EventListener with ServicePort 80 in KubernetesResource",
+		el: makeEL(withStatus, withTLSPort, func(el *v1beta1.EventListener) {
+			el.Spec.Resources.KubernetesResource = &v1beta1.KubernetesResource{
+				ServicePort: &k8sResSvcPort,
+			}
+		}),
+		config: *MakeConfig(),
+		expectedServicePort: corev1.ServicePort{
+			Name:     eventListenerServicePortName,
+			Protocol: corev1.ProtocolTCP,
+			Port:     k8sResSvcPort,
 			TargetPort: intstr.IntOrString{
 				IntVal: int32(eventListenerContainerPort),
 			},


### PR DESCRIPTION
Fixes Eventlistener's status.address.url port not matching specified spec.resources.kubernetesresource.serviceport. Previously, it only showed the default port.

Fixes #1473 
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
