### PR TITLE
Add KUBERNETES_MIN_VERSION env to override k8s variable

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -103,6 +103,8 @@ spec:
               value: "9000"
             - name: CONFIG_LEADERELECTION_NAME
               value: config-leader-election-triggers-controllers
+            - name: KUBERNETES_MIN_VERSION
+              value: "v1.28.0"
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/config/interceptors/core-interceptors-deployment.yaml
+++ b/config/interceptors/core-interceptors-deployment.yaml
@@ -72,6 +72,8 @@ spec:
           value: tekton-triggers-core-interceptors
         - name: INTERCEPTOR_TLS_SECRET_NAME
           value: tekton-triggers-core-interceptors-certs
+        - name: KUBERNETES_MIN_VERSION
+          value: "v1.28.0"
         readinessProbe:
           httpGet:
             path: /ready

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -67,6 +67,8 @@ spec:
               value: tekton.dev/triggers
             - name: CONFIG_LEADERELECTION_NAME
               value: config-leader-election-triggers-webhook
+            - name: KUBERNETES_MIN_VERSION
+              value: "v1.28.0"
           ports:
             - name: metrics
               containerPort: 9000

--- a/pkg/reconciler/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/eventlistener/eventlistener_test.go
@@ -274,6 +274,9 @@ func makeDeployment(ops ...func(d *appsv1.Deployment)) *appsv1.Deployment {
 						}, {
 							Name:  "METRICS_PROMETHEUS_PORT",
 							Value: "9000",
+						}, {
+							Name:  "KUBERNETES_MIN_VERSION",
+							Value: "v1.28.0",
 						}},
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: ptr.Bool(false),
@@ -442,6 +445,9 @@ func makeWithPod(ops ...func(d *duckv1.WithPod)) *duckv1.WithPod {
 						}, {
 							Name:  "METRICS_PROMETHEUS_PORT",
 							Value: "9000",
+						}, {
+							Name:  "KUBERNETES_MIN_VERSION",
+							Value: "v1.28.0",
 						}},
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: ptr.Bool(false),
@@ -594,6 +600,7 @@ func withDeletionTimestamp(el *v1beta1.EventListener) {
 func TestReconcile(t *testing.T) {
 	t.Setenv("METRICS_PROMETHEUS_PORT", "9000")
 	t.Setenv("SYSTEM_NAMESPACE", "tekton-pipelines")
+	t.Setenv("KUBERNETES_MIN_VERSION", "v1.28.0")
 
 	customPort := 80
 
@@ -989,6 +996,9 @@ func TestReconcile(t *testing.T) {
 		}, {
 			Name:  "METRICS_PROMETHEUS_PORT",
 			Value: "9000",
+		}, {
+			Name:  "KUBERNETES_MIN_VERSION",
+			Value: "v1.28.0",
 		}}
 	})
 
@@ -1067,6 +1077,9 @@ func TestReconcile(t *testing.T) {
 		}, {
 			Name:  "METRICS_PROMETHEUS_PORT",
 			Value: "9000",
+		}, {
+			Name:  "KUBERNETES_MIN_VERSION",
+			Value: "v1.28.0",
 		}}
 	})
 

--- a/pkg/reconciler/eventlistener/resources/custom.go
+++ b/pkg/reconciler/eventlistener/resources/custom.go
@@ -65,6 +65,10 @@ func MakeCustomObject(ctx context.Context, el *v1beta1.EventListener, configAcc 
 			// env METRICS_PROMETHEUS_PORT set by controller
 			Name:  "METRICS_PROMETHEUS_PORT",
 			Value: os.Getenv("METRICS_PROMETHEUS_PORT"),
+		}, corev1.EnvVar{
+			// KUBERNETES_MIN_VERSION overrides the Min version of k8s required
+			Name:  "KUBERNETES_MIN_VERSION",
+			Value: os.Getenv("KUBERNETES_MIN_VERSION"),
 		})
 
 		c.ReadinessProbe = &corev1.Probe{

--- a/pkg/reconciler/eventlistener/resources/custom_test.go
+++ b/pkg/reconciler/eventlistener/resources/custom_test.go
@@ -32,6 +32,7 @@ import (
 func TestCustomObject(t *testing.T) {
 	t.Setenv("METRICS_PROMETHEUS_PORT", "9000")
 	t.Setenv("SYSTEM_NAMESPACE", "tekton-pipelines")
+	t.Setenv("KUBERNETES_MIN_VERSION", "v1.28.0")
 
 	config := *MakeConfig()
 	metadata := map[string]interface{}{
@@ -107,6 +108,10 @@ func TestCustomObject(t *testing.T) {
 		map[string]interface{}{
 			"name":  "METRICS_PROMETHEUS_PORT",
 			"value": "9000",
+		},
+		map[string]interface{}{
+			"name":  "KUBERNETES_MIN_VERSION",
+			"value": "v1.28.0",
 		},
 	}
 
@@ -468,6 +473,7 @@ func TestCustomObject(t *testing.T) {
 func TestCustomObjectError(t *testing.T) {
 	t.Setenv("METRICS_PROMETHEUS_PORT", "9000")
 	t.Setenv("SYSTEM_NAMESPACE", "tekton-pipelines")
+	t.Setenv("KUBERNETES_MIN_VERSION", "v1.28.0")
 
 	config := *MakeConfig()
 

--- a/pkg/reconciler/eventlistener/resources/deployment.go
+++ b/pkg/reconciler/eventlistener/resources/deployment.go
@@ -194,6 +194,10 @@ func addDeploymentBits(el *v1beta1.EventListener, c Config) (ContainerOption, er
 			// env METRICS_PROMETHEUS_PORT set by controller
 			Name:  "METRICS_PROMETHEUS_PORT",
 			Value: os.Getenv("METRICS_PROMETHEUS_PORT"),
+		}, corev1.EnvVar{
+			// KUBERNETES_MIN_VERSION overrides the min k8s version required to run EL.
+			Name:  "KUBERNETES_MIN_VERSION",
+			Value: os.Getenv("KUBERNETES_MIN_VERSION"),
 		})
 	}, nil
 }


### PR DESCRIPTION
This adds KUBERNETES_MIN_VERSION to deployment of controller, webhook and eventlistener.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add KUBERNETES_MIN_VERSION env to override k8s variable. Currently, it is set 1.28 by default.
```
