### PR TITLE
Add string translation to CEL interceptor.

### DIFF
--- a/docs/cel_expressions.md
+++ b/docs/cel_expressions.md
@@ -470,7 +470,21 @@ which can be accessed by indexing.
      <pre>[1, 2, 3, 4, 5].last() == 5</pre>
     </td>
   </tr>
-
+  <tr>
+    <th>
+     translate()
+    </th>
+    <td>
+     <pre>&lt;string&gt;.translate(string, string) -> &lt;string&gt;</pre>
+    </td>
+    <td>
+     Uses a regular expression to replace characters from the source string with characters from the replacements.
+    </td>
+    <td>
+     <pre>"This is $an Invalid5String ".translate("[^a-z0-9]+", "") == "hisisannvalid5tring"</pre><br />
+     <pre>"This is $an Invalid5String ".translate("[^a-z0-9]+", "ABC") == "ABChisABCisABCanABCnvalid5ABCtring"</pre>
+    </td>
+  </tr>
 </table>
 
 ## Troubleshooting CEL expressions


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This adds a new "translate" function to the CEL interceptor library that allows using a regular expression to translate replacement characters to specified strings.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
New `translate` function added to the CEL interceptor.
```
