### PR TITLE
Fix is-multi-ns flag for triggerGroups

### DIFF
--- a/pkg/reconciler/eventlistener/resources/container.go
+++ b/pkg/reconciler/eventlistener/resources/container.go
@@ -33,6 +33,12 @@ func MakeContainer(el *v1beta1.EventListener, configAcc reconcilersource.ConfigA
 	if len(el.Spec.NamespaceSelector.MatchNames) != 0 {
 		isMultiNS = true
 	}
+	for _, triggerGroup := range el.Spec.TriggerGroups {
+		if len(triggerGroup.TriggerSelector.NamespaceSelector.MatchNames) != 0 {
+			isMultiNS = true
+			break
+		}
+	}
 
 	payloadValidation := true
 	if value, ok := el.GetAnnotations()[triggers.PayloadValidationAnnotation]; ok {

--- a/pkg/reconciler/eventlistener/resources/container_test.go
+++ b/pkg/reconciler/eventlistener/resources/container_test.go
@@ -287,6 +287,132 @@ func TestContainer(t *testing.T) {
 			},
 		},
 	}, {
+		name: "with namespace selector on triggergroup",
+		el: makeEL(func(el *v1beta1.EventListener) {
+			el.Spec.TriggerGroups = []v1beta1.EventListenerTriggerGroup{{Name: "a"}}
+			el.Spec.TriggerGroups[0].TriggerSelector.NamespaceSelector.MatchNames = []string{"a", "b"}
+		}),
+		want: corev1.Container{
+			Name:  "event-listener",
+			Image: DefaultImage,
+			Ports: []corev1.ContainerPort{{
+				ContainerPort: int32(eventListenerContainerPort),
+				Protocol:      corev1.ProtocolTCP,
+			}},
+			Args: []string{
+				"--el-name=" + eventListenerName,
+				"--el-namespace=" + namespace,
+				"--port=" + strconv.Itoa(eventListenerContainerPort),
+				"--readtimeout=" + strconv.FormatInt(DefaultReadTimeout, 10),
+				"--writetimeout=" + strconv.FormatInt(DefaultWriteTimeout, 10),
+				"--idletimeout=" + strconv.FormatInt(DefaultIdleTimeout, 10),
+				"--timeouthandler=" + strconv.FormatInt(DefaultTimeOutHandler, 10),
+				"--httpclient-readtimeout=" + strconv.FormatInt(DefaultHTTPClientReadTimeOut, 10),
+				"--httpclient-keep-alive=" + strconv.FormatInt(DefaultHTTPClientKeepAlive, 10),
+				"--httpclient-tlshandshaketimeout=" + strconv.FormatInt(DefaultHTTPClientTLSHandshakeTimeout, 10),
+				"--httpclient-responseheadertimeout=" + strconv.FormatInt(DefaultHTTPClientResponseHeaderTimeout, 10),
+				"--httpclient-expectcontinuetimeout=" + strconv.FormatInt(DefaultHTTPClientExpectContinueTimeout, 10),
+				"--is-multi-ns=" + strconv.FormatBool(true),
+				"--payload-validation=" + strconv.FormatBool(true),
+				"--cloudevent-uri=",
+			},
+			Env: []corev1.EnvVar{{
+				Name: "K_LOGGING_CONFIG",
+			}, {
+				Name: "K_METRICS_CONFIG",
+			}, {
+				Name: "K_TRACING_CONFIG",
+			}, {
+				Name:  "NAMESPACE",
+				Value: namespace,
+			}, {
+				Name:  "NAME",
+				Value: eventListenerName,
+			}, {
+				Name:  "EL_EVENT",
+				Value: "disable",
+			}, {
+				Name:  "K_SINK_TIMEOUT",
+				Value: strconv.FormatInt(DefaultTimeOutHandler, 10),
+			}},
+			SecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: ptr.Bool(false),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
+				// 65532 is the distroless nonroot user ID
+				RunAsUser:    ptr.Int64(65532),
+				RunAsGroup:   ptr.Int64(65532),
+				RunAsNonRoot: ptr.Bool(true),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
+		},
+	}, {
+		name: "with namespace selector on any triggergroup of multiple",
+		el: makeEL(func(el *v1beta1.EventListener) {
+			el.Spec.TriggerGroups = []v1beta1.EventListenerTriggerGroup{{Name: "a"}, {Name: "b"}, {Name: "c"}}
+			el.Spec.TriggerGroups[1].TriggerSelector.NamespaceSelector.MatchNames = []string{"a", "b"}
+		}),
+		want: corev1.Container{
+			Name:  "event-listener",
+			Image: DefaultImage,
+			Ports: []corev1.ContainerPort{{
+				ContainerPort: int32(eventListenerContainerPort),
+				Protocol:      corev1.ProtocolTCP,
+			}},
+			Args: []string{
+				"--el-name=" + eventListenerName,
+				"--el-namespace=" + namespace,
+				"--port=" + strconv.Itoa(eventListenerContainerPort),
+				"--readtimeout=" + strconv.FormatInt(DefaultReadTimeout, 10),
+				"--writetimeout=" + strconv.FormatInt(DefaultWriteTimeout, 10),
+				"--idletimeout=" + strconv.FormatInt(DefaultIdleTimeout, 10),
+				"--timeouthandler=" + strconv.FormatInt(DefaultTimeOutHandler, 10),
+				"--httpclient-readtimeout=" + strconv.FormatInt(DefaultHTTPClientReadTimeOut, 10),
+				"--httpclient-keep-alive=" + strconv.FormatInt(DefaultHTTPClientKeepAlive, 10),
+				"--httpclient-tlshandshaketimeout=" + strconv.FormatInt(DefaultHTTPClientTLSHandshakeTimeout, 10),
+				"--httpclient-responseheadertimeout=" + strconv.FormatInt(DefaultHTTPClientResponseHeaderTimeout, 10),
+				"--httpclient-expectcontinuetimeout=" + strconv.FormatInt(DefaultHTTPClientExpectContinueTimeout, 10),
+				"--is-multi-ns=" + strconv.FormatBool(true),
+				"--payload-validation=" + strconv.FormatBool(true),
+				"--cloudevent-uri=",
+			},
+			Env: []corev1.EnvVar{{
+				Name: "K_LOGGING_CONFIG",
+			}, {
+				Name: "K_METRICS_CONFIG",
+			}, {
+				Name: "K_TRACING_CONFIG",
+			}, {
+				Name:  "NAMESPACE",
+				Value: namespace,
+			}, {
+				Name:  "NAME",
+				Value: eventListenerName,
+			}, {
+				Name:  "EL_EVENT",
+				Value: "disable",
+			}, {
+				Name:  "K_SINK_TIMEOUT",
+				Value: strconv.FormatInt(DefaultTimeOutHandler, 10),
+			}},
+			SecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: ptr.Bool(false),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
+				// 65532 is the distroless nonroot user ID
+				RunAsUser:    ptr.Int64(65532),
+				RunAsGroup:   ptr.Int64(65532),
+				RunAsNonRoot: ptr.Bool(true),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
+		},
+	}, {
 		name: "without payload validation",
 		el: makeEL(func(el *v1beta1.EventListener) {
 			el.Annotations = map[string]string{


### PR DESCRIPTION
# Changes

Fix that the --is-multi-ns flag on the eventlistener is set to true, when using a namespaceSelector on any triggerGroup.

Fixes https://github.com/tektoncd/triggers/issues/1652
Fixes https://github.com/tektoncd/triggers/issues/1617
Fixes https://github.com/tektoncd/triggers/issues/1700
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix that the --is-multi-ns flag on the eventlistener is set to true, when using a namespaceSelector on any triggerGroup.
```
