### PR TITLE
Fix GolangCI issues causing test failures

### DIFF
--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -248,7 +248,7 @@ func (s *sinker) Start(ctx context.Context) error {
 
 	// For handling Liveness Probe
 	// TODO(dibyom): Livness, metrics etc. should be on a separate port
-	mux.HandleFunc("/live", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/live", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(200)
 		fmt.Fprint(w, "ok")
 	})
@@ -276,7 +276,7 @@ func (s *sinker) Start(ctx context.Context) error {
 }
 
 func New(sinkArgs sink.Args, sinkClients sink.Clients, recorder *sink.Recorder) adapter.AdapterConstructor {
-	return func(ctx context.Context, processed adapter.EnvConfigAccessor, ceClient cloudevents.Client) adapter.Adapter {
+	return func(ctx context.Context, processed adapter.EnvConfigAccessor, _ cloudevents.Client) adapter.Adapter {
 		env := processed.(*envConfig)
 		logger := logging.FromContext(ctx)
 

--- a/pkg/interceptors/github/github_test.go
+++ b/pkg/interceptors/github/github_test.go
@@ -631,7 +631,7 @@ func TestInterceptor_ExecuteTrigger_Changed_Files_Pull_Request(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ts := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			ts := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 				writer.Write([]byte(tt.githubServerReply))
 			}))
 			ctx, _ := test.SetupFakeContext(t)
@@ -913,7 +913,7 @@ func TestInterceptor_ExecuteTrigger_Changed_Files_Push(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ts := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			ts := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 				writer.Write([]byte(tt.githubServerReply))
 			}))
 			ctx, _ := test.SetupFakeContext(t)

--- a/pkg/interceptors/interceptors_test.go
+++ b/pkg/interceptors/interceptors_test.go
@@ -289,7 +289,7 @@ func TestResolveToURL(t *testing.T) {
 		want   string
 	}{{
 		name: "ClusterInterceptor has status.address.url",
-		getter: func(n string) (*v1alpha1.ClusterInterceptor, error) {
+		getter: func(_ string) (*v1alpha1.ClusterInterceptor, error) {
 			return &v1alpha1.ClusterInterceptor{
 				Status: v1alpha1.ClusterInterceptorStatus{
 					AddressStatus: duckv1.AddressStatus{
@@ -338,7 +338,7 @@ func TestResolveToURL(t *testing.T) {
 	}
 
 	t.Run("interceptor has no URL", func(t *testing.T) {
-		fakeGetter := func(name string) (*v1alpha1.ClusterInterceptor, error) {
+		fakeGetter := func(_ string) (*v1alpha1.ClusterInterceptor, error) {
 			return &v1alpha1.ClusterInterceptor{
 				Spec: v1alpha1.ClusterInterceptorSpec{
 					ClientConfig: v1alpha1.ClientConfig{

--- a/pkg/interceptors/webhook/webhook_test.go
+++ b/pkg/interceptors/webhook/webhook_test.go
@@ -116,7 +116,7 @@ func TestWebHookInterceptor_NotOK(t *testing.T) {
 	})
 
 	// Create test server
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
 	}))
 	defer ts.Close()

--- a/pkg/reconciler/clusterinterceptor/controller.go
+++ b/pkg/reconciler/clusterinterceptor/controller.go
@@ -27,11 +27,11 @@ import (
 )
 
 func NewController() func(context.Context, configmap.Watcher) *controller.Impl {
-	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+	return func(ctx context.Context, _ configmap.Watcher) *controller.Impl {
 		clusterInterceptorInformer := clusterinterceptorinformer.Get(ctx)
 		reconciler := &Reconciler{}
 
-		impl := clusterinterceptorreconciler.NewImpl(ctx, reconciler, func(impl *controller.Impl) controller.Options {
+		impl := clusterinterceptorreconciler.NewImpl(ctx, reconciler, func(_ *controller.Impl) controller.Options {
 			return controller.Options{
 				AgentName: ControllerName,
 			}

--- a/pkg/reconciler/eventlistener/controller.go
+++ b/pkg/reconciler/eventlistener/controller.go
@@ -62,7 +62,7 @@ func NewController(config resources.Config) func(context.Context, configmap.Watc
 			Metrics:           metrics.Get(ctx),
 		}
 
-		impl := eventlistenerreconciler.NewImpl(ctx, reconciler, func(impl *controller.Impl) controller.Options {
+		impl := eventlistenerreconciler.NewImpl(ctx, reconciler, func(_ *controller.Impl) controller.Options {
 			configStore := cfg.NewStore(logger.Named("config-store"))
 			configStore.WatchConfigs(cmw)
 			return controller.Options{

--- a/pkg/reconciler/interceptor/controller.go
+++ b/pkg/reconciler/interceptor/controller.go
@@ -27,11 +27,11 @@ import (
 )
 
 func NewController() func(context.Context, configmap.Watcher) *controller.Impl {
-	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+	return func(ctx context.Context, _ configmap.Watcher) *controller.Impl {
 		interceptorInformer := interceptorinformer.Get(ctx)
 		reconciler := &Reconciler{}
 
-		impl := interceptorreconciler.NewImpl(ctx, reconciler, func(impl *controller.Impl) controller.Options {
+		impl := interceptorreconciler.NewImpl(ctx, reconciler, func(_ *controller.Impl) controller.Options {
 			return controller.Options{
 				AgentName: ControllerName,
 			}

--- a/test/controller.go
+++ b/test/controller.go
@@ -102,7 +102,7 @@ type Assets struct {
 
 func init() {
 	// Register a separate fake dynamic client with out schemes.
-	injection.Fake.RegisterClient(func(ctx context.Context, cfg *rest.Config) context.Context {
+	injection.Fake.RegisterClient(func(ctx context.Context, _ *rest.Config) context.Context {
 		scheme := runtime.NewScheme()
 		err := servingv1.AddToScheme(scheme)
 		if err != nil {

--- a/test/gate.go
+++ b/test/gate.go
@@ -29,7 +29,7 @@ func FeatureFlagsToContext(ctx context.Context, flags map[string]string) (contex
 // the feature-flag configmap.
 // nolint:unused,deadcode
 func requireGate(name, value string) func(context.Context, *testing.T, *clients, string) {
-	return func(ctx context.Context, t *testing.T, c *clients, namespace string) {
+	return func(ctx context.Context, t *testing.T, c *clients, _ string) {
 		featureFlagsCM, err := c.KubeClient.CoreV1().ConfigMaps(system.Namespace()).Get(ctx, config.GetFeatureFlagsConfigName(), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("Failed to get ConfigMap `%s`: %s", config.GetFeatureFlagsConfigName(), err)

--- a/test/init_test.go
+++ b/test/init_test.go
@@ -162,7 +162,7 @@ func verifyDefaultServiceAccountExists(t *testing.T, namespace string, kubeClien
 
 func getCRDYaml(cs *clients, ns string) ([]byte, error) {
 	var output []byte
-	printOrAdd := func(kind, name string, i interface{}) {
+	printOrAdd := func(_, _ string, i interface{}) {
 		bs, err := json.Marshal(i)
 		if err != nil {
 			return


### PR DESCRIPTION
This fixes some of the golangci issues which are causing test failures after upgrading tests to go1.22

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
