### PR TITLE
Add first and last functions.

### DIFF
--- a/docs/cel_expressions.md
+++ b/docs/cel_expressions.md
@@ -442,6 +442,35 @@ which can be accessed by indexing.
      <pre>{"testing":"value"}.marshalJSON() == "{\"testing\": \"value\"}"</pre>
     </td>
   </tr>
+  <tr>
+    <th>
+     first()
+    </th>
+    <td>
+     <pre>&lt;jsonArray&gt;.first() -> &lt;jsonObject&gt;</pre>
+    </td>
+    <td>
+     Returns the first element in the array.
+    </td>
+    <td>
+     <pre>[1, 2, 3, 4, 5].first() == 1</pre>
+    </td>
+  </tr>
+  <tr>
+    <th>
+     last()
+    </th>
+    <td>
+     <pre>&lt;jsonArray&gt;.last() -> &lt;jsonObject&gt;</pre>
+    </td>
+    <td>
+     Returns the last element in the array.
+    </td>
+    <td>
+     <pre>[1, 2, 3, 4, 5].last() == 5</pre>
+    </td>
+  </tr>
+
 </table>
 
 ## Troubleshooting CEL expressions

--- a/pkg/interceptors/cel/cel_test.go
+++ b/pkg/interceptors/cel/cel_test.go
@@ -440,6 +440,10 @@ func TestExpressionEvaluation(t *testing.T) {
 				},
 			},
 		},
+		"numbers": []int64{
+			1, 2, 3, 4, 5,
+		},
+		"emptyList": []int64{},
 	}
 
 	refParts := strings.Split(testRef, "/")
@@ -620,6 +624,47 @@ func TestExpressionEvaluation(t *testing.T) {
 			name: "extension string join",
 			expr: "body.jsonArray.join(', ')",
 			want: types.String("one, two"),
+		},
+		{
+			name: "last element in array",
+			expr: "body.testURL.parseURL().path.split('/').last()",
+			want: types.String("to"),
+		},
+		{
+			name: "last element in empty array",
+			expr: `body.emptyList.last()`,
+			want: types.NullValue,
+		},
+		{
+			name: "last element in numeric array",
+			expr: `body.numbers.last()`,
+			want: types.Int(5),
+		},
+		{
+			name: "last element in literal array",
+			expr: "[1, 2, 3, 4, 5].last()",
+			want: types.Int(5),
+		},
+		{
+			name: "first element in literal array",
+			expr: "[1, 2, 3, 4, 5].first()",
+			want: types.Int(1),
+		},
+		{
+			name: "first element in array",
+			// Splitting gets an empty route element so this filters it out.
+			expr: "body.testURL.parseURL().path.split('/').filter(t, t.size() > 0).first()",
+			want: types.String("path"),
+		},
+		{
+			name: "first element in empty array",
+			expr: `body.emptyList.first()`,
+			want: types.NullValue,
+		},
+		{
+			name: "first element in numeric array",
+			expr: `body.numbers.first()`,
+			want: types.Int(1),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This adds two new functions to the CEL interceptor functions, `first` and `last` which simplifies access JSON array values in CEL expressions.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Two new functions for the CEL interceptor, to allow easy access to the first and last elements in an array.
```
