### PR TITLE
Add runAsUser and runAsGroup under setSecurityContext flag

### DIFF
--- a/pkg/reconciler/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/eventlistener/eventlistener_test.go
@@ -917,10 +917,7 @@ func TestReconcile(t *testing.T) {
 
 	deploymentMissingSecurityContext := makeDeployment(func(d *appsv1.Deployment) {
 		d.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{}
-		d.Spec.Template.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{
-			RunAsUser:  ptr.Int64(65532),
-			RunAsGroup: ptr.Int64(65532),
-		}
+		d.Spec.Template.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{}
 	})
 
 	deploymentWithSecurityContext := makeDeployment(func(d *appsv1.Deployment) {

--- a/pkg/reconciler/eventlistener/resources/container.go
+++ b/pkg/reconciler/eventlistener/resources/container.go
@@ -66,13 +66,12 @@ func MakeContainer(el *v1beta1.EventListener, configAcc reconcilersource.ConfigA
 		if *c.SetReadOnlyRootFilesystem {
 			containerSecurityContext.ReadOnlyRootFilesystem = ptr.Bool(true)
 		}
-	}
-
-	if !cfg.Defaults.IsDefaultRunAsUserEmpty {
-		containerSecurityContext.RunAsUser = ptr.Int64(cfg.Defaults.DefaultRunAsUser)
-	}
-	if !cfg.Defaults.IsDefaultRunAsGroupEmpty {
-		containerSecurityContext.RunAsGroup = ptr.Int64(cfg.Defaults.DefaultRunAsGroup)
+		if !cfg.Defaults.IsDefaultRunAsUserEmpty {
+			containerSecurityContext.RunAsUser = ptr.Int64(cfg.Defaults.DefaultRunAsUser)
+		}
+		if !cfg.Defaults.IsDefaultRunAsGroupEmpty {
+			containerSecurityContext.RunAsGroup = ptr.Int64(cfg.Defaults.DefaultRunAsGroup)
+		}
 	}
 
 	container := corev1.Container{


### PR DESCRIPTION
Adding runAsUser and runAsGroup under setSecurityContext flag
fixes : https://github.com/tektoncd/triggers/pull/1747#discussion_r1668082120

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
