### PR TITLE
Fix API doc by adding TriggerTemplate to Resource Types

### DIFF
--- a/docs/triggers-api.md
+++ b/docs/triggers-api.md
@@ -28,6 +28,8 @@ Resource Types:
 <a href="#triggers.tekton.dev/v1alpha1.Trigger">Trigger</a>
 </li><li>
 <a href="#triggers.tekton.dev/v1alpha1.TriggerBinding">TriggerBinding</a>
+</li><li>
+<a href="#triggers.tekton.dev/v1alpha1.TriggerTemplate">TriggerTemplate</a>
 </li></ul>
 <h3 id="triggers.tekton.dev/v1alpha1.ClusterTriggerBinding">ClusterTriggerBinding
 </h3>
@@ -470,6 +472,108 @@ TriggerBindingSpec
 <em>
 <a href="#triggers.tekton.dev/v1alpha1.TriggerBindingStatus">
 TriggerBindingStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="triggers.tekton.dev/v1alpha1.TriggerTemplate">TriggerTemplate
+</h3>
+<div>
+<p>TriggerTemplate takes parameters and uses them to create CRDs</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+triggers.tekton.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>TriggerTemplate</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#triggers.tekton.dev/v1alpha1.TriggerTemplateSpec">
+TriggerTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec holds the desired state of the TriggerTemplate from the client</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#triggers.tekton.dev/v1alpha1.ParamSpec">
+[]ParamSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>resourcetemplates</code><br/>
+<em>
+<a href="#triggers.tekton.dev/v1alpha1.TriggerResourceTemplate">
+[]TriggerResourceTemplate
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#triggers.tekton.dev/v1alpha1.TriggerTemplateStatus">
+TriggerTemplateStatus
 </a>
 </em>
 </td>
@@ -2460,95 +2564,10 @@ TriggerTemplateSpec
 </tr>
 </tbody>
 </table>
-<h3 id="triggers.tekton.dev/v1alpha1.TriggerTemplate">TriggerTemplate
-</h3>
-<div>
-<p>TriggerTemplate takes parameters and uses them to create CRDs</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#triggers.tekton.dev/v1alpha1.TriggerTemplateSpec">
-TriggerTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec holds the desired state of the TriggerTemplate from the client</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#triggers.tekton.dev/v1alpha1.ParamSpec">
-[]ParamSpec
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>resourcetemplates</code><br/>
-<em>
-<a href="#triggers.tekton.dev/v1alpha1.TriggerResourceTemplate">
-[]TriggerResourceTemplate
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#triggers.tekton.dev/v1alpha1.TriggerTemplateStatus">
-TriggerTemplateStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
 <h3 id="triggers.tekton.dev/v1alpha1.TriggerTemplateSpec">TriggerTemplateSpec
 </h3>
 <p>
-(<em>Appears on:</em><a href="#triggers.tekton.dev/v1alpha1.TriggerSpecTemplate">TriggerSpecTemplate</a>, <a href="#triggers.tekton.dev/v1alpha1.TriggerTemplate">TriggerTemplate</a>)
+(<em>Appears on:</em><a href="#triggers.tekton.dev/v1alpha1.TriggerTemplate">TriggerTemplate</a>, <a href="#triggers.tekton.dev/v1alpha1.TriggerSpecTemplate">TriggerSpecTemplate</a>)
 </p>
 <div>
 <p>TriggerTemplateSpec holds the desired state of TriggerTemplate</p>
@@ -2670,6 +2689,8 @@ Resource Types:
 <a href="#triggers.tekton.dev/v1beta1.Trigger">Trigger</a>
 </li><li>
 <a href="#triggers.tekton.dev/v1beta1.TriggerBinding">TriggerBinding</a>
+</li><li>
+<a href="#triggers.tekton.dev/v1beta1.TriggerTemplate">TriggerTemplate</a>
 </li></ul>
 <h3 id="triggers.tekton.dev/v1beta1.ClusterTriggerBinding">ClusterTriggerBinding
 </h3>
@@ -3135,6 +3156,108 @@ TriggerBindingSpec
 <em>
 <a href="#triggers.tekton.dev/v1beta1.TriggerBindingStatus">
 TriggerBindingStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="triggers.tekton.dev/v1beta1.TriggerTemplate">TriggerTemplate
+</h3>
+<div>
+<p>TriggerTemplate takes parameters and uses them to create CRDs</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+triggers.tekton.dev/v1beta1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>TriggerTemplate</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#triggers.tekton.dev/v1beta1.TriggerTemplateSpec">
+TriggerTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec holds the desired state of the TriggerTemplate from the client</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>params</code><br/>
+<em>
+<a href="#triggers.tekton.dev/v1beta1.ParamSpec">
+[]ParamSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>resourcetemplates</code><br/>
+<em>
+<a href="#triggers.tekton.dev/v1beta1.TriggerResourceTemplate">
+[]TriggerResourceTemplate
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#triggers.tekton.dev/v1beta1.TriggerTemplateStatus">
+TriggerTemplateStatus
 </a>
 </em>
 </td>
@@ -4577,95 +4700,10 @@ TriggerTemplateSpec
 </tr>
 </tbody>
 </table>
-<h3 id="triggers.tekton.dev/v1beta1.TriggerTemplate">TriggerTemplate
-</h3>
-<div>
-<p>TriggerTemplate takes parameters and uses them to create CRDs</p>
-</div>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code><br/>
-<em>
-<a href="#triggers.tekton.dev/v1beta1.TriggerTemplateSpec">
-TriggerTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec holds the desired state of the TriggerTemplate from the client</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>params</code><br/>
-<em>
-<a href="#triggers.tekton.dev/v1beta1.ParamSpec">
-[]ParamSpec
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>resourcetemplates</code><br/>
-<em>
-<a href="#triggers.tekton.dev/v1beta1.TriggerResourceTemplate">
-[]TriggerResourceTemplate
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code><br/>
-<em>
-<a href="#triggers.tekton.dev/v1beta1.TriggerTemplateStatus">
-TriggerTemplateStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
 <h3 id="triggers.tekton.dev/v1beta1.TriggerTemplateSpec">TriggerTemplateSpec
 </h3>
 <p>
-(<em>Appears on:</em><a href="#triggers.tekton.dev/v1beta1.TriggerSpecTemplate">TriggerSpecTemplate</a>, <a href="#triggers.tekton.dev/v1beta1.TriggerTemplate">TriggerTemplate</a>)
+(<em>Appears on:</em><a href="#triggers.tekton.dev/v1beta1.TriggerTemplate">TriggerTemplate</a>, <a href="#triggers.tekton.dev/v1beta1.TriggerSpecTemplate">TriggerSpecTemplate</a>)
 </p>
 <div>
 <p>TriggerTemplateSpec holds the desired state of TriggerTemplate</p>

--- a/pkg/apis/triggers/v1alpha1/trigger_template_types.go
+++ b/pkg/apis/triggers/v1alpha1/trigger_template_types.go
@@ -42,10 +42,10 @@ type TriggerResourceTemplate struct {
 // TriggerTemplateStatus describes the desired state of TriggerTemplate
 type TriggerTemplateStatus struct{}
 
-// TriggerTemplate takes parameters and uses them to create CRDs
-//
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// TriggerTemplate takes parameters and uses them to create CRDs
 // +k8s:openapi-gen=true
 type TriggerTemplate struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/triggers/v1beta1/trigger_template_types.go
+++ b/pkg/apis/triggers/v1beta1/trigger_template_types.go
@@ -42,10 +42,11 @@ type TriggerResourceTemplate struct {
 // TriggerTemplateStatus describes the desired state of TriggerTemplate
 type TriggerTemplateStatus struct{}
 
-// TriggerTemplate takes parameters and uses them to create CRDs
 //
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// TriggerTemplate takes parameters and uses them to create CRDs
 // +k8s:openapi-gen=true
 type TriggerTemplate struct {
 	metav1.TypeMeta `json:",inline"`


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fix #1726
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
