### PR TITLE
Add ImagePullSecrets field when create Deployment by EventListener

### DIFF
--- a/pkg/apis/triggers/v1beta1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_validation.go
@@ -277,12 +277,12 @@ func podSpecMask(in *corev1.PodSpec) *corev1.PodSpec {
 	out.NodeSelector = in.NodeSelector
 	out.Affinity = in.Affinity
 	out.TopologySpreadConstraints = in.TopologySpreadConstraints
+	out.ImagePullSecrets = in.ImagePullSecrets
 
 	// Disallowed fields
 	// This list clarifies which all podspec fields are not allowed.
 	out.Volumes = nil
 	out.EnableServiceLinks = nil
-	out.ImagePullSecrets = nil
 	out.InitContainers = nil
 	out.RestartPolicy = ""
 	out.TerminationGracePeriodSeconds = nil

--- a/pkg/reconciler/eventlistener/resources/deployment.go
+++ b/pkg/reconciler/eventlistener/resources/deployment.go
@@ -80,6 +80,7 @@ func MakeDeployment(ctx context.Context, el *v1beta1.EventListener, configAcc re
 		nodeSelector, annotations map[string]string
 		affinity                  *corev1.Affinity
 		topologySpreadConstraints []corev1.TopologySpreadConstraint
+		imagePullSecrets          []corev1.LocalObjectReference
 	)
 
 	for _, v := range container.Env {
@@ -105,6 +106,9 @@ func MakeDeployment(ctx context.Context, el *v1beta1.EventListener, configAcc re
 		}
 		if len(el.Spec.Resources.KubernetesResource.Template.Spec.NodeSelector) != 0 {
 			nodeSelector = el.Spec.Resources.KubernetesResource.Template.Spec.NodeSelector
+		}
+		if len(el.Spec.Resources.KubernetesResource.Template.Spec.ImagePullSecrets) != 0 {
+			imagePullSecrets = el.Spec.Resources.KubernetesResource.Template.Spec.ImagePullSecrets
 		}
 		if el.Spec.Resources.KubernetesResource.Template.Spec.ServiceAccountName != "" {
 			serviceAccountName = el.Spec.Resources.KubernetesResource.Template.Spec.ServiceAccountName
@@ -137,6 +141,7 @@ func MakeDeployment(ctx context.Context, el *v1beta1.EventListener, configAcc re
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
+					ImagePullSecrets:          imagePullSecrets,
 					Tolerations:               tolerations,
 					NodeSelector:              nodeSelector,
 					ServiceAccountName:        serviceAccountName,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

fixed https://github.com/tektoncd/triggers/issues/1448

when submit EventListener like this with imagePullSecrets now:

```
apiVersion: triggers.tekton.dev/v1beta1
kind: EventListener
metadata:
  name: fission-ci-listener-test
spec:
  serviceAccountName: tekton-triggers-example-sa
  resources:
    kubernetesResource:
      spec:
        template:
          spec:
            imagePullSecrets:
              - name: docker-login
  triggers:
    - interceptors:
        - ref:
            name: cel
          params:
            - name: filter
              value: 'body.gitUrl != "" && body.gitRevision != "" && body.oauth != ""'
      bindings:
        - ref: fission-ci-binding-test
      template:
        ref: fission-ci-template-test
```

it report errors like:
```
$ k apply -f eventlister.yaml -n tekton-run
Error from server (BadRequest): error when creating "eventlister.yaml": admission webhook "validation.webhook.triggers.tekton.dev" denied the request: validation failed: must not set the field(s): spec.resources.kubernetesResource.spec.template.spec.imagePullSecrets
```

this PR resolve the issue that deployment with imagePullSecrets by EventListener.

# Release Notes
```
None
```