### PR TITLE
Add `lowerAscii()` and `upperAscii()` to documentation

### DIFF
--- a/docs/cel_expressions.md
+++ b/docs/cel_expressions.md
@@ -485,6 +485,36 @@ which can be accessed by indexing.
      <pre>"This is $an Invalid5String ".translate("[^a-z0-9]+", "ABC") == "ABChisABCisABCanABCnvalid5ABCtring"</pre>
     </td>
   </tr>
+  <tr>
+    <th>
+     lowerAscii()
+    </th>
+    <td>
+     <pre>&lt;string&gt;.lowerAscii() -> &lt;string&gt;</pre>
+    </td>
+    <td>
+     Returns a new string where all ASCII characters are lower-cased.
+    </td>
+    <td>
+     <pre>"TacoCat".lowerAscii() == "tacocat"</pre><br />
+     <pre>"TacoCÆt Xii".lowerAscii() == "tacocÆt xii"</pre>
+    </td>
+  </tr>
+  <tr>
+    <th>
+     upperAscii()
+    </th>
+    <td>
+     <pre>&lt;string&gt;.upperAscii() -> &lt;string&gt;</pre>
+    </td>
+    <td>
+     Returns a new string where all ASCII characters are upper-cased.
+    </td>
+    <td>
+     <pre>"TacoCat".upperAscii() == "TACOCAT"</pre><br />
+     <pre>"TacoCÆt Xii".upperAscii() == "TACOCÆT XII"</pre>
+    </td>
+  </tr>
 </table>
 
 ## Troubleshooting CEL expressions


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release
<!--
# Release Notes

```release-note
NONE
```
-->