### PR TITLE
Revert "Follow naming conventions for resourceTemplates"

### DIFF
--- a/cmd/triggerrun/testdata/triggertemplate.yaml
+++ b/cmd/triggerrun/testdata/triggertemplate.yaml
@@ -13,7 +13,7 @@ spec:
   - name: message
     description: The message to print
     default: This is the default message
-  resourceTemplates:
+  resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:

--- a/docs/getting-started/triggers.yaml
+++ b/docs/getting-started/triggers.yaml
@@ -12,7 +12,7 @@ spec:
       description: The git repository url
     - name: namespace
       description: The namespace to create the resources
-  resourceTemplates:
+  resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
       metadata:

--- a/docs/triggers-api.md
+++ b/docs/triggers-api.md
@@ -2517,7 +2517,7 @@ TriggerTemplateSpec
 </tr>
 <tr>
 <td>
-<code>resourceTemplates</code><br/>
+<code>resourcetemplates</code><br/>
 <em>
 <a href="#triggers.tekton.dev/v1alpha1.TriggerResourceTemplate">
 []TriggerResourceTemplate
@@ -2575,7 +2575,7 @@ TriggerTemplateStatus
 </tr>
 <tr>
 <td>
-<code>resourceTemplates</code><br/>
+<code>resourcetemplates</code><br/>
 <em>
 <a href="#triggers.tekton.dev/v1alpha1.TriggerResourceTemplate">
 []TriggerResourceTemplate
@@ -4634,7 +4634,7 @@ TriggerTemplateSpec
 </tr>
 <tr>
 <td>
-<code>resourceTemplates</code><br/>
+<code>resourcetemplates</code><br/>
 <em>
 <a href="#triggers.tekton.dev/v1beta1.TriggerResourceTemplate">
 []TriggerResourceTemplate
@@ -4692,7 +4692,7 @@ TriggerTemplateStatus
 </tr>
 <tr>
 <td>
-<code>resourceTemplates</code><br/>
+<code>resourcetemplates</code><br/>
 <em>
 <a href="#triggers.tekton.dev/v1beta1.TriggerResourceTemplate">
 []TriggerResourceTemplate

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -70,7 +70,7 @@ triggers:
       spec: 
         params:
           - name: "my-param-name"
-        resourceTemplates:
+        resourcetemplates:
         - apiVersion: "tekton.dev/v1beta1"
           kind: TaskRun
           metadata:

--- a/docs/triggertemplates.md
+++ b/docs/triggertemplates.md
@@ -43,7 +43,7 @@ spec:
     default: This is the default message
   - name: contenttype
     description: The Content-Type of the event
-  resourceTemplates:
+  resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
@@ -96,7 +96,7 @@ A `TriggerTemplate` allows you to declare parameters supplied by the associated 
 * Tekton applies the value of the `default` field for each entry in the `params` array of your `TriggerTemplate` if it can't find a corresponding
   value in the associated `TriggerBinding` or cannot successfully extract the value from an HTTP header or body payload.
 
-* You can reference `tt.params` in the `resourceTemplates` section of your `TriggerTemplate` to make your `TriggerTemplate` reusable.
+* You can reference `tt.params` in the `resourcetemplates` section of your `TriggerTemplate` to make your `TriggerTemplate` reusable.
 
 * When you specify parameters in your resource template definitions, Tekton replaces the specified string with the parameter name, for example `$(tt.params.name)`.
   Therefore, simple string and number value replacements work fine directly in your YAML file. However, if a string has a numerical prefix, such as `123abcd`,

--- a/examples/v1alpha1/bitbucket-server/triggertemplate.yaml
+++ b/examples/v1alpha1/bitbucket-server/triggertemplate.yaml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: gitrevision
     - name: gitrepositoryurl
-  resourceTemplates:
+  resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: TaskRun
       metadata:

--- a/examples/v1alpha1/custom-resource/github-knative-listener-customresource.yaml
+++ b/examples/v1alpha1/custom-resource/github-knative-listener-customresource.yaml
@@ -63,7 +63,7 @@ spec:
   params:
     - name: gitrevision
     - name: gitrepositoryurl
-  resourceTemplates:
+  resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: TaskRun
       metadata:

--- a/examples/v1alpha1/embedded-trigger/triggertemplate.yaml
+++ b/examples/v1alpha1/embedded-trigger/triggertemplate.yaml
@@ -14,7 +14,7 @@ spec:
     default: This is the default message
   - name: contenttype
     description: The Content-Type of the event
-  resourceTemplates:
+  resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:

--- a/examples/v1alpha1/eventlistener-tls-connection/tls-eventlistener-interceptor.yaml
+++ b/examples/v1alpha1/eventlistener-tls-connection/tls-eventlistener-interceptor.yaml
@@ -65,7 +65,7 @@ spec:
   params:
     - name: gitrevision
     - name: gitrepositoryurl
-  resourceTemplates:
+  resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: TaskRun
       metadata:

--- a/examples/v1alpha1/eventlisteners/cel-eventlistener-interceptor.yaml
+++ b/examples/v1alpha1/eventlisteners/cel-eventlistener-interceptor.yaml
@@ -23,7 +23,7 @@ spec:
         spec:
           params:
             - name: sha
-          resourceTemplates:
+          resourcetemplates:
             - apiVersion: tekton.dev/v1beta1
               kind: TaskRun
               metadata:

--- a/examples/v1alpha1/eventlisteners/cel-eventlistener-multiple-overlays.yaml
+++ b/examples/v1alpha1/eventlisteners/cel-eventlistener-multiple-overlays.yaml
@@ -26,7 +26,7 @@ spec:
           params:
             - name: sha
             - name: branch
-          resourceTemplates:
+          resourcetemplates:
             - apiVersion: tekton.dev/v1beta1
               kind: TaskRun
               metadata:

--- a/examples/v1alpha1/github/github-eventlistener-interceptor.yaml
+++ b/examples/v1alpha1/github/github-eventlistener-interceptor.yaml
@@ -61,7 +61,7 @@ spec:
   params:
     - name: gitrevision
     - name: gitrepositoryurl
-  resourceTemplates:
+  resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: TaskRun
       metadata:

--- a/examples/v1alpha1/gitlab/gitlab-push-listener.yaml
+++ b/examples/v1alpha1/gitlab/gitlab-push-listener.yaml
@@ -29,7 +29,7 @@ spec:
           params:
             - name: gitrevision
             - name: gitrepositoryurl
-          resourceTemplates:
+          resourcetemplates:
             - apiVersion: tekton.dev/v1beta1
               kind: TaskRun
               metadata:

--- a/examples/v1alpha1/label-selector/triggers.yaml
+++ b/examples/v1alpha1/label-selector/triggers.yaml
@@ -68,7 +68,7 @@ spec:
     default: This is the default message
   - name: contenttype
     description: The Content-Type of the event
-  resourceTemplates:
+  resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:

--- a/examples/v1alpha1/namespace-selector/03_trigger.yaml
+++ b/examples/v1alpha1/namespace-selector/03_trigger.yaml
@@ -49,7 +49,7 @@ spec:
     default: This is the default message
   - name: contenttype
     description: The Content-Type of the event
-  resourceTemplates:
+  resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:

--- a/examples/v1alpha1/namespacedinterceptor/eventlistener.yaml
+++ b/examples/v1alpha1/namespacedinterceptor/eventlistener.yaml
@@ -23,7 +23,7 @@ spec:
           params:
             - name: gitrevision
             - name: gitrepositoryurl
-          resourceTemplates:
+          resourcetemplates:
             - apiVersion: tekton.dev/v1beta1
               kind: TaskRun
               metadata:

--- a/examples/v1alpha1/trigger-ref/triggertemplate.yaml
+++ b/examples/v1alpha1/trigger-ref/triggertemplate.yaml
@@ -14,7 +14,7 @@ spec:
     default: This is the default message
   - name: contenttype
     description: The Content-Type of the event
-  resourceTemplates:
+  resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:

--- a/examples/v1alpha1/triggertemplates/triggertemplate.yaml
+++ b/examples/v1alpha1/triggertemplates/triggertemplate.yaml
@@ -14,7 +14,7 @@ spec:
     default: This is the default message
   - name: contenttype
     description: The Content-Type of the event
-  resourceTemplates:
+  resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:

--- a/examples/v1beta1/awscodecommit/push/awscodecommit-push-listener.yaml
+++ b/examples/v1beta1/awscodecommit/push/awscodecommit-push-listener.yaml
@@ -50,7 +50,7 @@ spec:
     - name: aws-codecommit-commit
     - name: aws-codecommit-branch
     - name: aws-codecommit-useridentity
-  resourceTemplates:
+  resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: TaskRun
       metadata:

--- a/examples/v1beta1/azurerepo/pull/azurerepo-pullrequest-listener.yaml
+++ b/examples/v1beta1/azurerepo/pull/azurerepo-pullrequest-listener.yaml
@@ -67,7 +67,7 @@ spec:
     - name: azurerepo-pullreq-html-url
     - name: azurerepo-pullreq-title
     - name: azurerepo-pullreq-user
-  resourceTemplates:
+  resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: TaskRun
       metadata:

--- a/examples/v1beta1/azurerepo/push/azurerepo-push-listener.yaml
+++ b/examples/v1beta1/azurerepo/push/azurerepo-push-listener.yaml
@@ -58,7 +58,7 @@ spec:
     - name: azurerepo-url
     - name: azurerepo-name
     - name: pusher-name
-  resourceTemplates:
+  resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: TaskRun
       metadata:

--- a/examples/v1beta1/bitbucket-cloud/triggertemplate.yaml
+++ b/examples/v1beta1/bitbucket-cloud/triggertemplate.yaml
@@ -9,7 +9,7 @@ spec:
     - name: gitrepourl
     - name: gitreponame
     - name: pushername
-  resourceTemplates:
+  resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: TaskRun
       metadata:

--- a/examples/v1beta1/bitbucket-server/triggertemplate.yaml
+++ b/examples/v1beta1/bitbucket-server/triggertemplate.yaml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: gitrevision
     - name: gitrepositoryurl
-  resourceTemplates:
+  resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: TaskRun
       metadata:

--- a/examples/v1beta1/custom-resource/github-knative-listener-customresource.yaml
+++ b/examples/v1beta1/custom-resource/github-knative-listener-customresource.yaml
@@ -63,7 +63,7 @@ spec:
   params:
     - name: gitrevision
     - name: gitrepositoryurl
-  resourceTemplates:
+  resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: TaskRun
       metadata:

--- a/examples/v1beta1/embedded-trigger/triggertemplate.yaml
+++ b/examples/v1beta1/embedded-trigger/triggertemplate.yaml
@@ -14,7 +14,7 @@ spec:
     default: This is the default message
   - name: contenttype
     description: The Content-Type of the event
-  resourceTemplates:
+  resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:

--- a/examples/v1beta1/eventlistener-tls-connection/tls-eventlistener-interceptor.yaml
+++ b/examples/v1beta1/eventlistener-tls-connection/tls-eventlistener-interceptor.yaml
@@ -65,7 +65,7 @@ spec:
   params:
     - name: gitrevision
     - name: gitrepositoryurl
-  resourceTemplates:
+  resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: TaskRun
       metadata:

--- a/examples/v1beta1/eventlisteners/cel-eventlistener-interceptor.yaml
+++ b/examples/v1beta1/eventlisteners/cel-eventlistener-interceptor.yaml
@@ -23,7 +23,7 @@ spec:
         spec:
           params:
             - name: sha
-          resourceTemplates:
+          resourcetemplates:
             - apiVersion: tekton.dev/v1beta1
               kind: TaskRun
               metadata:

--- a/examples/v1beta1/eventlisteners/cel-eventlistener-multiple-overlays.yaml
+++ b/examples/v1beta1/eventlisteners/cel-eventlistener-multiple-overlays.yaml
@@ -26,7 +26,7 @@ spec:
           params:
             - name: sha
             - name: branch
-          resourceTemplates:
+          resourcetemplates:
             - apiVersion: tekton.dev/v1beta1
               kind: TaskRun
               metadata:

--- a/examples/v1beta1/eventlisteners/eventlistener-gke-autopilot.yaml
+++ b/examples/v1beta1/eventlisteners/eventlistener-gke-autopilot.yaml
@@ -44,7 +44,7 @@ spec:
             default: This is the default message
           - name: contenttype
             description: The Content-Type of the event
-          resourceTemplates:
+          resourcetemplates:
           - apiVersion: tekton.dev/v1beta1
             kind: PipelineRun
             metadata:

--- a/examples/v1beta1/github-add-changed-files-pr/github-eventlistener-interceptor.yaml
+++ b/examples/v1beta1/github-add-changed-files-pr/github-eventlistener-interceptor.yaml
@@ -51,7 +51,7 @@ metadata:
 spec:
   params:
     - name: changedfiles
-  resourceTemplates:
+  resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: TaskRun
       metadata:

--- a/examples/v1beta1/github-add-changed-files-push-cel/github-eventlistener-interceptor.yaml
+++ b/examples/v1beta1/github-add-changed-files-push-cel/github-eventlistener-interceptor.yaml
@@ -57,7 +57,7 @@ metadata:
 spec:
   params:
     - name: changedfiles
-  resourceTemplates:
+  resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: TaskRun
       metadata:

--- a/examples/v1beta1/github-owners/github-eventlistener-interceptor.yaml
+++ b/examples/v1beta1/github-owners/github-eventlistener-interceptor.yaml
@@ -61,7 +61,7 @@ metadata:
 spec:
   params:
     - name: gitrepositoryurl
-  resourceTemplates:
+  resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: TaskRun
       metadata:

--- a/examples/v1beta1/github/github-eventlistener-interceptor.yaml
+++ b/examples/v1beta1/github/github-eventlistener-interceptor.yaml
@@ -61,7 +61,7 @@ spec:
   params:
     - name: gitrevision
     - name: gitrepositoryurl
-  resourceTemplates:
+  resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: TaskRun
       metadata:

--- a/examples/v1beta1/gitlab/gitlab-push-listener.yaml
+++ b/examples/v1beta1/gitlab/gitlab-push-listener.yaml
@@ -29,7 +29,7 @@ spec:
           params:
             - name: gitrevision
             - name: gitrepositoryurl
-          resourceTemplates:
+          resourcetemplates:
             - apiVersion: tekton.dev/v1beta1
               kind: TaskRun
               metadata:

--- a/examples/v1beta1/label-selector/triggers.yaml
+++ b/examples/v1beta1/label-selector/triggers.yaml
@@ -54,7 +54,7 @@ spec:
     default: This is the default message
   - name: contenttype
     description: The Content-Type of the event
-  resourceTemplates:
+  resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:

--- a/examples/v1beta1/namespace-selector/03_trigger.yaml
+++ b/examples/v1beta1/namespace-selector/03_trigger.yaml
@@ -42,7 +42,7 @@ spec:
     default: This is the default message
   - name: contenttype
     description: The Content-Type of the event
-  resourceTemplates:
+  resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:

--- a/examples/v1beta1/slack/slack-eventlistener-interceptor.yaml
+++ b/examples/v1beta1/slack/slack-eventlistener-interceptor.yaml
@@ -35,7 +35,7 @@ spec:
         spec:
           params:
             - name: response
-          resourceTemplates:
+          resourcetemplates:
             - apiVersion: tekton.dev/v1beta1
               kind: TaskRun
               metadata:

--- a/examples/v1beta1/trigger-ref/triggertemplate.yaml
+++ b/examples/v1beta1/trigger-ref/triggertemplate.yaml
@@ -14,7 +14,7 @@ spec:
     default: This is the default message
   - name: contenttype
     description: The Content-Type of the event
-  resourceTemplates:
+  resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:

--- a/examples/v1beta1/triggergroups/trigger.yaml
+++ b/examples/v1beta1/triggergroups/trigger.yaml
@@ -31,7 +31,7 @@ spec:
       default: This is the default message
     - name: contenttype
       description: The Content-Type of the event
-  resourceTemplates:
+  resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
       metadata:

--- a/examples/v1beta1/triggertemplates/triggertemplate.yaml
+++ b/examples/v1beta1/triggertemplates/triggertemplate.yaml
@@ -14,7 +14,7 @@ spec:
     default: This is the default message
   - name: contenttype
     description: The Content-Type of the event
-  resourceTemplates:
+  resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:

--- a/pkg/apis/triggers/v1alpha1/trigger_template_types.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_template_types.go
@@ -31,7 +31,7 @@ type TriggerTemplateSpec struct {
 	// +listType=atomic
 	Params []ParamSpec `json:"params,omitempty"`
 	// +listType=atomic
-	ResourceTemplates []TriggerResourceTemplate `json:"resourceTemplates,omitempty"`
+	ResourceTemplates []TriggerResourceTemplate `json:"resourcetemplates,omitempty"`
 }
 
 // TriggerResourceTemplate describes a resource to create

--- a/pkg/apis/triggers/v1alpha1/trigger_template_validation.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_template_validation.go
@@ -51,10 +51,10 @@ func (s *TriggerTemplateSpec) validate(ctx context.Context) (errs *apis.FieldErr
 		errs = errs.Also(apis.ErrMissingField(apis.CurrentField))
 	}
 	if len(s.ResourceTemplates) == 0 {
-		errs = errs.Also(apis.ErrMissingField("resourceTemplates"))
+		errs = errs.Also(apis.ErrMissingField("resourcetemplates"))
 	}
-	errs = errs.Also(validateResourceTemplates(s.ResourceTemplates).ViaField("resourceTemplates"))
-	errs = errs.Also(verifyParamDeclarations(s.Params, s.ResourceTemplates).ViaField("resourceTemplates"))
+	errs = errs.Also(validateResourceTemplates(s.ResourceTemplates).ViaField("resourcetemplates"))
+	errs = errs.Also(verifyParamDeclarations(s.Params, s.ResourceTemplates).ViaField("resourcetemplates"))
 	return errs
 }
 

--- a/pkg/apis/triggers/v1alpha1/trigger_template_validation_test.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_template_validation_test.go
@@ -192,7 +192,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 		},
 		want: &apis.FieldError{
 			Message: "missing field(s)",
-			Paths:   []string{"spec.resourceTemplates"},
+			Paths:   []string{"spec.resourcetemplates"},
 		},
 	}, {
 		name: "resource template missing kind",
@@ -218,7 +218,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 		},
 		want: &apis.FieldError{
 			Message: "missing field(s)",
-			Paths:   []string{"spec.resourceTemplates[0].kind"},
+			Paths:   []string{"spec.resourcetemplates[0].kind"},
 		},
 	}, {
 		name: "resource template missing apiVersion",
@@ -244,7 +244,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 		},
 		want: &apis.FieldError{
 			Message: "missing field(s)",
-			Paths:   []string{"spec.resourceTemplates[0].apiVersion"},
+			Paths:   []string{"spec.resourcetemplates[0].apiVersion"},
 		},
 	}, {
 		name: "resource template invalid apiVersion",
@@ -271,7 +271,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 		},
 		want: &apis.FieldError{
 			Message: `invalid value: no kind "pipelinerun" is registered for version "foobar"`,
-			Paths:   []string{"spec.resourceTemplates[0]"},
+			Paths:   []string{"spec.resourcetemplates[0]"},
 		},
 	}, {
 		name: "resource template invalid kind",
@@ -298,7 +298,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 		},
 		want: &apis.FieldError{
 			Message: `invalid value: no kind "tekton.dev/v1alpha1" is registered for version "foo"`,
-			Paths:   []string{"spec.resourceTemplates[0]"},
+			Paths:   []string{"spec.resourcetemplates[0]"},
 		},
 	}, {
 		name: "tt.params used in resource template are declared",
@@ -334,7 +334,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 		},
 		want: &apis.FieldError{
 			Message: "invalid value: undeclared param '$(tt.params.foo)'",
-			Paths:   []string{"spec.resourceTemplates[0]"},
+			Paths:   []string{"spec.resourcetemplates[0]"},
 			Details: "'$(tt.params.foo)' must be declared in spec.params",
 		},
 	}, {
@@ -378,7 +378,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 				Namespace: "foo",
 			},
 		},
-		want: apis.ErrMissingField("spec", "spec.resourceTemplates"),
+		want: apis.ErrMissingField("spec", "spec.resourcetemplates"),
 	}}
 
 	for _, tc := range tcs {

--- a/pkg/apis/triggers/v1beta1/openapi_generated.go
+++ b/pkg/apis/triggers/v1beta1/openapi_generated.go
@@ -1634,7 +1634,7 @@ func schema_pkg_apis_triggers_v1beta1_TriggerTemplateSpec(ref common.ReferenceCa
 							},
 						},
 					},
-					"resourceTemplates": {
+					"resourcetemplates": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
 								"x-kubernetes-list-type": "atomic",

--- a/pkg/apis/triggers/v1beta1/trigger_template_types.go
+++ b/pkg/apis/triggers/v1beta1/trigger_template_types.go
@@ -31,7 +31,7 @@ type TriggerTemplateSpec struct {
 	// +listType=atomic
 	Params []ParamSpec `json:"params,omitempty"`
 	// +listType=atomic
-	ResourceTemplates []TriggerResourceTemplate `json:"resourceTemplates,omitempty"`
+	ResourceTemplates []TriggerResourceTemplate `json:"resourcetemplates,omitempty"`
 }
 
 // TriggerResourceTemplate describes a resource to create

--- a/pkg/apis/triggers/v1beta1/trigger_template_validation.go
+++ b/pkg/apis/triggers/v1beta1/trigger_template_validation.go
@@ -56,10 +56,10 @@ func (s *TriggerTemplateSpec) validate(ctx context.Context) (errs *apis.FieldErr
 		errs = errs.Also(apis.ErrMissingField(apis.CurrentField))
 	}
 	if len(s.ResourceTemplates) == 0 {
-		errs = errs.Also(apis.ErrMissingField("resourceTemplates"))
+		errs = errs.Also(apis.ErrMissingField("resourcetemplates"))
 	}
-	errs = errs.Also(validateResourceTemplates(s.ResourceTemplates).ViaField("resourceTemplates"))
-	errs = errs.Also(verifyParamDeclarations(s.Params, s.ResourceTemplates).ViaField("resourceTemplates"))
+	errs = errs.Also(validateResourceTemplates(s.ResourceTemplates).ViaField("resourcetemplates"))
+	errs = errs.Also(verifyParamDeclarations(s.Params, s.ResourceTemplates).ViaField("resourcetemplates"))
 	return errs
 }
 

--- a/pkg/apis/triggers/v1beta1/trigger_template_validation_test.go
+++ b/pkg/apis/triggers/v1beta1/trigger_template_validation_test.go
@@ -183,7 +183,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 		},
 		want: &apis.FieldError{
 			Message: "missing field(s)",
-			Paths:   []string{"spec.resourceTemplates"},
+			Paths:   []string{"spec.resourcetemplates"},
 		},
 	}, {
 		name: "resource template missing kind",
@@ -209,7 +209,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 		},
 		want: &apis.FieldError{
 			Message: "missing field(s)",
-			Paths:   []string{"spec.resourceTemplates[0].kind"},
+			Paths:   []string{"spec.resourcetemplates[0].kind"},
 		},
 	}, {
 		name: "resource template missing apiVersion",
@@ -235,7 +235,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 		},
 		want: &apis.FieldError{
 			Message: "missing field(s)",
-			Paths:   []string{"spec.resourceTemplates[0].apiVersion"},
+			Paths:   []string{"spec.resourcetemplates[0].apiVersion"},
 		},
 	}, {
 		name: "resource template invalid apiVersion",
@@ -262,7 +262,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 		},
 		want: &apis.FieldError{
 			Message: `invalid value: no kind "pipelinerun" is registered for version "foobar"`,
-			Paths:   []string{"spec.resourceTemplates[0]"},
+			Paths:   []string{"spec.resourcetemplates[0]"},
 		},
 	}, {
 		name: "resource template invalid kind",
@@ -289,7 +289,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 		},
 		want: &apis.FieldError{
 			Message: `invalid value: no kind "tekton.dev/v1beta1" is registered for version "foo"`,
-			Paths:   []string{"spec.resourceTemplates[0]"},
+			Paths:   []string{"spec.resourcetemplates[0]"},
 		},
 	}, {
 		name: "tt.params used in resource template are declared",
@@ -325,7 +325,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 		},
 		want: &apis.FieldError{
 			Message: "invalid value: undeclared param '$(tt.params.foo)'",
-			Paths:   []string{"spec.resourceTemplates[0]"},
+			Paths:   []string{"spec.resourcetemplates[0]"},
 			Details: "'$(tt.params.foo)' must be declared in spec.params",
 		},
 	}, {
@@ -369,7 +369,7 @@ func TestTriggerTemplate_Validate(t *testing.T) {
 				Namespace: "foo",
 			},
 		},
-		want: apis.ErrMissingField("spec", "spec.resourceTemplates"),
+		want: apis.ErrMissingField("spec", "spec.resourcetemplates"),
 	}}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
This reverts commit 447f613dd1731181e40ada3d9141548b45bbdb2c.

**Reason:**

Reverting this PR because altering the tag will impact the upgrade flow. The existing TriggerTemplate data with the old tag still persists in etcd. Consequently, during an upgrade with the new tag, the data isn't fetched for the trigger template as expected.

We'll revert this PR for now and reintroduce the change when we support the new ApiVersion. At that point, we'll utilize conversion functionality (convertTo and convertFrom) to ensure seamless transition. By incorporating the ApiVersion, we'll be able to adjust the tag accordingly.

Fixes: https://github.com/tektoncd/triggers/issues/1690


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
