### PR TITLE
fix: remove duplicated 'the' in triggers-api docs

### DIFF
--- a/docs/triggers-api.md
+++ b/docs/triggers-api.md
@@ -1109,7 +1109,7 @@ knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
 (Members of <code>AddressStatus</code> are embedded into this type.)
 </p>
 <p>EventListener is Addressable. It currently exposes the service DNS
-address of the the EventListener sink</p>
+address of the EventListener sink</p>
 </td>
 </tr>
 <tr>
@@ -3513,7 +3513,7 @@ knative.dev/pkg/apis/duck/v1beta1.AddressStatus
 (Members of <code>AddressStatus</code> are embedded into this type.)
 </p>
 <p>EventListener is Addressable. It currently exposes the service DNS
-address of the the EventListener sink</p>
+address of the EventListener sink</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Removed duplicated 'the' in triggers-api docs

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Removed duplicated 'the' in triggers-api docs
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
