### PR TITLE
issue-1666: EventListener loglevel for interceptor updated to DEBUG

### DIFF
--- a/pkg/sink/sink.go
+++ b/pkg/sink/sink.go
@@ -329,7 +329,7 @@ func (r Sink) processTriggerGroups(g triggersv1.EventListenerTriggerGroup, el *t
 			}
 		}
 		if !resp.Continue {
-			eventLog.Infof("interceptor stopped trigger processing: %v", resp.Status.Err())
+			eventLog.Debugf("interceptor stopped trigger processing: %v", resp.Status.Err())
 			return
 		}
 	}
@@ -417,7 +417,7 @@ func (r Sink) processTrigger(t triggersv1.Trigger, el *triggersv1.EventListener,
 
 	if iresp != nil {
 		if !iresp.Continue {
-			log.Infof("interceptor stopped trigger processing: %v", iresp.Status.Err())
+			log.Debugf("interceptor stopped trigger processing: %v", iresp.Status.Err())
 			return
 		}
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes -: Log level for Event Listener interceptor was updated to DEBUG level to reduce excessive logging.

Related to [issue-1666](https://github.com/tektoncd/triggers/issues/1666)


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
