### PR TITLE
Allow users to set custom securityContext in EventListener spec

### DIFF
--- a/docs/eventlisteners.md
+++ b/docs/eventlisteners.md
@@ -272,6 +272,7 @@ Tolerations
 Containers
 Affinity
 TopologySpreadConstraints
+SecurityContext
 ```
 
 Legal values for the `Containers` sub-field for `kubernetesResource` and `CustomResource` are:
@@ -283,12 +284,14 @@ Env
 LivenessProbe
 ReadinessProbe
 StartupProbe
+SecurityContext
 ```
 
 **CustomResource:**
 ```
 Resources
 Env
+SecurityContext
 ```
 
 ### Specifying a `kubernetesResource` object
@@ -310,6 +313,8 @@ spec:
               key: "value"
           spec:
             serviceAccountName: tekton-triggers-github-sa
+            securityContext:
+              runAsNonRoot: true
             nodeSelector:
               app: test
             tolerations:
@@ -317,6 +322,9 @@ spec:
               value: value
               operator: Equal
               effect: NoSchedule
+            containers:
+            - securityContext:
+                readOnlyRootFilesystem: true
 ```
 
 #### Specifying `Service` configuration

--- a/examples/v1beta1/eventlisteners/eventlistener-securitycontext.yaml
+++ b/examples/v1beta1/eventlisteners/eventlistener-securitycontext.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: listener-tolerations
+spec:
+  serviceAccountName: tekton-triggers-example-sa
+  resources:
+    kubernetesResource:
+      spec:
+        template:
+          spec:
+            securityContext:
+              runAsNonRoot: true
+            containers:
+              - resources:
+                  requests:
+                    memory: "64Mi"
+                    cpu: "250m"
+                  limits:
+                    memory: "128Mi"
+                    cpu: "500m"
+                securityContext:
+                  readOnlyRootFilesystem: true
+  triggers:
+    - name: foo-trig
+      bindings:
+        - ref: pipeline-binding
+        - ref: message-binding
+      template:
+        ref: pipeline-template

--- a/pkg/apis/triggers/v1beta1/event_listener_validation.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_validation.go
@@ -232,6 +232,7 @@ func containerFieldMaskForKubernetes(in *corev1.Container) *corev1.Container {
 	out.LivenessProbe = in.LivenessProbe
 	out.ReadinessProbe = in.ReadinessProbe
 	out.StartupProbe = in.StartupProbe
+	out.SecurityContext = in.SecurityContext
 	return containerFieldMask(out)
 }
 
@@ -239,6 +240,7 @@ func containerFieldMaskForCustomResource(in *corev1.Container) *corev1.Container
 	out := new(corev1.Container)
 	out.Resources = in.Resources
 	out.Env = in.Env
+	out.SecurityContext = in.SecurityContext
 	return containerFieldMask(out)
 }
 
@@ -278,6 +280,7 @@ func podSpecMask(in *corev1.PodSpec) *corev1.PodSpec {
 	out.Affinity = in.Affinity
 	out.TopologySpreadConstraints = in.TopologySpreadConstraints
 	out.ImagePullSecrets = in.ImagePullSecrets
+	out.SecurityContext = in.SecurityContext
 
 	// Disallowed fields
 	// This list clarifies which all podspec fields are not allowed.
@@ -294,7 +297,6 @@ func podSpecMask(in *corev1.PodSpec) *corev1.PodSpec {
 	out.HostPID = false
 	out.HostIPC = false
 	out.ShareProcessNamespace = nil
-	out.SecurityContext = nil
 	out.Hostname = ""
 	out.Subdomain = ""
 	out.SchedulerName = ""

--- a/pkg/apis/triggers/v1beta1/event_listener_validation_test.go
+++ b/pkg/apis/triggers/v1beta1/event_listener_validation_test.go
@@ -587,6 +587,48 @@ func Test_EventListenerValidate(t *testing.T) {
 					},
 				},
 			},
+		}, {
+			name: "Valid EventListener with kubernetes resources for securityContext",
+			el: &triggersv1beta1.EventListener{
+				ObjectMeta: myObjectMeta,
+				Spec: triggersv1beta1.EventListenerSpec{
+					Triggers: []triggersv1beta1.EventListenerTrigger{{
+						Template: &triggersv1beta1.EventListenerTemplate{
+							Ref: ptr.String("tt"),
+						},
+					}},
+					Resources: triggersv1beta1.Resources{
+						KubernetesResource: &triggersv1beta1.KubernetesResource{
+							WithPodSpec: duckv1.WithPodSpec{
+								Template: duckv1.PodSpecable{
+									Spec: corev1.PodSpec{
+										ServiceAccountName: "k8sresource",
+										SecurityContext: &corev1.PodSecurityContext{
+											RunAsNonRoot: ptr.Bool(true),
+										},
+										Containers: []corev1.Container{{
+											Resources: corev1.ResourceRequirements{
+												Limits: corev1.ResourceList{
+													corev1.ResourceCPU:    resource.Quantity{Format: resource.DecimalSI},
+													corev1.ResourceMemory: resource.Quantity{Format: resource.BinarySI},
+												},
+												Requests: corev1.ResourceList{
+													corev1.ResourceCPU:    resource.Quantity{Format: resource.DecimalSI},
+													corev1.ResourceMemory: resource.Quantity{Format: resource.BinarySI},
+												},
+											},
+											SecurityContext: &corev1.SecurityContext{
+												RunAsNonRoot: ptr.Bool(true),
+												RunAsUser:    ptr.Int64(65532),
+											},
+										}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		}}
 
 	for _, tc := range tests {

--- a/pkg/reconciler/eventlistener/eventlistener_test.go
+++ b/pkg/reconciler/eventlistener/eventlistener_test.go
@@ -928,8 +928,8 @@ func TestReconcile(t *testing.T) {
 	})
 
 	deploymentMissingSecurityContext := makeDeployment(func(d *appsv1.Deployment) {
-		d.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{}
-		d.Spec.Template.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{}
+		d.Spec.Template.Spec.SecurityContext = nil
+		d.Spec.Template.Spec.Containers[0].SecurityContext = nil
 	})
 
 	deploymentWithSecurityContext := makeDeployment(func(d *appsv1.Deployment) {

--- a/pkg/reconciler/eventlistener/resources/container.go
+++ b/pkg/reconciler/eventlistener/resources/container.go
@@ -50,9 +50,16 @@ func MakeContainer(el *v1beta1.EventListener, configAcc reconcilersource.ConfigA
 
 	ev := configAcc.ToEnvVars()
 
-	containerSecurityContext := corev1.SecurityContext{}
-	if *c.SetSecurityContext {
-		containerSecurityContext = corev1.SecurityContext{
+	var containerSecurityContext *corev1.SecurityContext
+	if el.Spec.Resources.KubernetesResource != nil {
+		if len(el.Spec.Resources.KubernetesResource.Template.Spec.Containers) != 0 {
+			if *c.SetSecurityContext {
+				containerSecurityContext = el.Spec.Resources.KubernetesResource.Template.Spec.Containers[0].SecurityContext
+			}
+		}
+	}
+	if *c.SetSecurityContext && containerSecurityContext == nil {
+		containerSecurityContext = &corev1.SecurityContext{
 			AllowPrivilegeEscalation: ptr.Bool(false),
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},
@@ -111,7 +118,7 @@ func MakeContainer(el *v1beta1.EventListener, configAcc reconcilersource.ConfigA
 			Name:  "K_SINK_TIMEOUT",
 			Value: strconv.FormatInt(*c.TimeOutHandler, 10),
 		}}...),
-		SecurityContext: &containerSecurityContext,
+		SecurityContext: containerSecurityContext,
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
1. Users can now define their own securityContext under the EventListener YAML.
ex: 
```
spec:
  serviceAccountName: tekton-triggers-example-sa
  resources:
    kubernetesResource:
      spec:
        template:
          spec:
            securityContext:
              runAsNonRoot: true
            containers:
              - resources:
                  requests:
                    memory: "64Mi"
                    cpu: "250m"
                  limits:
                    memory: "128Mi"
                    cpu: "500m"
                securityContext:
                  readOnlyRootFilesystem: true
```
2. When `el-security-context` is true
   - If the user sets a custom securityContext, it is give priority and used same.
   - If not, a default securityContext is applied.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add support for setting securityContext as part of EventListener spec
```
