### PR TITLE
Update eventlistener podSeurityContext to adhere to restricted pod se…

### DIFF
--- a/config/config-defaults-triggers.yaml
+++ b/config/config-defaults-triggers.yaml
@@ -42,4 +42,5 @@ data:
     default-service-account: "default"
     default-run-as-user: "65532"
     default-run-as-group: "65532"
+    default-fs-group: "65532"
     default-run-as-non-root: "true" # allowed values are true and false

--- a/pkg/apis/config/default_test.go
+++ b/pkg/apis/config/default_test.go
@@ -38,6 +38,7 @@ func TestNewDefaultsFromConfigMap(t *testing.T) {
 				DefaultServiceAccount: "default",
 				DefaultRunAsUser:      65532,
 				DefaultRunAsGroup:     65532,
+				DefaultFSGroup:        65532,
 				DefaultRunAsNonRoot:   true,
 			},
 			fileName: config.GetDefaultsConfigName(),
@@ -59,6 +60,7 @@ func TestNewDefaultsFromEmptyConfigMap(t *testing.T) {
 		DefaultServiceAccount: "default",
 		DefaultRunAsUser:      65532,
 		DefaultRunAsGroup:     65532,
+		DefaultFSGroup:        65532,
 		DefaultRunAsNonRoot:   true,
 	}
 	verifyConfigFileWithExpectedConfig(t, DefaultsConfigEmptyName, expectedConfig)
@@ -70,9 +72,11 @@ func TestNewDefaultsFromConfigMapWithEmptyVal(t *testing.T) {
 		DefaultServiceAccount:    "default",
 		DefaultRunAsUser:         65532,
 		DefaultRunAsGroup:        65532,
+		DefaultFSGroup:           65532,
 		DefaultRunAsNonRoot:      true, // when empty value set from configmap we set back to default value for runAsNonRoot
 		IsDefaultRunAsUserEmpty:  true,
 		IsDefaultRunAsGroupEmpty: true,
+		IsDefaultFsGroupEmpty:    true,
 	}
 	verifyConfigFileWithExpectedConfig(t, DefaultsConfigEmptyVal, expectedConfig)
 }

--- a/pkg/apis/config/testdata/config-defaults-empty.yaml
+++ b/pkg/apis/config/testdata/config-defaults-empty.yaml
@@ -39,4 +39,5 @@ data:
     default-service-accounts: "default"
     default-run-as-user: "65532"
     default-run-as-group: "65532"
+    default-fs-group: "65532"
     default-run-as-non-root: "false"

--- a/pkg/apis/config/testdata/config-defaults-triggers-empty-val.yaml
+++ b/pkg/apis/config/testdata/config-defaults-triggers-empty-val.yaml
@@ -21,4 +21,5 @@ data:
   default-service-account: "default"
   default-run-as-user: ""
   default-run-as-group: ""
+  default-fs-group: ""
   default-run-as-non-root: ""

--- a/pkg/apis/config/testdata/config-defaults-triggers.yaml
+++ b/pkg/apis/config/testdata/config-defaults-triggers.yaml
@@ -21,4 +21,5 @@ data:
   default-service-account: "default"
   default-run-as-user: "65532"
   default-run-as-group: "65532"
+  default-fs-group: "65532"
   default-run-as-non-root: "true"

--- a/pkg/reconciler/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/eventlistener/eventlistener_test.go
@@ -292,6 +292,12 @@ func makeDeployment(ops ...func(d *appsv1.Deployment)) *appsv1.Deployment {
 					}},
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: ptr.Bool(true),
+						RunAsUser:    ptr.Int64(65532),
+						RunAsGroup:   ptr.Int64(65532),
+						FSGroup:      ptr.Int64(65532),
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
 					},
 				},
 			},
@@ -900,6 +906,12 @@ func TestReconcile(t *testing.T) {
 	deploymentMissingReadOnlyRootFilesystem := makeDeployment(func(d *appsv1.Deployment) {
 		d.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
 			RunAsNonRoot: ptr.Bool(true),
+			RunAsUser:    ptr.Int64(65532),
+			RunAsGroup:   ptr.Int64(65532),
+			FSGroup:      ptr.Int64(65532),
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
 		}
 		d.Spec.Template.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{
 			AllowPrivilegeEscalation: ptr.Bool(false),
@@ -926,6 +938,12 @@ func TestReconcile(t *testing.T) {
 	deploymentWithSecurityContext := makeDeployment(func(d *appsv1.Deployment) {
 		d.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
 			RunAsNonRoot: ptr.Bool(true),
+			RunAsUser:    ptr.Int64(65532),
+			RunAsGroup:   ptr.Int64(65532),
+			FSGroup:      ptr.Int64(65532),
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
 		}
 		d.Spec.Template.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{
 			AllowPrivilegeEscalation: ptr.Bool(false),

--- a/pkg/reconciler/eventlistener/resources/deployment_test.go
+++ b/pkg/reconciler/eventlistener/resources/deployment_test.go
@@ -36,17 +36,19 @@ func TestDeployment(t *testing.T) {
 	t.Setenv("METRICS_PROMETHEUS_PORT", "9000")
 	t.Setenv("SYSTEM_NAMESPACE", "tekton-pipelines")
 
-	config := *MakeConfig()
+	resourcesConfig := *MakeConfig()
 	labels := map[string]string{
 		"app.kubernetes.io/managed-by": "EventListener",
 		"app.kubernetes.io/part-of":    "Triggers",
 		"eventlistener":                eventListenerName,
 	}
+	expectedSecurityContext := getStrongerSecurityPolicy(cfg.FromContextOrDefaults(context.Background()))
 
 	tests := []struct {
-		name string
-		el   *v1beta1.EventListener
-		want *appsv1.Deployment
+		name   string
+		el     *v1beta1.EventListener
+		config *cfg.Config
+		want   *appsv1.Deployment
 	}{{
 		name: "vanilla",
 		el:   makeEL(),
@@ -68,11 +70,11 @@ func TestDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: "sa",
 						Containers: []corev1.Container{
-							MakeContainer(makeEL(), &reconcilersource.EmptyVarsGenerator{}, config,
-								cfg.FromContextOrDefaults(context.Background()), mustAddDeployBits(t, makeEL(), config),
-								addCertsForSecureConnection(config)),
+							MakeContainer(makeEL(), &reconcilersource.EmptyVarsGenerator{}, resourcesConfig,
+								cfg.FromContextOrDefaults(context.Background()), mustAddDeployBits(t, makeEL(), resourcesConfig),
+								addCertsForSecureConnection(resourcesConfig)),
 						},
-						SecurityContext: &strongerSecurityPolicy,
+						SecurityContext: &expectedSecurityContext,
 					},
 				},
 			},
@@ -103,11 +105,11 @@ func TestDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: "sa",
 						Containers: []corev1.Container{
-							MakeContainer(makeEL(), &reconcilersource.EmptyVarsGenerator{}, config,
-								cfg.FromContextOrDefaults(context.Background()), mustAddDeployBits(t, makeEL(), config),
-								addCertsForSecureConnection(config)),
+							MakeContainer(makeEL(), &reconcilersource.EmptyVarsGenerator{}, resourcesConfig,
+								cfg.FromContextOrDefaults(context.Background()), mustAddDeployBits(t, makeEL(), resourcesConfig),
+								addCertsForSecureConnection(resourcesConfig)),
 						},
-						SecurityContext: &strongerSecurityPolicy,
+						SecurityContext: &expectedSecurityContext,
 					},
 				},
 			},
@@ -146,11 +148,11 @@ func TestDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: "sa",
 						Containers: []corev1.Container{
-							MakeContainer(makeEL(), &reconcilersource.EmptyVarsGenerator{}, config,
-								cfg.FromContextOrDefaults(context.Background()), mustAddDeployBits(t, makeEL(), config),
-								addCertsForSecureConnection(config)),
+							MakeContainer(makeEL(), &reconcilersource.EmptyVarsGenerator{}, resourcesConfig,
+								cfg.FromContextOrDefaults(context.Background()), mustAddDeployBits(t, makeEL(), resourcesConfig),
+								addCertsForSecureConnection(resourcesConfig)),
 						},
-						SecurityContext: &strongerSecurityPolicy,
+						SecurityContext: &expectedSecurityContext,
 						Tolerations: []corev1.Toleration{{
 							Key:   "foo",
 							Value: "bar",
@@ -192,11 +194,11 @@ func TestDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: "sa",
 						Containers: []corev1.Container{
-							MakeContainer(makeEL(), &reconcilersource.EmptyVarsGenerator{}, config,
-								cfg.FromContextOrDefaults(context.Background()), mustAddDeployBits(t, makeEL(), config),
-								addCertsForSecureConnection(config)),
+							MakeContainer(makeEL(), &reconcilersource.EmptyVarsGenerator{}, resourcesConfig,
+								cfg.FromContextOrDefaults(context.Background()), mustAddDeployBits(t, makeEL(), resourcesConfig),
+								addCertsForSecureConnection(resourcesConfig)),
 						},
-						SecurityContext: &strongerSecurityPolicy,
+						SecurityContext: &expectedSecurityContext,
 						NodeSelector: map[string]string{
 							"foo": "bar",
 						},
@@ -235,11 +237,11 @@ func TestDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: "bob",
 						Containers: []corev1.Container{
-							MakeContainer(makeEL(), &reconcilersource.EmptyVarsGenerator{}, config,
-								cfg.FromContextOrDefaults(context.Background()), mustAddDeployBits(t, makeEL(), config),
-								addCertsForSecureConnection(config)),
+							MakeContainer(makeEL(), &reconcilersource.EmptyVarsGenerator{}, resourcesConfig,
+								cfg.FromContextOrDefaults(context.Background()), mustAddDeployBits(t, makeEL(), resourcesConfig),
+								addCertsForSecureConnection(resourcesConfig)),
 						},
-						SecurityContext: &strongerSecurityPolicy,
+						SecurityContext: &expectedSecurityContext,
 					},
 				},
 			},
@@ -265,9 +267,9 @@ func TestDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: "sa",
 						Containers: []corev1.Container{
-							MakeContainer(makeEL(withTLSEnvFrom("Bill")), &reconcilersource.EmptyVarsGenerator{}, config,
-								cfg.FromContextOrDefaults(context.Background()), mustAddDeployBits(t, makeEL(withTLSEnvFrom("Bill")), config),
-								addCertsForSecureConnection(config)),
+							MakeContainer(makeEL(withTLSEnvFrom("Bill")), &reconcilersource.EmptyVarsGenerator{}, resourcesConfig,
+								cfg.FromContextOrDefaults(context.Background()), mustAddDeployBits(t, makeEL(withTLSEnvFrom("Bill")), resourcesConfig),
+								addCertsForSecureConnection(resourcesConfig)),
 						},
 						Volumes: []corev1.Volume{{
 							Name: "https-connection",
@@ -277,7 +279,7 @@ func TestDeployment(t *testing.T) {
 								},
 							},
 						}},
-						SecurityContext: &strongerSecurityPolicy,
+						SecurityContext: &expectedSecurityContext,
 					},
 				},
 			},
@@ -319,11 +321,11 @@ func TestDeployment(t *testing.T) {
 							MaxSkew: 1,
 						}},
 						Containers: []corev1.Container{
-							MakeContainer(makeEL(), &reconcilersource.EmptyVarsGenerator{}, config,
-								cfg.FromContextOrDefaults(context.Background()), mustAddDeployBits(t, makeEL(), config),
-								addCertsForSecureConnection(config)),
+							MakeContainer(makeEL(), &reconcilersource.EmptyVarsGenerator{}, resourcesConfig,
+								cfg.FromContextOrDefaults(context.Background()), mustAddDeployBits(t, makeEL(), resourcesConfig),
+								addCertsForSecureConnection(resourcesConfig)),
 						},
-						SecurityContext: &strongerSecurityPolicy,
+						SecurityContext: &expectedSecurityContext,
 					},
 				},
 			},
@@ -349,11 +351,73 @@ func TestDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						ServiceAccountName: "sa",
 						Containers: []corev1.Container{
-							MakeContainer(makeEL(setProbes()), &reconcilersource.EmptyVarsGenerator{}, config,
-								cfg.FromContextOrDefaults(context.Background()), mustAddDeployBits(t, makeEL(setProbes()), config),
-								addCertsForSecureConnection(config)),
+							MakeContainer(makeEL(setProbes()), &reconcilersource.EmptyVarsGenerator{}, resourcesConfig,
+								cfg.FromContextOrDefaults(context.Background()), mustAddDeployBits(t, makeEL(setProbes()), resourcesConfig),
+								addCertsForSecureConnection(resourcesConfig)),
 						},
-						SecurityContext: &strongerSecurityPolicy,
+						SecurityContext: &expectedSecurityContext,
+					},
+				},
+			},
+		},
+	}, {
+		name:   "with overridden runAsGroup, runAsUser, fsGroup",
+		el:     makeEL(setProbes()),
+		config: getConfigWithoverriddenRunAsGroupAndRunAsUserAndFsGroup("0"),
+		want: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "",
+				Namespace:       namespace,
+				Labels:          labels,
+				OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(makeEL())},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: labels,
+					},
+					Spec: corev1.PodSpec{
+						ServiceAccountName: "sa",
+						Containers: []corev1.Container{
+							MakeContainer(makeEL(setProbes()), &reconcilersource.EmptyVarsGenerator{}, resourcesConfig,
+								getConfigWithoverriddenRunAsGroupAndRunAsUserAndFsGroup("0"), mustAddDeployBits(t, makeEL(setProbes()), resourcesConfig),
+								addCertsForSecureConnection(resourcesConfig)),
+						},
+						SecurityContext: getSecurityContextWithoverriddenRunAsGroupAndRunAsUser(expectedSecurityContext, ptr.Int64(0)),
+					},
+				},
+			},
+		},
+	}, {
+		name:   "support empty defaults runAsGroup, runAsUser, fsGroup for distributions such as OpenShift",
+		el:     makeEL(setProbes()),
+		config: getConfigWithoverriddenRunAsGroupAndRunAsUserAndFsGroup(""),
+		want: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "",
+				Namespace:       namespace,
+				Labels:          labels,
+				OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(makeEL())},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: labels,
+					},
+					Spec: corev1.PodSpec{
+						ServiceAccountName: "sa",
+						Containers: []corev1.Container{
+							MakeContainer(makeEL(setProbes()), &reconcilersource.EmptyVarsGenerator{}, resourcesConfig,
+								getConfigWithoverriddenRunAsGroupAndRunAsUserAndFsGroup(""), mustAddDeployBits(t, makeEL(setProbes()), resourcesConfig),
+								addCertsForSecureConnection(resourcesConfig)),
+						},
+						SecurityContext: getSecurityContextWithoverriddenRunAsGroupAndRunAsUser(expectedSecurityContext, nil),
 					},
 				},
 			},
@@ -362,8 +426,12 @@ func TestDeployment(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := MakeDeployment(context.Background(), tt.el, &reconcilersource.EmptyVarsGenerator{}, config,
-				cfg.FromContextOrDefaults(context.Background()))
+			config := tt.config
+			if config == nil {
+				config = cfg.FromContextOrDefaults(context.Background())
+			}
+			got, err := MakeDeployment(context.Background(), tt.el, &reconcilersource.EmptyVarsGenerator{}, resourcesConfig,
+				config)
 			if err != nil {
 				t.Fatalf("MakeDeployment() = %v", err)
 			}
@@ -372,6 +440,26 @@ func TestDeployment(t *testing.T) {
 			}
 		})
 	}
+}
+
+func getSecurityContextWithoverriddenRunAsGroupAndRunAsUser(securityContext corev1.PodSecurityContext, overriddenValue *int64) *corev1.PodSecurityContext {
+	securityContextCopy := securityContext.DeepCopy()
+
+	securityContextCopy.RunAsUser = overriddenValue
+	securityContextCopy.RunAsGroup = overriddenValue
+	securityContextCopy.FSGroup = overriddenValue
+	return securityContextCopy
+}
+
+func getConfigWithoverriddenRunAsGroupAndRunAsUserAndFsGroup(value string) *cfg.Config {
+	config := cfg.FromContextOrDefaults(context.Background())
+	defaults, err := cfg.NewDefaultsFromMap(map[string]string{cfg.DefaultRunAsGroupKey: value, cfg.DefaultRunAsUserKey: value, cfg.DefaultFSGroupKey: value})
+	if err != nil {
+		panic(err)
+	}
+
+	config.Defaults = defaults
+	return config
 }
 
 func TestDeploymentError(t *testing.T) {


### PR DESCRIPTION
Solves issue #1739

Currently, when `el-security-context` is enabled, the `securityContext` for `EventListener` in the pod template only sets `runAsNonRoot`. Expanding podTemplate `securityContext` can make it easier to fulfill restricted pod security standards.

Makes it possible to have a default `securityContext` set for injected sidecar containers that does not fulfill restricted pod security standars. An example of this is injected istio containers. 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Alter podSecurityContext to include seccompProfile, runAsUser, runAsGroup and fsGroup when set-security-context is set.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Eventlistener podTemplate now includes securityContext settings: seccompProfile, runAsUser, runAsGroup, and fsGroup when flag el-security-context is true. 
```
