### PR TITLE
fix: test instability in UpdateCACertToClusterInterceptorCRD unit test

### DIFF
--- a/cmd/interceptors/main.go
+++ b/cmd/interceptors/main.go
@@ -83,7 +83,7 @@ func main() {
 	server.CreateAndValidateCerts(ctx, kubeclient.Get(ctx).CoreV1(), logger, service, tc.TriggersV1alpha1())
 
 	// watch for caCert existence in clusterInterceptor, update with new caCert if its missing in clusterInterceptor
-	server.UpdateCACertToClusterInterceptorCRD(ctx, service, tc.TriggersV1alpha1(), logger, time.Minute)
+	_ = server.UpdateCACertToClusterInterceptorCRD(ctx, service, tc.TriggersV1alpha1(), logger, time.Minute)
 
 	if err := startServer(ctx, ctx.Done(), mux, logger); err != nil {
 		logger.Fatal(err)

--- a/pkg/interceptors/server/server_test.go
+++ b/pkg/interceptors/server/server_test.go
@@ -416,7 +416,8 @@ func Test_UpdateCACertToClusterInterceptorCRD(t *testing.T) {
 		t.Error(err)
 	}
 
-	UpdateCACertToClusterInterceptorCRD(ctx, server, faketriggersclient.Get(ctx).TriggersV1alpha1(), logger.Sugar(), time.Second)
+	stopFunc := UpdateCACertToClusterInterceptorCRD(ctx, server, faketriggersclient.Get(ctx).TriggersV1alpha1(), logger.Sugar(), time.Second)
+	defer stopFunc()
 
 	time.Sleep(10 * time.Second)
 	ciNew, err := faketriggersclient.Get(ctx).TriggersV1alpha1().ClusterInterceptors().Get(ctx, "firstci1", metav1.GetOptions{})


### PR DESCRIPTION
- Add proper cleanup mechanism for the ticker goroutine in UpdateCACertToClusterInterceptorCRD
- Return a stop function to allow graceful shutdown of the background goroutine
- Update caller to use the returned stop function and handle the return value
- Add defer statement in test to ensure proper cleanup

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fix test instability in UpdateCACertToClusterInterceptorCRD unit test

This PR addresses test instability issues in the `Test_UpdateCACertToClusterInterceptorCRD` unit test by improving resource cleanup in the tested function.

 **Problem:**
 - The unit test was occasionally failing due to improper resource cleanup
 - Background goroutines and tickers from the `UpdateCACertToClusterInterceptorCRD` function weren't being properly stopped after test completion
 - This caused test interference and flaky test results

 **Solution:**
 - Modified `UpdateCACertToClusterInterceptorCRD` to return a cleanup function
 - Added proper goroutine termination mechanism using a done channel and select statement
 - Ensured ticker is properly stopped with `defer ticker.Stop()`
 - Updated the test to call the cleanup function, ensuring proper test isolation


<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
/kind flake