### PR TITLE
fix: Issue in eventlisteners e2e when kubernetes host has a path

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -31,6 +31,73 @@ which need `-tags=e2e` to be enabled.
 Environment variables used by end to end tests:
 
 - `KO_DOCKER_REPO` - Set this to an image registry your tests can push images to
+**kubeconfig**:
+
+- Use `--kubeconfig` flag pointing to a kubeconfig file, defaults to `~/.kube/config`.
+or
+- `KUBECONFIG` - Set this environment variable with the path to a kubeconfig file that will be used when [running](#running) tests
+
+Setting up the configuration file may differ between environments. Here is an example using a Kubernetes cluster behind a path `<host>/k/cluster`:
+
+```yaml
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: [REDACTED]
+    server: https://k8s.example.com/k/cluster
+  name: proxy
+contexts:
+- context:
+    cluster: proxy
+    namespace: default
+    user: kubeconfig-user
+  name: proxy
+current-context: proxy
+kind: Config
+preferences: {}
+users:
+- name: kubeconfig-user
+  user:
+    token: [REDACTED]
+```
+
+And another example using [minikube](https://minikube.sigs.k8s.io/):
+
+```yaml
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: "[REDACTED]"
+    extensions:
+    - extension:
+        provider: minikube.sigs.k8s.io
+        version: v1.35.0
+      name: cluster_info
+    server: https://127.0.0.1:32771
+  name: minikube
+contexts:
+- context:
+    cluster: minikube
+    extensions:
+    - extension:
+        provider: minikube.sigs.k8s.io
+        version: v1.35.0
+      name: context_info
+    namespace: default
+    user: minikube
+  name: minikube
+current-context: minikube
+kind: Config
+preferences: {}
+users:
+- name: minikube
+  user: {} # redacted
+```
+
+**Configuration issues**:
+
+- Having multiple `config` files in `KUBECONFIG` (i.e., `KUBECONFIG=$HOME/.kube/config:$HOME/.kube/config-2`) will cause test cases to fail. You can either assign `KUBECONFIG` to a single file or use the `--kubeconfig` flag when [running](#running) tests.
+
 
 ### Running
 
@@ -94,6 +161,8 @@ To run the YAML e2e tests, run the following command:
 ```bash
 ./test/e2e-tests-yaml.sh
 ```
+
+### Configuration
 
 ### Adding integration tests
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes



<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

fix: Issue in eventlisteners e2e when kubernetes host has a path

Previously having a prefix into the server url would generate an error during testing due to url parsing of host with embeded path:

`parse "https://k8s.example.com%2Fkubernetes%2Fpath/api/v1/namespaces/arrakis-t7ss8/pods/el-my-eventlistener-848756bd88-sg8fv/portforward": invalid URL escape "%2F" Previously having a prefix into the server url would generate an error during testing due to url parsing of host with embeded path`

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
