### PR TITLE
feat: auto fill http request content length for binding and cel eval tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ cmd/*/kodata/source.tar.gz
 # Temporary GOPATH used during code gen if user's Tekton checkout is
 # not already in GOPATH.
 .gopath
+/binding-eval

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ errcheck: | $(ERRCHECK) ; $(info $(M) running errcheck…) ## Run errcheck
 
 GOLANGCILINT = $(BIN)/golangci-lint
 $(BIN)/golangci-lint: ; $(info $(M) getting golangci-lint $(GOLANGCI_VERSION))
-        cd tools; GOBIN=$(BIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_VERSION)
+	cd tools; GOBIN=$(BIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_VERSION)
 
 .PHONY: golangci-lint
 golangci-lint: | $(GOLANGCILINT) ; $(info $(M) running golangci-lint…) @ ## Run golangci-lint

--- a/cmd/binding-eval/cmd/root_test.go
+++ b/cmd/binding-eval/cmd/root_test.go
@@ -18,15 +18,55 @@ package cmd
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestEvalBinding(t *testing.T) {
+func TestEvalBindingWithCorrectContentLength(t *testing.T) {
+	// Test with HTTP file that has correct content length header - expect to pass
 	out := new(bytes.Buffer)
 	if err := evalBinding(out, "../testdata/triggerbinding.yaml", "../testdata/http.txt"); err != nil {
-		t.Fatalf("evalBinding: %v", err)
+		t.Fatalf("evalBinding with correct Content-Length should pass: %v", err)
+	}
+
+	want := `[
+  {
+    "name": "bar",
+    "value": "tacocat"
+  },
+  {
+    "name": "foo",
+    "value": "body"
+  }
+]
+`
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Errorf("-want +got: %s", diff)
+	}
+}
+
+func TestEvalBindingWithWrongContentLength(t *testing.T) {
+	// Test with HTTP file that has wrong content length header - expect to fail
+	out := new(bytes.Buffer)
+	err := evalBinding(out, "../testdata/triggerbinding.yaml", "../testdata/http_wrong_content_length.txt")
+	if err == nil {
+		t.Fatal("evalBinding with wrong Content-Length should fail, but it passed")
+	}
+
+	// Verify that the error is related to parsing the body
+	expectedErrorSubstring := "unexpected end of JSON input"
+	if !strings.Contains(err.Error(), expectedErrorSubstring) {
+		t.Errorf("Expected error to contain %q, got: %v", expectedErrorSubstring, err)
+	}
+}
+
+func TestEvalBindingWithNoContentLength(t *testing.T) {
+	// Test with HTTP file that has no content length header - expect to pass
+	out := new(bytes.Buffer)
+	if err := evalBinding(out, "../testdata/triggerbinding.yaml", "../testdata/http_no_content_length.txt"); err != nil {
+		t.Fatalf("evalBinding with no Content-Length should pass: %v", err)
 	}
 
 	want := `[

--- a/cmd/binding-eval/testdata/http_no_content_length.txt
+++ b/cmd/binding-eval/testdata/http_no_content_length.txt
@@ -1,0 +1,5 @@
+POST /foo HTTP/1.1
+Content-Type: application/json
+X-Header: tacocat
+
+{"test": "body"}

--- a/cmd/binding-eval/testdata/http_wrong_content_length.txt
+++ b/cmd/binding-eval/testdata/http_wrong_content_length.txt
@@ -1,0 +1,6 @@
+POST /foo HTTP/1.1
+Content-Length: 10
+Content-Type: application/json
+X-Header: tacocat
+
+{"test": "body"}

--- a/cmd/cel-eval/cmd/root.go
+++ b/cmd/cel-eval/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/decls"
@@ -138,7 +139,36 @@ func readHTTP(path string) (*http.Request, []byte, error) {
 	}
 	defer f.Close()
 
-	req, err := http.ReadRequest(bufio.NewReader(f))
+	// Read the entire file content first
+	fileContent, err := io.ReadAll(f)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error reading file: %w", err)
+	}
+
+	// Split into headers and body parts
+	parts := strings.SplitN(string(fileContent), "\n\n", 2)
+	if len(parts) != 2 {
+		parts = strings.SplitN(string(fileContent), "\r\n\r\n", 2)
+	}
+
+	var headerPart, bodyPart string
+	if len(parts) == 2 {
+		headerPart = parts[0]
+		bodyPart = parts[1]
+	} else {
+		headerPart = string(fileContent)
+		bodyPart = ""
+	}
+
+	// Auto compute and fill the content length field if it is not present
+	if len(bodyPart) > 0 && !strings.Contains(headerPart, "Content-Length:") {
+		headerPart += fmt.Sprintf("\nContent-Length: %d", len(bodyPart))
+	}
+
+	// Reconstruct the HTTP request with the Content-Length header
+	reconstructedContent := headerPart + "\n\n" + bodyPart
+
+	req, err := http.ReadRequest(bufio.NewReader(strings.NewReader(reconstructedContent)))
 	if err != nil {
 		return nil, nil, fmt.Errorf("error reading request: %w", err)
 	}
@@ -147,6 +177,7 @@ func readHTTP(path string) (*http.Request, []byte, error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("error reading HTTP body: %w", err)
 	}
+
 	return req, body, nil
 }
 

--- a/cmd/cel-eval/cmd/root_test.go
+++ b/cmd/cel-eval/cmd/root_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -12,6 +13,34 @@ func TestEvalCEL(t *testing.T) {
 	out := new(bytes.Buffer)
 	if err := evalCEL(context.TODO(), out, "../testdata/expression.txt", "../testdata/http.txt"); err != nil {
 		t.Fatalf("evalCEL: %v", err)
+	}
+
+	want := "true"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Errorf("-want +got: %s", diff)
+	}
+}
+
+func TestEvalBindingWithWrongContentLength(t *testing.T) {
+	// Test with HTTP file that has wrong content length header - expect to fail
+	out := new(bytes.Buffer)
+	err := evalCEL(context.TODO(), out, "../testdata/expression.txt", "../testdata/http_wrong_content_length.txt")
+	if err == nil {
+		t.Fatal("evalBinding with wrong Content-Length should fail, but it passed")
+	}
+
+	// Verify that the error is related to parsing the body
+	expectedErrorSubstring := "unexpected end of JSON input"
+	if !strings.Contains(err.Error(), expectedErrorSubstring) {
+		t.Errorf("Expected error to contain %q, got: %v", expectedErrorSubstring, err)
+	}
+}
+
+func TestEvalBindingWithNoContentLength(t *testing.T) {
+	// Test with HTTP file that has no content length header - expect to pass
+	out := new(bytes.Buffer)
+	if err := evalCEL(context.TODO(), out, "../testdata/expression.txt", "../testdata/http_no_content_length.txt"); err != nil {
+		t.Fatalf("evalBinding with no Content-Length should pass: %v", err)
 	}
 
 	want := "true"

--- a/cmd/cel-eval/testdata/http_no_content_length.txt
+++ b/cmd/cel-eval/testdata/http_no_content_length.txt
@@ -1,0 +1,5 @@
+POST /foo HTTP/1.1
+Content-Type: application/json
+X-Header: tacocat
+
+{"test": {"nested": "value"}}

--- a/cmd/cel-eval/testdata/http_wrong_content_length.txt
+++ b/cmd/cel-eval/testdata/http_wrong_content_length.txt
@@ -1,0 +1,6 @@
+POST /foo HTTP/1.1
+Content-Length: 26
+Content-Type: application/json
+X-Header: tacocat
+
+{"test": {"nested": "value"}}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
