### PR TITLE
fix for issue-1711-: Metrics not getting update correctly for eventlistener_event_count

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -620,7 +620,7 @@ The following pipeline metrics are available on the `eventlistener` Service on p
 |  Name | Type | Labels/Tags | Status |
 | ---------- | ----------- | :-: | ----------- |
 | `eventlistener_triggered_resources` | Counter | `kind`=&lt;kind&gt; | experimental |
-| `eventlistener_event_count` | Counter | `status`=&lt;status&gt; | experimental |
+| `eventlistener_event_received_count` | Counter | `status`=&lt;status&gt; | experimental |
 | `eventlistener_http_duration_seconds_[bucket, sum, count]` | Histogram | - | experimental |
 
 Several kinds of exporters can be configured for an `EventListener`, including Prometheus, Google Stackdriver, and many others.

--- a/pkg/sink/metrics.go
+++ b/pkg/sink/metrics.go
@@ -20,7 +20,7 @@ var (
 		"The eventlistener HTTP request duration",
 		stats.UnitDimensionless)
 	elDistribution = view.Distribution(metrics.BucketsNBy10(0.001, 5)...)
-	eventCount     = stats.Float64("event_count",
+	eventRcdCount     = stats.Float64("event_received_count",
 		"number of events received by sink",
 		stats.UnitDimensionless)
 	triggeredResources = stats.Int64("triggered_resources", "Count of the number of triggered eventlistener resources", stats.UnitDimensionless)
@@ -65,8 +65,8 @@ func NewRecorder() (*Recorder, error) {
 			TagKeys:     []tag.Key{r.kind},
 		},
 		&view.View{
-			Description: eventCount.Description(),
-			Measure:     eventCount,
+			Description: eventRcdCount.Description(),
+			Measure:     eventRcdCount,
 			Aggregation: view.Count(),
 			TagKeys:     []tag.Key{r.status},
 		},
@@ -119,11 +119,11 @@ func (s *Sink) recordCountMetrics(status string) {
 	)
 
 	if err != nil {
-		s.Logger.Warnf("failed to create tag for metric event_count: %w", err)
+		s.Logger.Warnf("failed to create tag for metric event_received_count: %w", err)
 		return
 	}
 
-	metrics.Record(ctx, eventCount.M(1))
+	metrics.Record(ctx, eventRcdCount.M(1))
 }
 
 func (s *Sink) recordResourceCreation(resources []json.RawMessage) {

--- a/pkg/sink/metrics.go
+++ b/pkg/sink/metrics.go
@@ -20,7 +20,7 @@ var (
 		"The eventlistener HTTP request duration",
 		stats.UnitDimensionless)
 	elDistribution = view.Distribution(metrics.BucketsNBy10(0.001, 5)...)
-	eventRcdCount     = stats.Float64("event_received_count",
+	eventRcdCount  = stats.Float64("event_received_count",
 		"number of events received by sink",
 		stats.UnitDimensionless)
 	triggeredResources = stats.Int64("triggered_resources", "Count of the number of triggered eventlistener resources", stats.UnitDimensionless)

--- a/pkg/sink/metrics_test.go
+++ b/pkg/sink/metrics_test.go
@@ -112,7 +112,7 @@ func TestRecordRecordDurationMetrics(t *testing.T) {
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			defer metricstest.Unregister("event_count", "http_duration_seconds")
+			defer metricstest.Unregister("event_received_count", "http_duration_seconds")
 			logger := zaptest.NewLogger(t).Sugar()
 			metrics.FlushExporter()
 			err := metrics.UpdateExporter(context.TODO(), metrics.ExporterOptions{
@@ -148,7 +148,7 @@ func TestRecordRecordCountMetrics(t *testing.T) {
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			defer metricstest.Unregister("event_count", "http_duration_seconds")
+			defer metricstest.Unregister("event_received_count", "http_duration_seconds")
 			logger := zaptest.NewLogger(t).Sugar()
 			metrics.FlushExporter()
 			err := metrics.UpdateExporter(context.TODO(), metrics.ExporterOptions{
@@ -165,7 +165,7 @@ func TestRecordRecordCountMetrics(t *testing.T) {
 				Logger:   logger,
 			}
 			s.recordCountMetrics(failTag)
-			metricstest.CheckCountData(t, "event_count", test.expectedTags, test.expectedCount)
+			metricstest.CheckCountData(t, "event_received_count", test.expectedTags, test.expectedCount)
 		})
 	}
 }


### PR DESCRIPTION
fix for issue-1711-: Metrics not getting update correctly for eventlistener_event_count

[Issue](https://github.com/tektoncd/triggers/issues/1711) -:  eventlistener_event_count metrics is not updated correctly
~~~
eventlistener_client_results{name=""} 34
# HELP eventlistener_event_count Number of events sent
# TYPE eventlistener_event_count counter
eventlistener_event_count{event_source="",event_type="",name="",namespace_name="",resource_group="",response_code="",response_code_class="",response_error="",response_timeout=""} 404
# HELP eventlistener_go_alloc The number of bytes of allocated heap objects
~~~

Metrics Output After the changes
~~~
# HELP eventlistener_event_received_count number of events received by sink
# TYPE eventlistener_event_received_count counter
eventlistener_event_received_count{status="succeeded"} 1
~~~

Fix -: Metric name updated from " eventlistener_event_count" to "eventlistener_event_received_count". 
Docs updated

# Release Notes

```release-note
NONE
```
