### PR TITLE
Node port service match kubernetes resource

### DIFF
--- a/pkg/reconciler/eventlistener/resources/common_test.go
+++ b/pkg/reconciler/eventlistener/resources/common_test.go
@@ -94,6 +94,14 @@ func withServiceTypeLoadBalancer(el *v1beta1.EventListener) {
 	}
 }
 
+func withNodePort30300(el *v1beta1.EventListener) {
+	port := int32(30300)
+	el.Spec.Resources.KubernetesResource = &v1beta1.KubernetesResource{
+		ServiceType: corev1.ServiceTypeNodePort,
+		ServicePort: &port,
+	}
+}
+
 func withServicePort80(el *v1beta1.EventListener) {
 	port := int32(80)
 	el.Spec.Resources.KubernetesResource = &v1beta1.KubernetesResource{

--- a/pkg/reconciler/eventlistener/resources/service.go
+++ b/pkg/reconciler/eventlistener/resources/service.go
@@ -76,6 +76,7 @@ func MakeService(ctx context.Context, el *v1beta1.EventListener, c Config) *core
 func ServicePort(el *v1beta1.EventListener, c Config) corev1.ServicePort {
 	var elCert, elKey string
 
+	nodePort := int32(0)
 	servicePortName := eventListenerServicePortName
 	servicePort := *c.Port
 
@@ -89,6 +90,9 @@ func ServicePort(el *v1beta1.EventListener, c Config) corev1.ServicePort {
 		}
 		if el.Spec.Resources.KubernetesResource.ServicePort != nil {
 			servicePort = int(*el.Spec.Resources.KubernetesResource.ServicePort)
+			if el.Spec.Resources.KubernetesResource.ServiceType == corev1.ServiceTypeNodePort {
+				nodePort = *el.Spec.Resources.KubernetesResource.ServicePort
+			}
 		}
 	}
 
@@ -112,14 +116,17 @@ func ServicePort(el *v1beta1.EventListener, c Config) corev1.ServicePort {
 		}
 	}
 
-	return corev1.ServicePort{
+	svc := corev1.ServicePort{
 		Name:     servicePortName,
 		Protocol: corev1.ProtocolTCP,
 		Port:     int32(servicePort),
 		TargetPort: intstr.IntOrString{
 			IntVal: int32(eventListenerContainerPort),
 		},
+		NodePort: nodePort,
 	}
+
+	return svc
 }
 
 // ListenerHostname returns the intended hostname for the EventListener service.

--- a/pkg/reconciler/eventlistener/resources/service_test.go
+++ b/pkg/reconciler/eventlistener/resources/service_test.go
@@ -97,6 +97,38 @@ func TestService(t *testing.T) {
 				},
 			},
 		}}, {
+		name: "EventListener with node port: 30300",
+		el:   makeEL(withNodePort30300, withStatus),
+		want: &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      generatedResourceName,
+				Namespace: namespace,
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "EventListener",
+					"app.kubernetes.io/part-of":    "Triggers",
+					"eventlistener":                eventListenerName,
+				},
+				OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(makeEL())},
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{{
+					Name:     eventListenerServicePortName,
+					Protocol: corev1.ProtocolTCP,
+					Port:     int32(30300),
+					NodePort: int32(30300),
+					TargetPort: intstr.IntOrString{
+						IntVal: int32(eventListenerContainerPort),
+					},
+				}, metricsPort},
+				Selector: map[string]string{
+					"app.kubernetes.io/managed-by": "EventListener",
+					"app.kubernetes.io/part-of":    "Triggers",
+					"eventlistener":                eventListenerName,
+				},
+			},
+		},
+	}, {
 		name: "EventListener with service port: 80",
 		el:   makeEL(withServicePort80, withStatus),
 		want: &corev1.Service{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Closes #1586 

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Resolve node port when serviceType is NodePort
```
