### PR TITLE
Point Gitlab Interceptors docs to more direct Webhook event types link

### DIFF
--- a/docs/interceptors.md
+++ b/docs/interceptors.md
@@ -322,7 +322,7 @@ To use a GitLab `Interceptor` as a GitLab webhook validator, do the following:
 
 To use a GitLab `Interceptor` as a filter for event data, specify the event types
 you want the `Interceptor` to accept in the `eventTypes` field. The `Interceptor`
-accepts data event types listed in [Events](https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#events).
+accepts data event types listed in [Events](https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html).
 
 Below is an example GitLab `Interceptor` reference:
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Revise docs to point to Gitlab Docs that contain the full list of Webhook event types, instead of a generic description of Webhook events.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
