### PR TITLE
Bump CEL to v0.20.1

### DIFF
--- a/cmd/cel-eval/cmd/root.go
+++ b/cmd/cel-eval/cmd/root.go
@@ -43,7 +43,7 @@ func init() {
 // revive:disable:unused-parameter
 
 func rootRun(cmd *cobra.Command, args []string) {
-	if err := evalCEL(os.Stdout, expressionPath, httpPath); err != nil {
+	if err := evalCEL(cmd.Context(), os.Stdout, expressionPath, httpPath); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -54,7 +54,7 @@ func (sg secretGetter) Get(ctx context.Context, triggerNS string, sr *triggersv1
 	return nil, nil
 }
 
-func evalCEL(w io.Writer, expressionPath, httpPath string) error {
+func evalCEL(ctx context.Context, w io.Writer, expressionPath, httpPath string) error {
 	// Read expression
 	expression, err := readExpression(expressionPath)
 	if err != nil {
@@ -74,9 +74,12 @@ func evalCEL(w io.Writer, expressionPath, httpPath string) error {
 
 	mapStrDyn := decls.NewMapType(decls.String, decls.Dyn)
 	env, err := cel.NewEnv(
-		triggerscel.Triggers(context.Background(), "default", secretGetter{}),
+		triggerscel.Triggers(ctx, "default", secretGetter{}),
 		celext.Strings(),
 		celext.Encoders(),
+		celext.Sets(),
+		celext.Lists(),
+		celext.Math(),
 		cel.Declarations(
 			decls.NewVar("body", mapStrDyn),
 			decls.NewVar("header", mapStrDyn),

--- a/cmd/cel-eval/cmd/root_test.go
+++ b/cmd/cel-eval/cmd/root_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -9,7 +10,7 @@ import (
 
 func TestEvalCEL(t *testing.T) {
 	out := new(bytes.Buffer)
-	if err := evalCEL(out, "../testdata/expression.txt", "../testdata/http.txt"); err != nil {
+	if err := evalCEL(context.TODO(), out, "../testdata/expression.txt", "../testdata/http.txt"); err != nil {
 		t.Fatalf("evalCEL: %v", err)
 	}
 

--- a/docs/cel_expressions.md
+++ b/docs/cel_expressions.md
@@ -59,8 +59,10 @@ You can either explicitly convert the number, or add another double value e.g.
 
 ```yaml
 interceptors:
-  - cel:
-      overlays:
+  - ref:
+      name: cel
+      params:
+      - name: overlays:
         - key: count_plus_1
           expression: "body.count + 1.0"
         - key: count_plus_2
@@ -85,10 +87,13 @@ The following example will generate an error with the JSON example.
 
 ```yaml
 interceptors:
-  - cel:
-      overlays:
-        - key: bad_measure_times_3
-          expression: "body.measure * 3"
+  - ref:
+      name: cel
+      params:
+      - name: overlays:
+        values:
+          - key: bad_measure_times_3
+            expression: "body.measure * 3"
 ```
 
 **bad_measure_times_3** will fail with
@@ -150,6 +155,14 @@ This would add an extensions key `filtered` with only one of the labels.
 
 All the functionality from the cel-go project's [CEL extension](https://github.com/google/cel-go/tree/master/ext) is available in
 your CEL expressions.
+
+The following extensions are available:
+
+ * [Strings](https://pkg.go.dev/github.com/google/cel-go@v0.20.1/ext#Strings).
+ * [Encoders](https://pkg.go.dev/github.com/google/cel-go@v0.20.1/ext#Encoders)
+ * [Sets](https://pkg.go.dev/github.com/google/cel-go@v0.20.1/ext#Sets)
+ * [Lists](https://pkg.go.dev/github.com/google/cel-go@v0.20.1/ext#Lists)
+ * [Math](https://pkg.go.dev/github.com/google/cel-go@v0.20.1/ext#Math)
 
 ### cel-go Bytes
 

--- a/pkg/interceptors/cel/cel.go
+++ b/pkg/interceptors/cel/cel.go
@@ -105,6 +105,9 @@ func makeCelEnv(ctx context.Context, ns string, sg interceptors.SecretGetter) (*
 		Triggers(ctx, ns, sg),
 		celext.Strings(),
 		celext.Encoders(),
+		celext.Sets(),
+		celext.Lists(),
+		celext.Math(),
 		cel.Declarations(
 			decls.NewVar("body", mapStrDyn),
 			decls.NewVar("header", mapStrDyn),

--- a/pkg/interceptors/cel/cel_test.go
+++ b/pkg/interceptors/cel/cel_test.go
@@ -689,7 +689,23 @@ func TestExpressionEvaluation(t *testing.T) {
 			expr: `body.numbers.first()`,
 			want: types.Int(1),
 		},
+		{
+			name: "sets extension sets.contains",
+			expr: `sets.contains(body.numbers, [1, 6])`,
+			want: types.False,
+		},
+		{
+			name: "slicing arrays",
+			expr: `[1,2,3,4].slice(1,3)`,
+			want: reg.NativeToValue([]int{2, 3}),
+		},
+		{
+			name: "cel maths",
+			expr: `math.greatest(body.numbers)`,
+			want: types.Int(5),
+		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(rt *testing.T) {
 			ctx, _ := test.SetupFakeContext(rt)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This registers the newest cel Extensions.

 * Lists
 * Sets
 * Maths

The docs are updated and the cel-eval tool has been updated to register the extensions.

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

/kind cleanup

# Release Notes

```release-note
CEL interceptor updated to cel-go v0.20.1 and extensions for manipulating lists, sets and mathematical functions have been added.
```
