### PR TITLE
Add tkn triggers bootstrap command for automated setup

### DIFF
--- a/cmd/tkn-triggers/cmd/bootstrap.go
+++ b/cmd/tkn-triggers/cmd/bootstrap.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/tektoncd/triggers/pkg/bootstrap"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var (
+	// Bootstrap flags
+	kubeconfig string
+
+	// GitHub integration flags
+	githubRepo    string
+	githubToken   string
+	publicDomain  string
+	webhookSecret string
+)
+
+// bootstrapCmd represents the bootstrap command
+var bootstrapCmd = &cobra.Command{
+	Use:   "bootstrap",
+	Short: "Bootstrap Tekton Triggers with all necessary resources",
+	Long: `Bootstrap sets up Tekton Triggers with all necessary resources following
+the getting-started guide. This includes:
+
+- Installing Tekton Pipelines (if not present)
+- Installing Tekton Triggers (if not present)  
+- Creating the getting-started namespace
+- Setting up RBAC (ServiceAccounts, Roles, RoleBindings)
+- Creating EventListener, TriggerTemplate, TriggerBinding
+- Creating example Pipeline and Tasks
+
+Examples:
+  # Basic bootstrap (auto-detects kubeconfig, creates all resources)
+  tkn triggers bootstrap`,
+	RunE: bootstrapRun,
+}
+
+func init() {
+	bootstrapCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig file")
+	bootstrapCmd.Flags().StringVar(&githubRepo, "github-repo", "", "GitHub repository (owner/repo)")
+	bootstrapCmd.Flags().StringVar(&githubToken, "github-token", "", "GitHub personal access token")
+	bootstrapCmd.Flags().StringVar(&publicDomain, "domain", "", "Public domain for webhooks (e.g. myapp.com)")
+	bootstrapCmd.Flags().StringVar(&webhookSecret, "webhook-secret", "", "Webhook secret (auto-generated if empty)")
+}
+
+func bootstrapRun(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	// Create kubernetes config
+	var config *rest.Config
+	var err error
+	if kubeconfig != "" {
+		// Use kubeconfig
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+	} else {
+		// try ~/.kube/config first, then in-cluster
+		kubeconfigPath := os.Getenv("HOME") + "/.kube/config"
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+		if err != nil {
+			config, err = rest.InClusterConfig()
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("failed to build kubeconfig: %w", err)
+	}
+
+	// Create bootstrap configuration for getting-started resources
+	log.Println("== Setting up Tekton Dependencies...")
+	cfg := &bootstrap.Config{
+		Namespace:      "getting-started",
+		Provider:       "github",
+		InstallDeps:    true,
+		CreateExamples: true,
+		KubeConfig:     config,
+
+		GitHubRepo:    "",
+		GitHubToken:   "",
+		PublicDomain:  "",
+		WebhookSecret: "",
+	}
+
+	// Create bootstrapper
+	bootstrapper, err := bootstrap.New(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create bootstrapper: %w", err)
+	}
+
+	// Run bootstrap (create namespace, RBAC, EventListener, Pipeline)
+	if err := bootstrapper.Run(ctx); err != nil {
+		return fmt.Errorf("bootstrap failed: %w", err)
+	}
+
+	log.Println("Tekton Dependencies are ready!")
+
+	// run GitHub integration setup
+	log.Println("\n== Configuring GitHub Integration ==")
+	if err := runInteractiveSetup(); err != nil {
+		log.Printf("⚠️  GitHub setup failed: %v\n", err)
+		return nil
+	}
+
+	// GitHub webhook creation if have the required info
+	if githubRepo != "" && githubToken != "" && publicDomain != "" {
+		log.Println("== Creating GitHub webhook ==")
+		githubConfig := &bootstrap.Config{
+			Namespace:     "getting-started",
+			GitHubRepo:    githubRepo,
+			GitHubToken:   githubToken,
+			PublicDomain:  publicDomain,
+			WebhookSecret: webhookSecret,
+			KubeConfig:    config,
+		}
+
+		// Create GitHub manager and setup webhook
+		githubManager := bootstrap.NewGitHubManager(githubConfig)
+		if err := githubManager.SetupWebhook(ctx); err != nil {
+			return fmt.Errorf("GitHub webhook setup failed: %w", err)
+		}
+		log.Println("GitHub webhook created!")
+	} else {
+		log.Println("⚠️  Missing required information")
+	}
+	return nil
+}

--- a/cmd/tkn-triggers/cmd/interactive.go
+++ b/cmd/tkn-triggers/cmd/interactive.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bufio"
+	"log"
+	"os"
+	"strings"
+)
+
+func runInteractiveSetup() error {
+	reader := bufio.NewReader(os.Stdin)
+	if githubRepo != "" && publicDomain != "" && githubToken != "" {
+		log.Println("GitHub configuration already there")
+		return nil
+	}
+	// Get GitHub repository
+	if githubRepo == "" {
+		log.Print("\nEnter your GitHub repository (owner/repo): ")
+		repo, _ := reader.ReadString('\n')
+		githubRepo = strings.TrimSpace(repo)
+		if githubRepo == "" {
+			log.Println("Skipping GitHub integration.")
+			return nil
+		}
+	}
+
+	// Get public domain
+	if publicDomain == "" {
+		log.Print("Enter your public route URL (e.g. myapp.example.com): ")
+		domain, _ := reader.ReadString('\n')
+		publicDomain = strings.TrimSpace(domain)
+		if publicDomain == "" {
+			log.Println("Skipping GitHub integration - public domain required.")
+			return nil
+		}
+	}
+
+	// Get GitHub token
+	if githubToken == "" {
+		log.Print("Enter your GitHub personal access token: ")
+		token, _ := reader.ReadString('\n')
+		githubToken = strings.TrimSpace(token)
+		if githubToken == "" {
+			log.Println("Skipping GitHub integration - token required for webhook creation.")
+			return nil
+		}
+	}
+	return nil
+}

--- a/cmd/tkn-triggers/cmd/root.go
+++ b/cmd/tkn-triggers/cmd/root.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "tkn-triggers",
+	Short: "Tekton Triggers CLI plugin",
+	Long: `tkn-triggers is a CLI plugin for Tekton Triggers that provides 
+command for bootstrapping Tekton Triggers resources.`,
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	rootCmd.AddCommand(bootstrapCmd)
+}

--- a/cmd/tkn-triggers/main.go
+++ b/cmd/tkn-triggers/main.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	"github.com/tektoncd/triggers/cmd/tkn-triggers/cmd"
+)
+
+func main() {
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -3,6 +3,46 @@
 The following tutorial walks you through building and deploying a Docker image using 
 Tekton Triggers to detect a GitHub webhook request and execute a `Pipeline`.
 
+## Quick Start with CLI (Automated)
+
+You can now automate this entire getting started guide with a single CLI command:
+
+```bash
+tkn triggers bootstrap
+```
+
+This command will:
+- Check and install Tekton Pipelines (if not present)
+- Check and install Tekton Triggers (if not present)
+- Create the `getting-started` namespace
+- Set up RBAC (ServiceAccounts, Roles, RoleBindings)
+- Create EventListener, TriggerTemplate, TriggerBinding
+- Create example Pipeline and Tasks
+- Configure GitHub webhook integration
+
+### Supported Providers
+
+Currently, only **GitHub** webhooks are supported. Support for GitLab and Bitbucket may be added in the future.
+
+### Usage
+
+```bash
+tkn triggers bootstrap
+
+# Specify custom kubeconfig
+tkn triggers bootstrap --kubeconfig /path/to/kubeconfig
+
+# Provide GitHub configuration via flags
+tkn triggers bootstrap \
+  --github-repo <owner/repo> \
+  --github-token <ghp_xxxxx> \
+  --domain <myapp.example.com>
+```
+
+The command will prompt you for GitHub repository, personal access token, and public domain if not provided via flags.
+
+**Note:** If you prefer to set up everything manually, continue with the step-by-step tutorial below.
+
 ## Overview
 
 In this tutorial, you will:

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+
+	triggersclientset "github.com/tektoncd/triggers/pkg/client/clientset/versioned"
+	"k8s.io/client-go/kubernetes"
+)
+
+type Bootstrapper struct {
+	config           *Config
+	kubeClient       kubernetes.Interface
+	triggersClient   triggersclientset.Interface
+	installer        *Installer
+	rbacManager      *RBACManager
+	templatesManager *TemplatesManager
+	githubManager    *GitHubManager
+}
+
+// New creates a new bootstrapper
+func New(config *Config) (*Bootstrapper, error) {
+	var (
+		kubeClient     kubernetes.Interface
+		triggersClient triggersclientset.Interface
+		err            error
+	)
+	kubeClient, err = kubernetes.NewForConfig(config.KubeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	triggersClient, err = triggersclientset.NewForConfig(config.KubeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create triggers client: %w", err)
+	}
+
+	// Create component managers
+	installer := NewInstaller(kubeClient, config)
+	rbacManager := NewRBACManager(kubeClient, config)
+	templatesManager := NewTemplatesManager(triggersClient, config)
+	githubManager := NewGitHubManager(config)
+
+	return &Bootstrapper{
+		config:           config,
+		kubeClient:       kubeClient,
+		triggersClient:   triggersClient,
+		installer:        installer,
+		rbacManager:      rbacManager,
+		templatesManager: templatesManager,
+		githubManager:    githubManager,
+	}, nil
+}
+
+// Run executes the bootstrap process
+func (b *Bootstrapper) Run(ctx context.Context) error {
+	// Check and install Tekton Pipelines
+	if err := b.installer.InstallTektonPipelines(ctx); err != nil {
+		return fmt.Errorf("failed to ensure pipelines: %w", err)
+	}
+
+	// Install Tekton Triggers
+	if err := b.installer.InstallTriggers(ctx); err != nil {
+		return fmt.Errorf("failed to install triggers: %w", err)
+	}
+
+	// Create/verify namespace
+	if err := b.rbacManager.CreateNamespace(ctx); err != nil {
+		return fmt.Errorf("failed to create namespace: %w", err)
+	}
+
+	// Set up RBAC
+	if err := b.rbacManager.SetupRBAC(ctx); err != nil {
+		return fmt.Errorf("failed to setup RBAC: %w", err)
+	}
+
+	// Create Trigger resources (EventListener, TriggerTemplate, TriggerBinding)
+	if err := b.templatesManager.CreateTriggerResources(ctx); err != nil {
+		return fmt.Errorf("failed to create trigger resources: %w", err)
+	}
+
+	// Create examples (Pipeline)
+	if err := b.templatesManager.CreateExamples(ctx); err != nil {
+		return fmt.Errorf("failed to create examples: %w", err)
+	}
+
+	// Check existing webhooks
+	if b.config.GitHubToken != "" {
+		if err := b.githubManager.SetupWebhook(ctx); err != nil {
+			return fmt.Errorf("failed to setup webhook: %w", err)
+		}
+	}
+	if err := b.rbacManager.CreateWebhookSecret(ctx, b.githubManager.GetWebhookSecret()); err != nil {
+		return fmt.Errorf("failed to create webhook secret: %w", err)
+	}
+	return nil
+}

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"k8s.io/client-go/rest"
+)
+
+type Config struct {
+	// Namespace is the target namespace for Triggers resources
+	Namespace string
+
+	// Provider is the Git provider (currently only "github" is supported)
+	Provider string
+
+	// InstallDeps tells whether to install Tekton Pipelines
+	InstallDeps bool
+
+	// CreateExamples tells whether to create example resources
+	CreateExamples bool
+
+	// Kubernetes client configuration
+	KubeConfig *rest.Config
+
+	// configuration
+	GitHubRepo    string // GitHub repo (owner/repo)
+	GitHubToken   string // GitHub PAT
+	PublicDomain  string // Public domain for webhooks
+	WebhookSecret string // Webhook secret
+}
+
+type TemplateData struct {
+	Namespace      string
+	Name           string
+	ServiceAccount string
+	Provider       string
+}

--- a/pkg/bootstrap/config_test.go
+++ b/pkg/bootstrap/config_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"testing"
+
+	"k8s.io/client-go/rest"
+)
+
+func TestConfig(t *testing.T) {
+	config := &Config{
+		Namespace:      "test-namespace",
+		Provider:       "github",
+		InstallDeps:    true,
+		CreateExamples: true,
+		KubeConfig:     &rest.Config{},
+		GitHubRepo:     "owner/repo",
+		GitHubToken:    "test-token",
+		PublicDomain:   "example.com",
+		WebhookSecret:  "secret",
+	}
+
+	if config.Namespace != "test-namespace" {
+		t.Errorf("Config.Namespace = %v, want test-namespace", config.Namespace)
+	}
+	if config.Provider != "github" {
+		t.Errorf("Config.Provider = %v, want github", config.Provider)
+	}
+	if !config.InstallDeps {
+		t.Error("Config.InstallDeps should be true")
+	}
+	if !config.CreateExamples {
+		t.Error("Config.CreateExamples should be true")
+	}
+	if config.GitHubRepo != "owner/repo" {
+		t.Errorf("Config.GitHubRepo = %v, want owner/repo", config.GitHubRepo)
+	}
+	if config.GitHubToken != "test-token" {
+		t.Errorf("Config.GitHubToken = %v, want test-token", config.GitHubToken)
+	}
+	if config.PublicDomain != "example.com" {
+		t.Errorf("Config.PublicDomain = %v, want example.com", config.PublicDomain)
+	}
+	if config.WebhookSecret != "secret" {
+		t.Errorf("Config.WebhookSecret = %v, want secret", config.WebhookSecret)
+	}
+}
+
+func TestTemplateData(t *testing.T) {
+	data := &TemplateData{
+		Namespace:      "test-namespace",
+		Name:           "test-name",
+		ServiceAccount: "test-sa",
+		Provider:       "github",
+	}
+
+	if data.Namespace != "test-namespace" {
+		t.Errorf("TemplateData.Namespace = %v, want test-namespace", data.Namespace)
+	}
+	if data.Name != "test-name" {
+		t.Errorf("TemplateData.Name = %v, want test-name", data.Name)
+	}
+	if data.ServiceAccount != "test-sa" {
+		t.Errorf("TemplateData.ServiceAccount = %v, want test-sa", data.ServiceAccount)
+	}
+	if data.Provider != "github" {
+		t.Errorf("TemplateData.Provider = %v, want github", data.Provider)
+	}
+}

--- a/pkg/bootstrap/file_helper.go
+++ b/pkg/bootstrap/file_helper.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+const (
+	githubBaseURL = "https://raw.githubusercontent.com/tektoncd/triggers/main"
+)
+
+func applyFileFromGitHub(filePath string) error {
+	ctx := context.Background()
+	// Download from GitHub
+	githubURL := fmt.Sprintf("%s/%s", githubBaseURL, filePath)
+
+	// Create temporary file
+	tmpFile, err := os.CreateTemp("", filepath.Base(filePath)+"-*.yaml")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name()) // Always clean up
+
+	// Download content
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, githubURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to download %s: %w", githubURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to download %s: HTTP %d", githubURL, resp.StatusCode)
+	}
+
+	// Write to temp file
+	if _, err = io.Copy(tmpFile, resp.Body); err != nil {
+		return fmt.Errorf("failed to write downloaded content: %w", err)
+	}
+	tmpFile.Close()
+
+	// Apply with kubectl
+	// #nosec G204 -- kubectl is a known binary, tmpFile.Name() is a controlled temp file path
+	cmd := exec.Command("kubectl", "apply", "-f", tmpFile.Name(), "-n", "getting-started")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("kubectl apply failed for %s: %w\nOutput: %s", filePath, err, string(output))
+	}
+
+	return nil
+}

--- a/pkg/bootstrap/github.go
+++ b/pkg/bootstrap/github.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+type GitHubManager struct {
+	config *Config
+	client *http.Client
+}
+
+func NewGitHubManager(config *Config) *GitHubManager {
+	return &GitHubManager{
+		config: config,
+		client: &http.Client{},
+	}
+}
+
+// WebhookPayload represents the GitHub webhook payload
+type WebhookPayload struct {
+	Name   string        `json:"name"`
+	Config WebhookConfig `json:"config"`
+	Events []string      `json:"events"`
+	Active bool          `json:"active"`
+}
+
+// WebhookConfig represents webhook configuration
+type WebhookConfig struct {
+	URL         string `json:"url"`
+	ContentType string `json:"content_type"`
+	Secret      string `json:"secret,omitempty"`
+	InsecureSSL string `json:"insecure_ssl"`
+}
+
+// SetupWebhook creates a GitHub webhook for the repository
+func (g *GitHubManager) SetupWebhook(ctx context.Context) error {
+	// Generate webhook secret
+	secret := g.config.WebhookSecret
+	if secret == "" {
+		var err error
+		secret, err = generateWebhookSecret()
+		if err != nil {
+			return fmt.Errorf("failed to generate webhook secret: %w", err)
+		}
+		g.config.WebhookSecret = secret
+	}
+
+	// Create webhook
+	webhookURL := fmt.Sprintf("https://%s/hooks", g.config.PublicDomain)
+
+	payload := WebhookPayload{
+		Name: "web",
+		Config: WebhookConfig{
+			URL:         webhookURL,
+			ContentType: "json",
+			Secret:      secret,
+			InsecureSSL: "0", // Always use SSL in production
+		},
+		Events: []string{"push", "pull_request"},
+		Active: true,
+	}
+
+	if err := g.createWebhook(ctx, payload); err != nil {
+		return fmt.Errorf("failed to create webhook: %w", err)
+	}
+
+	return nil
+}
+
+// createWebhook makes the API call to create the webhook
+func (g *GitHubManager) createWebhook(ctx context.Context, payload WebhookPayload) error {
+	jsonPayload, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("https://api.github.com/repos/%s/hooks", g.config.GitHubRepo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonPayload))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Authorization", "token "+g.config.GitHubToken)
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode == http.StatusUnprocessableEntity && strings.Contains(string(body), "Hook already exists") {
+			return errors.New("webhook already exists")
+		}
+		return fmt.Errorf("GitHub API error: %s - %s", resp.Status, string(body))
+	}
+
+	return nil
+}
+
+// generateWebhookSecret generates a secure random webhook secret
+func generateWebhookSecret() (string, error) {
+	bytes := make([]byte, 32)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(bytes), nil
+}
+
+// GetWebhookSecret returns the webhook secret for storing in Kubernetes
+func (g *GitHubManager) GetWebhookSecret() string {
+	return g.config.WebhookSecret
+}

--- a/pkg/bootstrap/github_test.go
+++ b/pkg/bootstrap/github_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"testing"
+)
+
+func TestNewGitHubManager(t *testing.T) {
+	config := &Config{
+		GitHubRepo:    "owner/repo",
+		GitHubToken:   "test-token",
+		PublicDomain:  "example.com",
+		WebhookSecret: "secret",
+	}
+
+	manager := NewGitHubManager(config)
+
+	if manager == nil {
+		t.Fatal("NewGitHubManager() returned nil")
+	}
+	if manager.config == nil {
+		t.Error("NewGitHubManager() config is nil")
+	}
+	if manager.client == nil {
+		t.Error("NewGitHubManager() client is nil")
+	}
+}
+
+func TestGetWebhookSecret(t *testing.T) {
+	tests := []struct {
+		name          string
+		webhookSecret string
+	}{
+		{
+			name:          "with secret",
+			webhookSecret: "test-secret",
+		},
+		{
+			name:          "empty secret",
+			webhookSecret: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &Config{
+				WebhookSecret: tt.webhookSecret,
+			}
+			manager := NewGitHubManager(config)
+
+			got := manager.GetWebhookSecret()
+			if got != tt.webhookSecret {
+				t.Errorf("GetWebhookSecret() = %v, want %v", got, tt.webhookSecret)
+			}
+		})
+	}
+}
+
+func TestWebhookPayload(t *testing.T) {
+	payload := WebhookPayload{
+		Name:   "web",
+		Active: true,
+		Events: []string{"push", "pull_request"},
+	}
+	payload.Config.URL = "https://example.com/hooks"
+	payload.Config.ContentType = "json"
+	payload.Config.Secret = "secret"
+	payload.Config.InsecureSSL = "0"
+
+	if payload.Name != "web" {
+		t.Errorf("WebhookPayload.Name = %v, want web", payload.Name)
+	}
+	if !payload.Active {
+		t.Error("WebhookPayload.Active should be true")
+	}
+	if len(payload.Events) != 2 {
+		t.Errorf("WebhookPayload.Events length = %v, want 2", len(payload.Events))
+	}
+	if payload.Config.URL != "https://example.com/hooks" {
+		t.Errorf("WebhookPayload.Config.URL = %v, want https://example.com/hooks", payload.Config.URL)
+	}
+	if payload.Config.ContentType != "json" {
+		t.Errorf("WebhookPayload.Config.ContentType = %v, want json", payload.Config.ContentType)
+	}
+	if payload.Config.Secret != "secret" {
+		t.Errorf("WebhookPayload.Config.Secret = %v, want secret", payload.Config.Secret)
+	}
+	if payload.Config.InsecureSSL != "0" {
+		t.Errorf("WebhookPayload.Config.InsecureSSL = %v, want 0", payload.Config.InsecureSSL)
+	}
+}

--- a/pkg/bootstrap/installer.go
+++ b/pkg/bootstrap/installer.go
@@ -1,0 +1,340 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+type Installer struct {
+	kubeClient      kubernetes.Interface
+	config          *Config
+	tektonNamespace string
+}
+
+func NewInstaller(kubeClient kubernetes.Interface, config *Config) *Installer {
+	return &Installer{
+		kubeClient:      kubeClient,
+		config:          config,
+		tektonNamespace: "",
+	}
+}
+
+func (i *Installer) getTektonNamespace(ctx context.Context) string {
+	if i.tektonNamespace != "" {
+		return i.tektonNamespace
+	}
+
+	namespaces := []string{
+		"openshift-pipelines",
+		"tekton-pipelines",
+	}
+
+	for _, ns := range namespaces {
+		_, err := i.kubeClient.AppsV1().Deployments(ns).Get(ctx, "tekton-pipelines-controller", metav1.GetOptions{})
+		if err == nil {
+			i.tektonNamespace = ns
+			log.Printf("Tekton Pipelines is installed in %s namespace.", ns)
+			return i.tektonNamespace
+		}
+	}
+
+	// Default to tekton-pipelines if not found
+	i.tektonNamespace = "tekton-pipelines"
+	return i.tektonNamespace
+}
+
+// common helper for polling
+func (i *Installer) pollUntilReady(ctx context.Context, timeout time.Duration, condition wait.ConditionWithContextFunc) error {
+	deadline := time.Now().Add(timeout)
+	ctx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, true, condition)
+}
+
+// waitForNamespace waits for a namespace to exist and ready
+func (i *Installer) waitForNamespace(ctx context.Context, namespace string, timeout time.Duration) error {
+	if i.kubeClient == nil {
+		return nil
+	}
+
+	return i.pollUntilReady(ctx, timeout, func(ctx context.Context) (bool, error) {
+		ns, err := i.kubeClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+
+		// Check if namespace is ready
+		if ns.Status.Phase != "Active" {
+			return false, nil
+		}
+
+		return true, nil
+	})
+}
+
+// waitForDeployment waits for a deployment to ready
+func (i *Installer) waitForDeployment(ctx context.Context, namespace, name string, timeout time.Duration) error {
+	if i.kubeClient == nil {
+		return nil
+	}
+
+	return i.pollUntilReady(ctx, timeout, func(ctx context.Context) (bool, error) {
+		deployment, err := i.kubeClient.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+
+		// Check if deployment is ready
+		if deployment.Status.ReadyReplicas == 0 || deployment.Status.ReadyReplicas < *deployment.Spec.Replicas {
+			return false, nil
+		}
+
+		return true, nil
+	})
+}
+
+// InstallTriggers installs Tekton Triggers CRDs and controllers
+func (i *Installer) InstallTriggers(ctx context.Context) error {
+	// Check if Triggers is already installed
+	if i.isTriggersInstalled(ctx) {
+		log.Println("Tekton Triggers is installed and running.")
+		return nil
+	}
+	if err := i.downloadAndApplyTriggers(ctx); err != nil {
+		return fmt.Errorf("failed to install Triggers: %w", err)
+	}
+
+	log.Println("Waiting for Tekton Triggers to be ready...")
+	return i.waitForTriggersReady(ctx)
+}
+
+func (i *Installer) isTriggersInstalled(ctx context.Context) bool {
+	if i.kubeClient == nil {
+		return false
+	}
+	ns := i.getTektonNamespace(ctx)
+	deployment, err := i.kubeClient.AppsV1().Deployments(ns).Get(ctx, "tekton-triggers-controller", metav1.GetOptions{})
+	if err != nil {
+		return false
+	}
+	return deployment.Status.ReadyReplicas > 0
+}
+
+// waitForTriggersReady waits for Tekton Triggers components to be ready
+func (i *Installer) waitForTriggersReady(ctx context.Context) error {
+	ns := i.getTektonNamespace(ctx)
+	if err := i.waitForNamespace(ctx, ns, 2*time.Minute); err != nil {
+		return fmt.Errorf("timeout waiting for %s namespace: %w", ns, err)
+	}
+
+	// Wait for Triggers controller deployment to be ready
+	if err := i.waitForDeployment(ctx, ns, "tekton-triggers-controller", 3*time.Minute); err != nil {
+		return fmt.Errorf("timeout waiting for tekton-triggers-controller: %w", err)
+	}
+
+	log.Println("Tekton Triggers is ready!")
+	return nil
+}
+
+// InstallTektonPipelines installs Tekton Pipelines if requested and not present
+func (i *Installer) InstallTektonPipelines(ctx context.Context) error {
+	if !i.config.InstallDeps {
+		// Check if Pipelines is installed, it's required for Triggers
+		if !i.isPipelinesInstalled(ctx) {
+			return errors.New("tekton Pipelines is not installed and is required for Triggers")
+		}
+		return nil
+	}
+
+	if i.isPipelinesInstalled(ctx) {
+		log.Println("Tekton Pipelines is installed and running.")
+		return nil
+	}
+
+	if err := i.downloadAndApplyPipelines(ctx); err != nil {
+		return fmt.Errorf("failed to install Pipelines: %w", err)
+	}
+
+	// Wait for Pipelines to be ready before continuing
+	log.Println("Waiting for Pipelines to be ready, this may take a minute or two...")
+	if err := i.waitForPipelinesReady(ctx); err != nil {
+		return fmt.Errorf("failed to wait for Pipelines: %w", err)
+	}
+
+	log.Println("Tekton Pipelines is ready!")
+	return nil
+}
+
+// isPipelinesInstalled checks if Tekton Pipelines is installed and ready
+func (i *Installer) isPipelinesInstalled(ctx context.Context) bool {
+	if i.kubeClient == nil {
+		return false
+	}
+	ns := i.getTektonNamespace(ctx)
+	deployment, err := i.kubeClient.AppsV1().Deployments(ns).Get(ctx, "tekton-pipelines-controller", metav1.GetOptions{})
+	if err != nil {
+		return false
+	}
+	return deployment.Status.ReadyReplicas > 0
+}
+
+func (i *Installer) downloadAndApplyTriggers(ctx context.Context) error {
+	triggersURL := "https://storage.googleapis.com/tekton-releases/triggers/latest/release.yaml"
+	interceptorsURL := "https://storage.googleapis.com/tekton-releases/triggers/latest/interceptors.yaml"
+
+	if err := i.downloadAndApplyManifest(ctx, triggersURL); err != nil {
+		return fmt.Errorf("failed to apply triggers manifest: %w", err)
+	}
+
+	if err := i.downloadAndApplyManifest(ctx, interceptorsURL); err != nil {
+		return fmt.Errorf("failed to apply interceptors manifest: %w", err)
+	}
+
+	return nil
+}
+
+func (i *Installer) downloadAndApplyPipelines(ctx context.Context) error {
+	pipelinesURL := "https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml"
+
+	if err := i.downloadAndApplyManifest(ctx, pipelinesURL); err != nil {
+		return fmt.Errorf("failed to apply pipelines manifest: %w", err)
+	}
+
+	return nil
+}
+
+// downloadAndApplyManifest downloads a YAML manifest from URL and applies it to the cluster
+func (i *Installer) downloadAndApplyManifest(ctx context.Context, url string) error {
+	// Download the manifest
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to download manifest: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to download manifest: HTTP %d", resp.StatusCode)
+	}
+
+	// Read the YAML content
+	yamlContent, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read manifest: %w", err)
+	}
+
+	// Apply the manifest using kubectl-like logic
+	if err := i.applyYAMLManifest(ctx, yamlContent); err != nil {
+		return fmt.Errorf("failed to apply manifest: %w", err)
+	}
+
+	return nil
+}
+
+// applyYAMLManifest applies a multi-document YAML manifest
+func (i *Installer) applyYAMLManifest(ctx context.Context, yamlContent []byte) error {
+	if err := i.applyManifestViaKubectl(ctx, yamlContent); err != nil {
+		return fmt.Errorf("failed to apply manifest: %w", err)
+	}
+
+	return nil
+}
+
+// applyManifestViaKubectl applies YAML using kubectl apply
+func (i *Installer) applyManifestViaKubectl(ctx context.Context, yamlContent []byte) error {
+	// Write YAML to temporary file
+	tmpFile, err := os.CreateTemp("", "tekton-manifest-*.yaml")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+
+	if _, err := tmpFile.Write(yamlContent); err != nil {
+		return fmt.Errorf("failed to write manifest: %w", err)
+	}
+	tmpFile.Close()
+
+	kubeconfigFlag := ""
+	if i.config.KubeConfig != nil {
+		kubeconfigFlag = "--kubeconfig=" + os.Getenv("HOME") + "/.kube/config"
+	}
+
+	// #nosec G204 -- kubectl is a known binary, tmpFile.Name() is a controlled temp file path
+	cmd := exec.CommandContext(ctx, "kubectl", "apply", "-f", tmpFile.Name())
+	if kubeconfigFlag != "" {
+		// #nosec G204 -- kubectl is a known binary, tmpFile.Name() is a controlled temp file path
+		cmd = exec.CommandContext(ctx, "kubectl", kubeconfigFlag, "apply", "-f", tmpFile.Name())
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("kubectl apply failed: %w\nOutput: %s", err, string(output))
+	}
+
+	return nil
+}
+
+// waitForPipelinesReady waits for Tekton Pipelines to be fully ready
+func (i *Installer) waitForPipelinesReady(ctx context.Context) error {
+	ns := i.getTektonNamespace(ctx)
+
+	// Wait for the Tekton namespace
+	if err := i.waitForNamespace(ctx, ns, 2*time.Minute); err != nil {
+		return fmt.Errorf("timeout waiting for %s namespace: %w", ns, err)
+	}
+
+	// Wait for Pipelines controller deployment to be ready
+	if err := i.waitForDeployment(ctx, ns, "tekton-pipelines-controller", 5*time.Minute); err != nil {
+		return fmt.Errorf("timeout waiting for tekton-pipelines-controller: %w", err)
+	}
+
+	// Wait for webhook deployment to be ready
+	if err := i.waitForDeployment(ctx, ns, "tekton-pipelines-webhook", 3*time.Minute); err != nil {
+		return fmt.Errorf("timeout waiting for tekton-pipelines-webhook: %w", err)
+	}
+
+	// buffer for webhook service to be fully responsive
+	time.Sleep(10 * time.Second)
+	return nil
+}

--- a/pkg/bootstrap/installer_test.go
+++ b/pkg/bootstrap/installer_test.go
@@ -1,0 +1,337 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetTektonNamespace(t *testing.T) {
+	tests := []struct {
+		name              string
+		existingNamespace string
+		wantNamespace     string
+	}{
+		{
+			name:              "detects openshift-pipelines",
+			existingNamespace: "openshift-pipelines",
+			wantNamespace:     "openshift-pipelines",
+		},
+		{
+			name:              "detects tekton-pipelines",
+			existingNamespace: "tekton-pipelines",
+			wantNamespace:     "tekton-pipelines",
+		},
+		{
+			name:              "defaults to tekton-pipelines when not found",
+			existingNamespace: "",
+			wantNamespace:     "tekton-pipelines",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			config := &Config{InstallDeps: true}
+
+			var objects []runtime.Object
+			if tt.existingNamespace != "" {
+				// Create a deployment in the existing namespace
+				deployment := &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tekton-pipelines-controller",
+						Namespace: tt.existingNamespace,
+					},
+					Status: appsv1.DeploymentStatus{
+						ReadyReplicas: 1,
+					},
+				}
+				objects = append(objects, deployment)
+			}
+
+			fakeClient := fake.NewSimpleClientset(objects...)
+			installer := NewInstaller(fakeClient, config)
+
+			gotNamespace := installer.getTektonNamespace(ctx)
+			if gotNamespace != tt.wantNamespace {
+				t.Errorf("getTektonNamespace() = %v, want %v", gotNamespace, tt.wantNamespace)
+			}
+
+			// Test caching this should return same value without API call
+			gotNamespace2 := installer.getTektonNamespace(ctx)
+			if gotNamespace2 != tt.wantNamespace {
+				t.Errorf("getTektonNamespace() cached = %v, want %v", gotNamespace2, tt.wantNamespace)
+			}
+		})
+	}
+}
+
+func TestIsPipelinesInstalled(t *testing.T) {
+	tests := []struct {
+		name          string
+		deployment    *appsv1.Deployment
+		wantInstalled bool
+	}{
+		{
+			name: "pipelines installed and ready",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tekton-pipelines-controller",
+					Namespace: "tekton-pipelines",
+				},
+				Status: appsv1.DeploymentStatus{
+					ReadyReplicas: 1,
+				},
+			},
+			wantInstalled: true,
+		},
+		{
+			name: "pipelines deployed but not ready",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tekton-pipelines-controller",
+					Namespace: "tekton-pipelines",
+				},
+				Status: appsv1.DeploymentStatus{
+					ReadyReplicas: 0,
+				},
+			},
+			wantInstalled: false,
+		},
+		{
+			name:          "pipelines not installed",
+			deployment:    nil,
+			wantInstalled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			config := &Config{InstallDeps: true}
+
+			var objects []runtime.Object
+			if tt.deployment != nil {
+				objects = append(objects, tt.deployment)
+			}
+
+			fakeClient := fake.NewSimpleClientset(objects...)
+			installer := NewInstaller(fakeClient, config)
+
+			gotInstalled := installer.isPipelinesInstalled(ctx)
+			if gotInstalled != tt.wantInstalled {
+				t.Errorf("isPipelinesInstalled() = %v, want %v", gotInstalled, tt.wantInstalled)
+			}
+		})
+	}
+}
+
+func TestIsTriggersInstalled(t *testing.T) {
+	tests := []struct {
+		name          string
+		deployment    *appsv1.Deployment
+		wantInstalled bool
+	}{
+		{
+			name: "triggers installed and ready",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tekton-triggers-controller",
+					Namespace: "tekton-pipelines",
+				},
+				Status: appsv1.DeploymentStatus{
+					ReadyReplicas: 1,
+				},
+			},
+			wantInstalled: true,
+		},
+		{
+			name: "triggers deployed but not ready",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tekton-triggers-controller",
+					Namespace: "tekton-pipelines",
+				},
+				Status: appsv1.DeploymentStatus{
+					ReadyReplicas: 0,
+				},
+			},
+			wantInstalled: false,
+		},
+		{
+			name:          "triggers not installed",
+			deployment:    nil,
+			wantInstalled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			config := &Config{InstallDeps: true}
+
+			var objects []runtime.Object
+			if tt.deployment != nil {
+				objects = append(objects, tt.deployment)
+			}
+
+			fakeClient := fake.NewSimpleClientset(objects...)
+			installer := NewInstaller(fakeClient, config)
+
+			gotInstalled := installer.isTriggersInstalled(ctx)
+			if gotInstalled != tt.wantInstalled {
+				t.Errorf("isTriggersInstalled() = %v, want %v", gotInstalled, tt.wantInstalled)
+			}
+		})
+	}
+}
+
+func TestWaitForNamespace(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace *corev1.Namespace
+		wantError bool
+	}{
+		{
+			name: "namespace exists and active",
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-namespace",
+				},
+				Status: corev1.NamespaceStatus{
+					Phase: corev1.NamespaceActive,
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "namespace exists but terminating",
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-namespace",
+				},
+				Status: corev1.NamespaceStatus{
+					Phase: corev1.NamespaceTerminating,
+				},
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &Config{InstallDeps: true}
+
+			var objects []runtime.Object
+			if tt.namespace != nil {
+				objects = append(objects, tt.namespace)
+			}
+
+			fakeClient := fake.NewSimpleClientset(objects...)
+			_ = NewInstaller(fakeClient, config)
+		})
+	}
+}
+
+func TestWaitForDeployment(t *testing.T) {
+	tests := []struct {
+		name       string
+		deployment *appsv1.Deployment
+		wantError  bool
+	}{
+		{
+			name: "deployment ready",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: "test-namespace",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: int32Ptr(1),
+				},
+				Status: appsv1.DeploymentStatus{
+					ReadyReplicas: 1,
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "deployment not ready",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: "test-namespace",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: int32Ptr(1),
+				},
+				Status: appsv1.DeploymentStatus{
+					ReadyReplicas: 0,
+				},
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &Config{InstallDeps: true}
+
+			var objects []runtime.Object
+			if tt.deployment != nil {
+				objects = append(objects, tt.deployment)
+			}
+
+			fakeClient := fake.NewSimpleClientset(objects...)
+			_ = NewInstaller(fakeClient, config)
+		})
+	}
+}
+
+func TestNewInstaller(t *testing.T) {
+	config := &Config{
+		Namespace:   "test",
+		InstallDeps: true,
+	}
+	fakeClient := fake.NewSimpleClientset()
+
+	installer := NewInstaller(fakeClient, config)
+
+	if installer == nil {
+		t.Error("NewInstaller() returned nil")
+	}
+	if installer.kubeClient == nil {
+		t.Error("NewInstaller() kubeClient is nil")
+	}
+	if installer.config == nil {
+		t.Error("NewInstaller() config is nil")
+	}
+	if installer.tektonNamespace != "" {
+		t.Errorf("NewInstaller() tektonNamespace should be empty initially, got %v", installer.tektonNamespace)
+	}
+}
+
+func int32Ptr(i int32) *int32 {
+	return &i
+}

--- a/pkg/bootstrap/rbac.go
+++ b/pkg/bootstrap/rbac.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type RBACManager struct {
+	kubeClient kubernetes.Interface
+	config     *Config
+}
+
+func NewRBACManager(kubeClient kubernetes.Interface, config *Config) *RBACManager {
+	return &RBACManager{
+		kubeClient: kubeClient,
+		config:     config,
+	}
+}
+
+// CreateNamespace creates the target namespace if it doesn't exist
+func (r *RBACManager) CreateNamespace(ctx context.Context) error {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: r.config.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of": "tekton-triggers",
+				"tekton.dev/bootstrap":      "true",
+			},
+		},
+	}
+
+	_, err := r.kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to create namespace: %w", err)
+	}
+	return nil
+}
+
+// SetupRBAC creates necessary service accounts, roles, and bindings
+func (r *RBACManager) SetupRBAC(ctx context.Context) error {
+	// Apply admin-role.yaml (ServiceAccount + RoleBinding + ClusterRoleBinding)
+	if err := r.applyGettingStartedRBAC(ctx); err != nil {
+		return err
+	}
+
+	// Apply webhook-role.yaml (Role + ServiceAccount + RoleBinding for webhook tasks)
+	if err := r.applyWebhookRBAC(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// applyGettingStartedRBAC applies the admin-role.yaml from getting-started docs
+func (r *RBACManager) applyGettingStartedRBAC(ctx context.Context) error {
+	if err := applyFileFromGitHub("docs/getting-started/rbac/admin-role.yaml"); err != nil {
+		return fmt.Errorf("failed to apply admin-role.yaml: %w", err)
+	}
+
+	if err := applyFileFromGitHub("docs/getting-started/rbac/clusterrolebinding.yaml"); err != nil {
+		return fmt.Errorf("failed to apply clusterrolebinding.yaml: %w", err)
+	}
+	return nil
+}
+
+// applyWebhookRBAC applies webhook-role.yaml from getting-started docs
+func (r *RBACManager) applyWebhookRBAC(ctx context.Context) error {
+	if err := applyFileFromGitHub("docs/getting-started/rbac/webhook-role.yaml"); err != nil {
+		return fmt.Errorf("failed to apply webhook-role.yaml: %w", err)
+	}
+	return nil
+}
+
+// CreateWebhookSecret creates a Kubernetes secret for webhook authentication
+func (r *RBACManager) CreateWebhookSecret(ctx context.Context, webhookSecret string) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "github-webhook-secret",
+			Namespace: r.config.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of": "tekton-triggers",
+				"tekton.dev/bootstrap":      "true",
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"webhook-secret": []byte(webhookSecret),
+		},
+	}
+
+	_, err := r.kubeClient.CoreV1().Secrets(r.config.Namespace).Create(ctx, secret, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to create webhook secret: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/bootstrap/templates.go
+++ b/pkg/bootstrap/templates.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+
+	triggersclientset "github.com/tektoncd/triggers/pkg/client/clientset/versioned"
+)
+
+// TemplatesManager handles creation of Trigger templates and resources
+type TemplatesManager struct {
+	triggersClient triggersclientset.Interface
+	config         *Config
+}
+
+// NewTemplatesManager creates a new templates manager
+func NewTemplatesManager(triggersClient triggersclientset.Interface, config *Config) *TemplatesManager {
+	return &TemplatesManager{
+		triggersClient: triggersClient,
+		config:         config,
+	}
+}
+
+// CreateTriggerResources creates Trigger resources from getting-started docs
+func (t *TemplatesManager) CreateTriggerResources(ctx context.Context) error {
+	return t.applyGettingStartedTriggers(ctx)
+}
+
+// CreateExamples creates the Pipeline from getting-started docs
+func (t *TemplatesManager) CreateExamples(ctx context.Context) error {
+	return t.applyGettingStartedPipeline(ctx)
+}
+
+// applyGettingStartedTriggers applies triggers.yaml from getting-started docs
+func (t *TemplatesManager) applyGettingStartedTriggers(ctx context.Context) error {
+	if err := applyFileFromGitHub("docs/getting-started/triggers.yaml"); err != nil {
+		return fmt.Errorf("failed to apply triggers.yaml: %w", err)
+	}
+	return nil
+}
+
+// applyGettingStartedPipeline applies pipeline.yaml from getting-started docs
+func (t *TemplatesManager) applyGettingStartedPipeline(ctx context.Context) error {
+	if err := applyFileFromGitHub("docs/getting-started/pipeline.yaml"); err != nil {
+		return fmt.Errorf("failed to apply pipeline.yaml: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Implement a new 'tkn triggers bootstrap' command that automates the complete setup of Tekton Triggers with GitHub integration which will:
          1. Install Tekton Pipelines and Triggers (if needed)
          2. Create the getting-started namespace and RBAC
          3. Apply all Trigger resources (EventListener, TriggerTemplate, TriggerBinding)
          4. Create example Pipeline and Tasks
          5. Prompt for GitHub repository, domain, and token
          6. Create GitHub webhook

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
