### PR TITLE
fix: Markdown syntax error for Note in events.md

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -28,7 +28,8 @@ Resource            |Event      |Event Type
 `EventListener`     | `Done`    | `dev.tekton.event.triggers.done.v1`
 `EventListener`     | `Failed`  | `dev.tekton.event.triggers.failed.v1`
 
-##Note
+## Note
+
 By default Kubernetes events are disabled for EventListener.
 
 To enable Kubernetes events add/update controller.yaml with below arg


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes an issue in events.md document in the # Note section that would render as a regular paragraph. With this fix the sections becomes evident to the reader

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
