### PR TITLE
Set readOnlyRootFilesystem as true in Interceptor

### DIFF
--- a/config/interceptors/core-interceptors-deployment.yaml
+++ b/config/interceptors/core-interceptors-deployment.yaml
@@ -82,6 +82,7 @@ spec:
           timeoutSeconds: 5
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           # User 65532 is the distroless nonroot user ID
           runAsUser: 65532
           runAsGroup: 65532


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
As part of this PR https://github.com/tektoncd/triggers/pull/1735 handled only for Contorller and Webhook but not for interceptor 
This PR will address that

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Interceptor Deployment security context `readOnlyRootFilesystem`  are set to true to increase the security and to avoid being flagged by the security scanner.
```
