### PR TITLE
Rename `Decade` to `Century`

### DIFF
--- a/pkg/interceptors/server/server.go
+++ b/pkg/interceptors/server/server.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	Decade                  = 100 * 365 * 24 * time.Hour
+	Century                 = 100 * 365 * 24 * time.Hour
 	interceptorTLSSecretKey = "INTERCEPTOR_TLS_SECRET_NAME"
 	interceptorTLSSvcKey    = "INTERCEPTOR_TLS_SVC_NAME"
 )
@@ -159,7 +159,7 @@ func (is *Server) ExecuteInterceptor(r *http.Request) ([]byte, error) {
 }
 
 func CreateAndValidateCerts(ctx context.Context, coreV1Interface corev1.CoreV1Interface, logger *zap.SugaredLogger, service *Server, tc triggersv1alpha1.TriggersV1alpha1Interface) {
-	serverCert, caCert, err := createCerts(ctx, coreV1Interface, time.Now().Add(Decade), logger, false)
+	serverCert, caCert, err := createCerts(ctx, coreV1Interface, time.Now().Add(Century), logger, false)
 	if err != nil {
 		return
 	}
@@ -278,7 +278,7 @@ func (is *Server) checkCertValidity(ctx context.Context, serverCert, caCert []by
 			if _, err := cert.Verify(opts); err != nil {
 				logger.Errorf("failed to verify certificate: %v", err.Error())
 
-				serverCertNew, caCertNew, err := createCerts(ctx, coreV1Interface, time.Now().Add(Decade), logger, true)
+				serverCertNew, caCertNew, err := createCerts(ctx, coreV1Interface, time.Now().Add(Century), logger, true)
 				if err != nil {
 					logger.Errorf("failed to create certs %v", err)
 				}

--- a/pkg/interceptors/server/server_test.go
+++ b/pkg/interceptors/server/server_test.go
@@ -212,7 +212,7 @@ func Test_SecretNotExist(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	ctx, _ := test.SetupFakeContext(t)
 	clientSet := fakekubeclient.Get(ctx).CoreV1()
-	_, _, err := createCerts(ctx, clientSet, time.Now().Add(Decade), logger.Sugar(), false)
+	_, _, err := createCerts(ctx, clientSet, time.Now().Add(Century), logger.Sugar(), false)
 	if err != nil && !strings.Contains(err.Error(), "not found") {
 		t.Error(err)
 	}
@@ -241,7 +241,7 @@ func createSecret(t *testing.T, noAfter time.Time, certExpire bool) (v1.CoreV1In
 }
 
 func Test_CreateSecret(t *testing.T) {
-	_, sCert, caCert, err := createSecret(t, time.Now().Add(Decade), true)
+	_, sCert, caCert, err := createSecret(t, time.Now().Add(Century), true)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
# Changes

We had an [issue](https://github.com/rh-ecosystem-edge/recert/pull/167)  with long expiration so I noticed the name was wrong

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```