### PR TITLE
Add LoadBalancerClass support in EventListener

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -332,6 +332,15 @@ spec:
       servicePort: 8128
 ```
 
+If you use a loadbalancer service, you can optionally define a (LoadBalancerClass)[https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class] with the `ServiceLoadBalancerClass` attribute.
+```yaml
+spec:
+  resources:
+    kubernetesResource:
+      serviceType: LoadBalancer
+      serviceLoadBalancerClass: internal
+```
+
 #### Specifying `Replicas`
 
 You can optionally use the `replicas` field to instruct Tekton Triggers to deploy more than one instance of your `EventListener` in individual Kubernetes Pods.

--- a/docs/triggers-api.md
+++ b/docs/triggers-api.md
@@ -3975,6 +3975,18 @@ int32
 </tr>
 <tr>
 <td>
+<code>serviceLoadBalancerClass</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Define the .spec.loadBalancerClass for Service with the type LoadBalancer.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>spec</code><br/>
 <em>
 <a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#WithPodSpec">

--- a/examples/v1beta1/eventlisteners/eventlistener-loadbalancerclass.yaml
+++ b/examples/v1beta1/eventlisteners/eventlistener-loadbalancerclass.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: listener-loadbalancerclass
+spec:
+  serviceAccountName: tekton-triggers-example-sa
+  triggers:
+    - name: foo-trig
+      bindings:
+        - ref: pipeline-binding
+        - ref: message-binding
+      template:
+        ref: pipeline-template
+  resources:
+    kubernetesResource:
+      serviceType: LoadBalancer
+      serviceLoadBalancerClass: private

--- a/pkg/apis/triggers/v1beta1/event_listener_types.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_types.go
@@ -79,10 +79,11 @@ type CustomResource struct {
 }
 
 type KubernetesResource struct {
-	Replicas           *int32             `json:"replicas,omitempty"`
-	ServiceType        corev1.ServiceType `json:"serviceType,omitempty"`
-	ServicePort        *int32             `json:"servicePort,omitempty"`
-	duckv1.WithPodSpec `json:"spec,omitempty"`
+	Replicas                 *int32             `json:"replicas,omitempty"`
+	ServiceType              corev1.ServiceType `json:"serviceType,omitempty"`
+	ServicePort              *int32             `json:"servicePort,omitempty"`
+	ServiceLoadBalancerClass *string            `json:"serviceLoadBalancerClass,omitempty"`
+	duckv1.WithPodSpec       `json:"spec,omitempty"`
 }
 
 // EventListenerTrigger represents a connection between TriggerBinding, Params,

--- a/pkg/apis/triggers/v1beta1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_validation.go
@@ -149,6 +149,10 @@ func validateKubernetesObject(orig *KubernetesResource) (errs *apis.FieldError) 
 		errs = errs.Also(validateEnv(orig.Template.Spec.Containers[0].Env).ViaField("spec.template.spec.containers[0].env"))
 	}
 
+	if orig.ServiceLoadBalancerClass != nil && orig.ServiceType != corev1.ServiceTypeLoadBalancer {
+		errs = errs.Also(apis.ErrInvalidValue(*orig.ServiceLoadBalancerClass, "serviceLoadBalancerClass", "ServiceLoadBalancerClass is only needed for LoadBalancer service type"))
+	}
+
 	return errs
 }
 

--- a/pkg/apis/triggers/v1beta1/openapi_generated.go
+++ b/pkg/apis/triggers/v1beta1/openapi_generated.go
@@ -826,6 +826,12 @@ func schema_pkg_apis_triggers_v1beta1_KubernetesResource(ref common.ReferenceCal
 							Format: "int32",
 						},
 					},
+					"serviceLoadBalancerClass": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},

--- a/pkg/apis/triggers/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/triggers/v1beta1/zz_generated.deepcopy.go
@@ -379,6 +379,11 @@ func (in *KubernetesResource) DeepCopyInto(out *KubernetesResource) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ServiceLoadBalancerClass != nil {
+		in, out := &in.ServiceLoadBalancerClass, &out.ServiceLoadBalancerClass
+		*out = new(string)
+		**out = **in
+	}
 	in.WithPodSpec.DeepCopyInto(&out.WithPodSpec)
 	return
 }

--- a/pkg/reconciler/eventlistener/resources/common_test.go
+++ b/pkg/reconciler/eventlistener/resources/common_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/ptr"
 )
 
 // makeEL is a helper to build an EventListener for tests.
@@ -99,6 +100,13 @@ func withNodePort30300(el *v1beta1.EventListener) {
 	el.Spec.Resources.KubernetesResource = &v1beta1.KubernetesResource{
 		ServiceType: corev1.ServiceTypeNodePort,
 		ServicePort: &port,
+	}
+}
+
+func withServiceTypeLoadBalancerClass(el *v1beta1.EventListener) {
+	el.Spec.Resources.KubernetesResource = &v1beta1.KubernetesResource{
+		ServiceType:              "LoadBalancer",
+		ServiceLoadBalancerClass: ptr.String("lbc"),
 	}
 }
 

--- a/pkg/reconciler/eventlistener/resources/service.go
+++ b/pkg/reconciler/eventlistener/resources/service.go
@@ -64,13 +64,19 @@ func MakeService(ctx context.Context, el *v1beta1.EventListener, c Config) *core
 
 	servicePort = ServicePort(el, c)
 
-	return &corev1.Service{
+	svc := &corev1.Service{
 		ObjectMeta: ObjectMeta(el, FilterLabels(ctx, el.Labels), c.StaticResourceLabels),
 		Spec: corev1.ServiceSpec{
 			Selector: GenerateLabels(el.Name, c.StaticResourceLabels),
 			Type:     serviceType,
 			Ports:    []corev1.ServicePort{servicePort, metricsPort}},
 	}
+
+	if el.Spec.Resources.KubernetesResource != nil && el.Spec.Resources.KubernetesResource.ServiceLoadBalancerClass != nil {
+		svc.Spec.LoadBalancerClass = el.Spec.Resources.KubernetesResource.ServiceLoadBalancerClass
+	}
+
+	return svc
 }
 
 func ServicePort(el *v1beta1.EventListener, c Config) corev1.ServicePort {


### PR DESCRIPTION
# Changes

Add the ability to define the service `spec.loadBalancerClass` for EventListener with a Service of type `LoadBalancer`.

It's useful if your cluster has multiples LoadBalancer controllers and you need to choose on which one you want to expose the EventListener, for example you can have one controller for public IPs and another for privates IPs.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
EventListners have a new field letting you choose on which LoadBalancer you want to expose the underlying service if you have severals.
```
