### PR TITLE
Fix bitbucket server example when both SSH and HTTPS enabled

### DIFF
--- a/examples/v1beta1/bitbucket-server/triggerbinding.yaml
+++ b/examples/v1beta1/bitbucket-server/triggerbinding.yaml
@@ -8,4 +8,4 @@ spec:
     - name: gitrevision
       value: $(body.changes[0].ref.displayId)
     - name: gitrepositoryurl
-      value: $(body.repository.links.clone[0].href)
+      value: $(body.repository.links.clone[?(@.name=="ssh")].href)


### PR DESCRIPTION
Fix the bitbucket server example when it has both SSH and HTTPS.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
