### PR TITLE
Add GitHub Actions workflow for go coverage job

### DIFF
--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -1,0 +1,65 @@
+name: Go coverage
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+  # run at least once every 2 months to prevent the coverage artifact from expiring
+  schedule:
+    - cron: '14 3 3 */2 *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  go-coverage:
+    name: Go coverage
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          path: ${{ github.workspace }}/src/github.com/tektoncd/triggers
+
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
+        with:
+          go-version-file: "${{ github.workspace }}/src/github.com/tektoncd/triggers/go.mod"
+
+      - name: Generate coverage
+        working-directory: ${{ github.workspace }}/src/github.com/tektoncd/triggers
+        run: |
+          go test -cover -coverprofile=coverage.txt ./... || true
+          echo "Generated coverage profile"
+
+      - name: Archive coverage results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: code-coverage
+          path: ${{ github.workspace }}/src/github.com/tektoncd/triggers/coverage.txt
+
+      - name: Comment on PR
+        if: github.event_name == 'pull_request'
+        uses: fgrosse/go-coverage-report@8c1d1a09864211d258937b1b1a5b849f7e4f2682 # v1.2.0
+        continue-on-error: true # This may fail if artifact on main branch does not exist (first run or expired)
+        with:
+          coverage-artifact-name: "code-coverage"
+          coverage-file-name: "coverage.txt"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
https://github.com/tektoncd/plumbing/issues/2842

It uses workflow artifacts to store current coverage on merged to main and uses this as a baseline for comparison when running on PRs.

It's also configured to run at least once every 2 months to avoid the workflow artifact expiring.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
