### PR TITLE
Add probes support in Triggers eventlistener

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -83,7 +83,7 @@ spec:
               "-period-seconds",
               "10",
               "-failure-threshold",
-              "1",
+              "3",
             ]
           env:
             - name: SYSTEM_NAMESPACE

--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -265,7 +265,7 @@ You can optionally customize the sink deployment for your `EventListener` using 
 - Kubernetes Resource using the `kubernetesResource` field
 - Custom Resource objects via the `CustomResource` field
 
-Legal values for the `PodSpec` and `Containers` sub-fields for both `kubernetesResource` and `CustomResource` fields are:
+Legal values for the `PodSpec` sub-fields for both `kubernetesResource` and `CustomResource` are:
 ```
 ServiceAccountName
 NodeSelector
@@ -275,7 +275,18 @@ Affinity
 TopologySpreadConstraints
 ```
 
-Legal values for the `Containers` sub-field are:
+Legal values for the `Containers` sub-field for `kubernetesResource` and `CustomResource` are:
+
+**kubernetesResource:**
+```
+Resources
+Env
+LivenessProbe
+ReadinessProbe
+StartupProbe
+```
+
+**CustomResource:**
 ```
 Resources
 Env

--- a/pkg/apis/triggers/v1alpha1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1alpha1/event_listener_validation.go
@@ -106,7 +106,7 @@ func validateCustomObject(customData *CustomResource) (errs *apis.FieldError) {
 	// bounded by condition because containers fields are optional so there is a chance that containers can be nil.
 	if len(orig.Spec.Template.Spec.Containers) == 1 {
 		errs = errs.Also(apis.CheckDisallowedFields(orig.Spec.Template.Spec.Containers[0],
-			*containerFieldMask(&orig.Spec.Template.Spec.Containers[0])).ViaField("spec.template.spec.containers[0]"))
+			*containerFieldMaskForCustomResource(&orig.Spec.Template.Spec.Containers[0])).ViaField("spec.template.spec.containers[0]"))
 		// validate env
 		errs = errs.Also(validateEnv(orig.Spec.Template.Spec.Containers[0].Env).ViaField("spec.template.spec.containers[0].env"))
 	}
@@ -129,7 +129,7 @@ func validateKubernetesObject(orig *KubernetesResource) (errs *apis.FieldError) 
 	// bounded by condition because containers fields are optional so there is a chance that containers can be nil.
 	if len(orig.Template.Spec.Containers) == 1 {
 		errs = errs.Also(apis.CheckDisallowedFields(orig.Template.Spec.Containers[0],
-			*containerFieldMask(&orig.Template.Spec.Containers[0])).ViaField("spec.template.spec.containers[0]"))
+			*containerFieldMaskForKubernetes(&orig.Template.Spec.Containers[0])).ViaField("spec.template.spec.containers[0]"))
 		// validate env
 		errs = errs.Also(validateEnv(orig.Template.Spec.Containers[0].Env).ViaField("spec.template.spec.containers[0].env"))
 	}
@@ -206,20 +206,30 @@ func envVarMask(in *corev1.EnvVar) *corev1.EnvVar {
 	return out
 }
 
-func containerFieldMask(in *corev1.Container) *corev1.Container {
+func containerFieldMaskForKubernetes(in *corev1.Container) *corev1.Container {
 	out := new(corev1.Container)
 	out.Resources = in.Resources
 	out.Env = in.Env
+	out.LivenessProbe = in.LivenessProbe
+	out.ReadinessProbe = in.ReadinessProbe
+	out.StartupProbe = in.StartupProbe
+	return containerFieldMask(out)
+}
 
+func containerFieldMaskForCustomResource(in *corev1.Container) *corev1.Container {
+	out := new(corev1.Container)
+	out.Resources = in.Resources
+	out.Env = in.Env
+	return containerFieldMask(out)
+}
+
+func containerFieldMask(out *corev1.Container) *corev1.Container {
 	// Disallowed fields
 	// This list clarifies which all container attributes are not allowed.
 	out.Name = ""
 	out.Image = ""
 	out.Args = nil
 	out.Ports = nil
-	out.LivenessProbe = nil
-	out.ReadinessProbe = nil
-	out.StartupProbe = nil
 	out.Command = nil
 	out.VolumeMounts = nil
 	out.ImagePullPolicy = ""


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
* Triggers now support probes setting on EventListener object
* Triggers now have default value for failure-threshold as 3 for both readiness and liveness probes
* Updated doc with the information of supported  fields
* Added unit test to cover the field set for kubernetes and custom resources

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Triggers now support probes setting on EventListener object
Triggers now have default value for failure-threshold as 3 for both readiness and liveness probes
```

