### PR TITLE
Add new flag set-read-only-root-filesystem to set readOnlyRootFilesys…

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -39,15 +39,16 @@ const (
 )
 
 var (
-	image                 = flag.String("el-image", elresources.DefaultImage, "The container image for the EventListener Pod.")
-	port                  = flag.Int("el-port", elresources.DefaultPort, "The container port for the EventListener to listen on.")
-	setSecurityContext    = flag.Bool("el-security-context", elresources.DefaultSetSecurityContext, "Add a security context to the event listener deployment.")
-	setEventListenerEvent = flag.String("el-events", elresources.DefaultEventListenerEvent, "Enable events for event listener deployment.")
-	readTimeOut           = flag.Int64("el-readtimeout", elresources.DefaultReadTimeout, "The read timeout for EventListener Server.")
-	writeTimeOut          = flag.Int64("el-writetimeout", elresources.DefaultWriteTimeout, "The write timeout for EventListener Server.")
-	idleTimeOut           = flag.Int64("el-idletimeout", elresources.DefaultIdleTimeout, "The idle timeout for EventListener Server.")
-	timeOutHandler        = flag.Int64("el-timeouthandler", elresources.DefaultTimeOutHandler, "The timeout for Timeout Handler of EventListener Server.")
-	httpClientReadTimeOut = flag.Int64("el-httpclient-readtimeout", elresources.DefaultHTTPClientReadTimeOut,
+	image                     = flag.String("el-image", elresources.DefaultImage, "The container image for the EventListener Pod.")
+	port                      = flag.Int("el-port", elresources.DefaultPort, "The container port for the EventListener to listen on.")
+	setSecurityContext        = flag.Bool("el-security-context", elresources.DefaultSetSecurityContext, "Add a security context to the event listener deployment.")
+	setReadOnlyRootFilesystem = flag.Bool("el-read-only-root-filesystem", elresources.DefaultSetReadOnlyRootFilesystem, "Sets readOnlyRootFilesystem to the provided value for the event listener deployment. Note: only applied when flag el-security-context is set to true.")
+	setEventListenerEvent     = flag.String("el-events", elresources.DefaultEventListenerEvent, "Enable events for event listener deployment.")
+	readTimeOut               = flag.Int64("el-readtimeout", elresources.DefaultReadTimeout, "The read timeout for EventListener Server.")
+	writeTimeOut              = flag.Int64("el-writetimeout", elresources.DefaultWriteTimeout, "The write timeout for EventListener Server.")
+	idleTimeOut               = flag.Int64("el-idletimeout", elresources.DefaultIdleTimeout, "The idle timeout for EventListener Server.")
+	timeOutHandler            = flag.Int64("el-timeouthandler", elresources.DefaultTimeOutHandler, "The timeout for Timeout Handler of EventListener Server.")
+	httpClientReadTimeOut     = flag.Int64("el-httpclient-readtimeout", elresources.DefaultHTTPClientReadTimeOut,
 		"The HTTP Client read timeout for EventListener Server.")
 	httpClientKeepAlive = flag.Int64("el-httpclient-keep-alive", elresources.DefaultHTTPClientKeepAlive,
 		"The HTTP Client read timeout for EventListener Server.")
@@ -71,6 +72,7 @@ func main() {
 		Image:                           image,
 		Port:                            port,
 		SetSecurityContext:              setSecurityContext,
+		SetReadOnlyRootFilesystem:       setReadOnlyRootFilesystem,
 		SetEventListenerEvent:           setEventListenerEvent,
 		ReadTimeOut:                     readTimeOut,
 		WriteTimeOut:                    writeTimeOut,

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -60,6 +60,7 @@ spec:
               "-el-port",
               "8080",
               "-el-security-context=true",
+              "-el-read-only-root-filesystem=true",
               "-el-events",
               "disable",
               "-el-readtimeout",

--- a/pkg/reconciler/eventlistener/resources/config.go
+++ b/pkg/reconciler/eventlistener/resources/config.go
@@ -23,6 +23,8 @@ var (
 	DefaultPort = 8080
 	// DefaultSetSecurityContext is the SetSecurityContext value used by default.
 	DefaultSetSecurityContext = true
+	// DefaultSetReadOnlyRootFilesystem is the SetReadOnlyRootFilesystem value used by default.
+	DefaultSetReadOnlyRootFilesystem = true
 	// DefaultEventListenerEvent is the EventListenerEvent value used by default.
 	DefaultEventListenerEvent = "disable"
 	// DefaultReadTimeout is the ReadTimeout used by default.
@@ -63,6 +65,8 @@ type Config struct {
 	Port *int
 	// SetSecurityContext defines if the security context is set.
 	SetSecurityContext *bool
+	// SetReadOnlyRootFilesystem defines the value for readOnlyRootFilesystem
+	SetReadOnlyRootFilesystem *bool
 	// SetEventListenerEvent defines to enable or disable of emitting events for EventListener.
 	SetEventListenerEvent *string
 	// ReadTimeOut defines the read timeout for EventListener Server.
@@ -99,11 +103,11 @@ type ConfigOption func(d *Config)
 // It generates a default Config for the EventListener without any flags set and accepts functions for modification.
 func MakeConfig(ops ...ConfigOption) *Config {
 	c := &Config{
-		Image:                 &DefaultImage,
-		Port:                  &DefaultPort,
-		SetSecurityContext:    &DefaultSetSecurityContext,
-		SetEventListenerEvent: &DefaultEventListenerEvent,
-
+		Image:                           &DefaultImage,
+		Port:                            &DefaultPort,
+		SetSecurityContext:              &DefaultSetSecurityContext,
+		SetEventListenerEvent:           &DefaultEventListenerEvent,
+		SetReadOnlyRootFilesystem:       &DefaultSetReadOnlyRootFilesystem,
 		ReadTimeOut:                     &DefaultReadTimeout,
 		WriteTimeOut:                    &DefaultWriteTimeout,
 		IdleTimeOut:                     &DefaultIdleTimeout,

--- a/pkg/reconciler/eventlistener/resources/container.go
+++ b/pkg/reconciler/eventlistener/resources/container.go
@@ -62,6 +62,10 @@ func MakeContainer(el *v1beta1.EventListener, configAcc reconcilersource.ConfigA
 				Type: corev1.SeccompProfileTypeRuntimeDefault,
 			},
 		}
+
+		if *c.SetReadOnlyRootFilesystem {
+			containerSecurityContext.ReadOnlyRootFilesystem = ptr.Bool(true)
+		}
 	}
 
 	if !cfg.Defaults.IsDefaultRunAsUserEmpty {

--- a/pkg/reconciler/eventlistener/resources/container_test.go
+++ b/pkg/reconciler/eventlistener/resources/container_test.go
@@ -92,9 +92,10 @@ func TestContainer(t *testing.T) {
 					Drop: []corev1.Capability{"ALL"},
 				},
 				// 65532 is the distroless nonroot user ID
-				RunAsUser:    ptr.Int64(65532),
-				RunAsGroup:   ptr.Int64(65532),
-				RunAsNonRoot: ptr.Bool(true),
+				RunAsUser:              ptr.Int64(65532),
+				RunAsGroup:             ptr.Int64(65532),
+				RunAsNonRoot:           ptr.Bool(true),
+				ReadOnlyRootFilesystem: ptr.Bool(true),
 				SeccompProfile: &corev1.SeccompProfile{
 					Type: corev1.SeccompProfileTypeRuntimeDefault,
 				},
@@ -166,9 +167,10 @@ func TestContainer(t *testing.T) {
 					Drop: []corev1.Capability{"ALL"},
 				},
 				// 65532 is the distroless nonroot user ID
-				RunAsUser:    ptr.Int64(65532),
-				RunAsGroup:   ptr.Int64(65532),
-				RunAsNonRoot: ptr.Bool(true),
+				RunAsUser:              ptr.Int64(65532),
+				RunAsGroup:             ptr.Int64(65532),
+				RunAsNonRoot:           ptr.Bool(true),
+				ReadOnlyRootFilesystem: ptr.Bool(true),
 				SeccompProfile: &corev1.SeccompProfile{
 					Type: corev1.SeccompProfileTypeRuntimeDefault,
 				},
@@ -219,9 +221,10 @@ func TestContainer(t *testing.T) {
 					Drop: []corev1.Capability{"ALL"},
 				},
 				// 65532 is the distroless nonroot user ID
-				RunAsUser:    ptr.Int64(65532),
-				RunAsGroup:   ptr.Int64(65532),
-				RunAsNonRoot: ptr.Bool(true),
+				RunAsUser:              ptr.Int64(65532),
+				RunAsGroup:             ptr.Int64(65532),
+				RunAsNonRoot:           ptr.Bool(true),
+				ReadOnlyRootFilesystem: ptr.Bool(true),
 				SeccompProfile: &corev1.SeccompProfile{
 					Type: corev1.SeccompProfileTypeRuntimeDefault,
 				},
@@ -281,9 +284,10 @@ func TestContainer(t *testing.T) {
 					Drop: []corev1.Capability{"ALL"},
 				},
 				// 65532 is the distroless nonroot user ID
-				RunAsUser:    ptr.Int64(65532),
-				RunAsGroup:   ptr.Int64(65532),
-				RunAsNonRoot: ptr.Bool(true),
+				RunAsUser:              ptr.Int64(65532),
+				RunAsGroup:             ptr.Int64(65532),
+				RunAsNonRoot:           ptr.Bool(true),
+				ReadOnlyRootFilesystem: ptr.Bool(true),
 				SeccompProfile: &corev1.SeccompProfile{
 					Type: corev1.SeccompProfileTypeRuntimeDefault,
 				},
@@ -344,9 +348,10 @@ func TestContainer(t *testing.T) {
 					Drop: []corev1.Capability{"ALL"},
 				},
 				// 65532 is the distroless nonroot user ID
-				RunAsUser:    ptr.Int64(65532),
-				RunAsGroup:   ptr.Int64(65532),
-				RunAsNonRoot: ptr.Bool(true),
+				RunAsUser:              ptr.Int64(65532),
+				RunAsGroup:             ptr.Int64(65532),
+				RunAsNonRoot:           ptr.Bool(true),
+				ReadOnlyRootFilesystem: ptr.Bool(true),
 				SeccompProfile: &corev1.SeccompProfile{
 					Type: corev1.SeccompProfileTypeRuntimeDefault,
 				},
@@ -407,9 +412,10 @@ func TestContainer(t *testing.T) {
 					Drop: []corev1.Capability{"ALL"},
 				},
 				// 65532 is the distroless nonroot user ID
-				RunAsUser:    ptr.Int64(65532),
-				RunAsGroup:   ptr.Int64(65532),
-				RunAsNonRoot: ptr.Bool(true),
+				RunAsUser:              ptr.Int64(65532),
+				RunAsGroup:             ptr.Int64(65532),
+				RunAsNonRoot:           ptr.Bool(true),
+				ReadOnlyRootFilesystem: ptr.Bool(true),
 				SeccompProfile: &corev1.SeccompProfile{
 					Type: corev1.SeccompProfileTypeRuntimeDefault,
 				},
@@ -471,9 +477,10 @@ func TestContainer(t *testing.T) {
 					Drop: []corev1.Capability{"ALL"},
 				},
 				// 65532 is the distroless nonroot user ID
-				RunAsUser:    ptr.Int64(65532),
-				RunAsGroup:   ptr.Int64(65532),
-				RunAsNonRoot: ptr.Bool(true),
+				RunAsUser:              ptr.Int64(65532),
+				RunAsGroup:             ptr.Int64(65532),
+				RunAsNonRoot:           ptr.Bool(true),
+				ReadOnlyRootFilesystem: ptr.Bool(true),
 				SeccompProfile: &corev1.SeccompProfile{
 					Type: corev1.SeccompProfileTypeRuntimeDefault,
 				},

--- a/pkg/reconciler/eventlistener/resources/custom_test.go
+++ b/pkg/reconciler/eventlistener/resources/custom_test.go
@@ -155,10 +155,11 @@ func TestCustomObject(t *testing.T) {
 										"allowPrivilegeEscalation": false,
 										"capabilities": map[string]interface{}{
 											"drop": []interface{}{string("ALL")}},
-										"runAsGroup":     int64(65532),
-										"runAsNonRoot":   bool(true),
-										"runAsUser":      int64(65532),
-										"seccompProfile": map[string]interface{}{"type": string("RuntimeDefault")},
+										"runAsGroup":             int64(65532),
+										"runAsNonRoot":           bool(true),
+										"readOnlyRootFilesystem": bool(true),
+										"runAsUser":              int64(65532),
+										"seccompProfile":         map[string]interface{}{"type": string("RuntimeDefault")},
 									},
 									"resources": map[string]interface{}{},
 									"readinessProbe": map[string]interface{}{
@@ -231,10 +232,11 @@ func TestCustomObject(t *testing.T) {
 										"allowPrivilegeEscalation": false,
 										"capabilities": map[string]interface{}{
 											"drop": []interface{}{string("ALL")}},
-										"runAsGroup":     int64(65532),
-										"runAsNonRoot":   bool(true),
-										"runAsUser":      int64(65532),
-										"seccompProfile": map[string]interface{}{"type": string("RuntimeDefault")},
+										"runAsGroup":             int64(65532),
+										"runAsNonRoot":           bool(true),
+										"readOnlyRootFilesystem": bool(true),
+										"runAsUser":              int64(65532),
+										"seccompProfile":         map[string]interface{}{"type": string("RuntimeDefault")},
 									},
 									"resources": map[string]interface{}{},
 									"readinessProbe": map[string]interface{}{
@@ -308,10 +310,11 @@ func TestCustomObject(t *testing.T) {
 										"allowPrivilegeEscalation": false,
 										"capabilities": map[string]interface{}{
 											"drop": []interface{}{string("ALL")}},
-										"runAsGroup":     int64(65532),
-										"runAsNonRoot":   bool(true),
-										"runAsUser":      int64(65532),
-										"seccompProfile": map[string]interface{}{"type": string("RuntimeDefault")},
+										"runAsGroup":             int64(65532),
+										"runAsNonRoot":           bool(true),
+										"readOnlyRootFilesystem": bool(true),
+										"runAsUser":              int64(65532),
+										"seccompProfile":         map[string]interface{}{"type": string("RuntimeDefault")},
 									},
 									"readinessProbe": map[string]interface{}{
 										"httpGet": map[string]interface{}{
@@ -425,10 +428,11 @@ func TestCustomObject(t *testing.T) {
 										"allowPrivilegeEscalation": false,
 										"capabilities": map[string]interface{}{
 											"drop": []interface{}{string("ALL")}},
-										"runAsGroup":     int64(65532),
-										"runAsNonRoot":   bool(true),
-										"runAsUser":      int64(65532),
-										"seccompProfile": map[string]interface{}{"type": string("RuntimeDefault")},
+										"runAsGroup":             int64(65532),
+										"runAsNonRoot":           bool(true),
+										"readOnlyRootFilesystem": bool(true),
+										"runAsUser":              int64(65532),
+										"seccompProfile":         map[string]interface{}{"type": string("RuntimeDefault")},
 									},
 									"readinessProbe": map[string]interface{}{
 										"httpGet": map[string]interface{}{


### PR DESCRIPTION
Solves: #1741
Support to set readOnlyRootFilesystem for EventListener container

# Changes
Add new flag set-read-only-root-filesystem.
Sets container securityContext readOnlyRootFilesystem to true when new flag is set to true

Prior to this it was not possible to set readOnlyRootFilesystem for EventListener container. Aligns security towards azure aks best practices and industry

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Added a new flag `el-read-only-root-filesystem` to the `tekton-triggers-controller` container. This flag, which is set to `true` by default, configures the `EventListener` container's `securityContext.readOnlyRootFilesystem` to `true`. This change aligns with Azure AKS best practices and enhances security.
```
