### PR TITLE
Update github interceptor to only validate sha-256 signature

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -105,8 +105,8 @@ This means that the selected `Interceptor` is unable to parse the structure of t
 
 ## Troubleshooting signature and token errors
 
-When sending a hook protected by a secret, GitHub includes an `X-Hub-Signature` object in the header, while GitLab includes an `X-GitLab-Token` object.
-You may see `no X-Hub-Signature set` and/or `no X-GitLab-Token header set` errors in your logs in one of the following scenarios:
+When sending a hook protected by a secret, GitHub includes an `X-Hub-Signature-256` object in the header, while GitLab includes an `X-GitLab-Token` object.
+You may see `no X-Hub-Signature-256 header set` and/or `no X-GitLab-Token header set` errors in your logs in one of the following scenarios:
 
 *  If you specify a secret in your `Interceptor` but don't specify it in the hook.
 *  You are sending unsigned payloads to an `Interceptor` that expects signed payloads.

--- a/examples/v1alpha1/custom-resource/README.md
+++ b/examples/v1alpha1/custom-resource/README.md
@@ -15,7 +15,7 @@ Creates an EventListener that listens for GitHub webhook events.
    ```bash
    curl -v \
    -H 'X-GitHub-Event: pull_request' \
-   -H 'X-Hub-Signature: sha1=ba0cdc263b3492a74b601d240c27efe81c4720cb' \
+   -H 'X-Hub-Signature-256: sha256=c26dd919ebe335852219c49f74c4b24f1c62c93c77294be3ac6d8f2e4691a023' \
    -H 'Content-Type: application/json' \
    -d '{"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git"}}' \
    http://<el_address>
@@ -23,7 +23,7 @@ Creates an EventListener that listens for GitHub webhook events.
 
    The response status code should be `202 Accepted`
    
-   [`HMAC`](https://www.freeformatter.com/hmac-generator.html) tool used to create X-Hub-Signature.
+   [`HMAC`](https://www.freeformatter.com/hmac-generator.html) tool used to create X-Hub-Signature-256.
    
    In [`HMAC`](https://www.freeformatter.com/hmac-generator.html) `string` is the *body payload ex:* `{"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git"}}`
    and `secretKey` is the *given secretToken ex:* `1234567`.

--- a/examples/v1alpha1/custom-resource/curl.sh
+++ b/examples/v1alpha1/custom-resource/curl.sh
@@ -1,6 +1,6 @@
 curl -v \
 -H 'X-GitHub-Event: pull_request' \
--H 'X-Hub-Signature: sha1=ba0cdc263b3492a74b601d240c27efe81c4720cb' \
+-H 'X-Hub-Signature-256: sha256=c26dd919ebe335852219c49f74c4b24f1c62c93c77294be3ac6d8f2e4691a023' \
 -H 'Content-Type: application/json' \
 -d '{"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git"}}' \
 http://127.0.0.1:$1 -H "Host: $2"

--- a/examples/v1alpha1/embedded-trigger/README.md
+++ b/examples/v1alpha1/embedded-trigger/README.md
@@ -51,7 +51,7 @@ run the following command in your shell of choice or using Postman:
 curl -X POST \
   http://localhost:8080 \
   -H 'Content-Type: application/json' \
-  -H 'X-Hub-Signature: sha1=2da37dcb9404ff17b714ee7a505c384758ddeb7b' \
+  -H 'X-Hub-Signature-256: sha256=5bfc4c007697a264f4255882e9fbffe34cbe1cf6040118db7e017e6200f45acd' \
   -d '{
 	"repository":
 	{

--- a/examples/v1alpha1/embedded-trigger/curl.sh
+++ b/examples/v1alpha1/embedded-trigger/curl.sh
@@ -1,7 +1,7 @@
 curl -X POST \
   http://localhost:8080 \
   -H 'Content-Type: application/json' \
-  -H 'X-Hub-Signature: sha1=2da37dcb9404ff17b714ee7a505c384758ddeb7b' \
+  -H 'X-Hub-Signature-256: sha256=5bfc4c007697a264f4255882e9fbffe34cbe1cf6040118db7e017e6200f45acd' \
   -d '{
 	"repository":
 	{

--- a/examples/v1alpha1/eventlistener-tls-connection/README.md
+++ b/examples/v1alpha1/eventlistener-tls-connection/README.md
@@ -60,7 +60,7 @@ the EventListener to listen for TLS connections
    ```bash
    curl -v \
    -H 'X-GitHub-Event: pull_request' \
-   -H 'X-Hub-Signature: sha1=ba0cdc263b3492a74b601d240c27efe81c4720cb' \
+   -H 'X-Hub-Signature-256: sha256=c26dd919ebe335852219c49f74c4b24f1c62c93c77294be3ac6d8f2e4691a023' \
    -H 'Content-Type: application/json' \
    -d '{"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git"}}' \
    https://<el-address> --cacert rootCA.crt --key client.key --cert client.crt
@@ -68,7 +68,7 @@ the EventListener to listen for TLS connections
 
    The response status code should be `202 Accepted`
 
-   [`HMAC`](https://www.freeformatter.com/hmac-generator.html) tool used to create X-Hub-Signature.
+   [`HMAC`](https://www.freeformatter.com/hmac-generator.html) tool used to create X-Hub-Signature-256.
 
    In [`HMAC`](https://www.freeformatter.com/hmac-generator.html) `string` is the *body payload ex:* `{"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git"}}`
    and `secretKey` is the *given secretToken ex:* `1234567`.

--- a/examples/v1alpha1/github/README.md
+++ b/examples/v1alpha1/github/README.md
@@ -21,7 +21,7 @@ Creates an EventListener that listens for GitHub webhook events.
    ```bash
    curl -v \
    -H 'X-GitHub-Event: pull_request' \
-   -H 'X-Hub-Signature: sha1=ba0cdc263b3492a74b601d240c27efe81c4720cb' \
+   -H 'X-Hub-Signature-256: sha256=c26dd919ebe335852219c49f74c4b24f1c62c93c77294be3ac6d8f2e4691a023' \
    -H 'Content-Type: application/json' \
    -d '{"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git"}}' \
    http://localhost:8080
@@ -29,7 +29,7 @@ Creates an EventListener that listens for GitHub webhook events.
 
    The response status code should be `202 Accepted`
 
-   [`HMAC`](https://www.freeformatter.com/hmac-generator.html) tool used to create X-Hub-Signature.
+   [`HMAC`](https://www.freeformatter.com/hmac-generator.html) tool used to create X-Hub-Signature-256.
 
    In [`HMAC`](https://www.freeformatter.com/hmac-generator.html) `string` is the *body payload ex:* `{"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git"}}`
    and `secretKey` is the *given secretToken ex:* `1234567`.

--- a/examples/v1alpha1/github/curl.sh
+++ b/examples/v1alpha1/github/curl.sh
@@ -1,6 +1,6 @@
 curl -v \
 -H 'X-GitHub-Event: pull_request' \
--H 'X-Hub-Signature: sha1=ba0cdc263b3492a74b601d240c27efe81c4720cb' \
+-H 'X-Hub-Signature-256: sha256=c26dd919ebe335852219c49f74c4b24f1c62c93c77294be3ac6d8f2e4691a023' \
 -H 'Content-Type: application/json' \
 -d '{"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git"}}' \
 http://localhost:8080

--- a/examples/v1alpha1/label-selector/README.md
+++ b/examples/v1alpha1/label-selector/README.md
@@ -25,7 +25,7 @@ Creates an EventListener that serve triggers selected via a label selector.
    ```bash
    curl -k -v \
    -H 'X-GitHub-Event: pull_request' \
-   -H 'X-Hub-Signature: sha1=8d7c4d33686fd908394208a07d997b8f5bd70aa6' \
+   -H 'X-Hub-Signature-256: sha256=b6bfbf622a1f9138123646c7b89f3a60092a803dc2f824bd39642bd80d85825a' \
    -H 'Content-Type: application/json' \
    -d '{"head_commit":{"id":"28911bbb5a3e2ea034daf1f6be0a822d50e31e73"},"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git", "url":"https://github.com/tektoncd/triggers.git"}}' \
    http://localhost:8080

--- a/examples/v1alpha1/label-selector/curl.sh
+++ b/examples/v1alpha1/label-selector/curl.sh
@@ -1,6 +1,6 @@
 curl -k -v \
 -H 'X-GitHub-Event: pull_request' \
--H 'X-Hub-Signature: sha1=8d7c4d33686fd908394208a07d997b8f5bd70aa6' \
+-H 'X-Hub-Signature-256: sha256=b6bfbf622a1f9138123646c7b89f3a60092a803dc2f824bd39642bd80d85825a' \
 -H 'Content-Type: application/json' \
 -d '{"head_commit":{"id":"28911bbb5a3e2ea034daf1f6be0a822d50e31e73"},"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git", "url":"https://github.com/tektoncd/triggers.git"}}' \
 http://localhost:8080

--- a/examples/v1alpha1/namespace-selector/README.md
+++ b/examples/v1alpha1/namespace-selector/README.md
@@ -25,7 +25,7 @@ Creates an EventListener that serve triggers in multiple namespaces.
    ```bash
        curl -k -v \
        -H 'X-GitHub-Event: pull_request' \
-       -H 'X-Hub-Signature: sha1=8d7c4d33686fd908394208a07d997b8f5bd70aa6' \
+       -H 'X-Hub-Signature-256: sha256=b6bfbf622a1f9138123646c7b89f3a60092a803dc2f824bd39642bd80d85825a' \
        -H 'Content-Type: application/json' \
        -d '{"head_commit":{"id":"28911bbb5a3e2ea034daf1f6be0a822d50e31e73"},"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git", "url":"https://github.com/tektoncd/triggers.git"}}' \
        http://localhost:8080   

--- a/examples/v1alpha1/namespace-selector/curl.sh
+++ b/examples/v1alpha1/namespace-selector/curl.sh
@@ -1,6 +1,6 @@
     curl -k -v \
     -H 'X-GitHub-Event: pull_request' \
-    -H 'X-Hub-Signature: sha1=8d7c4d33686fd908394208a07d997b8f5bd70aa6' \
+    -H 'X-Hub-Signature-256: sha256=b6bfbf622a1f9138123646c7b89f3a60092a803dc2f824bd39642bd80d85825a' \
     -H 'Content-Type: application/json' \
     -d '{"head_commit":{"id":"28911bbb5a3e2ea034daf1f6be0a822d50e31e73"},"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git", "url":"https://github.com/tektoncd/triggers.git"}}' \
     http://localhost:8080   

--- a/examples/v1alpha1/namespacedinterceptor/README.md
+++ b/examples/v1alpha1/namespacedinterceptor/README.md
@@ -19,7 +19,7 @@ Creates a NamespacedInterceptor and an EventListener which utilizes this Interce
 1. Test by sending the sample payload.
 
    ```bash
-   curl -k -v     -H 'X-GitHub-Event: pull_request'     -H 'X-Hub-Signature: sha1=8d7c4d33686fd908394208a07d997b8f5bd70aa6'     -H 'Content-Type: application/json'     -d '{"head_commit":{"id":"28911bbb5a3e2ea034daf1f6be0a822d50e31e73"},"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git", "url":"https://github.com/tektoncd/triggers.git"}}'     http://localhost:8080
+   curl -k -v     -H 'X-GitHub-Event: pull_request'     -H 'X-Hub-Signature-256: sha256=b6bfbf622a1f9138123646c7b89f3a60092a803dc2f824bd39642bd80d85825a'     -H 'Content-Type: application/json'     -d '{"head_commit":{"id":"28911bbb5a3e2ea034daf1f6be0a822d50e31e73"},"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git", "url":"https://github.com/tektoncd/triggers.git"}}'     http://localhost:8080
    ```
 
    The response status code should be `202 Accepted`

--- a/examples/v1beta1/custom-resource/README.md
+++ b/examples/v1beta1/custom-resource/README.md
@@ -15,7 +15,7 @@ Creates an EventListener that listens for GitHub webhook events.
    ```bash
    curl -v \
    -H 'X-GitHub-Event: pull_request' \
-   -H 'X-Hub-Signature: sha1=ba0cdc263b3492a74b601d240c27efe81c4720cb' \
+   -H 'X-Hub-Signature-256: sha256=c26dd919ebe335852219c49f74c4b24f1c62c93c77294be3ac6d8f2e4691a023' \
    -H 'Content-Type: application/json' \
    -d '{"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git"}}' \
    http://<el_address>
@@ -23,7 +23,7 @@ Creates an EventListener that listens for GitHub webhook events.
 
    The response status code should be `202 Accepted`
    
-   [`HMAC`](https://www.freeformatter.com/hmac-generator.html) tool used to create X-Hub-Signature.
+   [`HMAC`](https://www.freeformatter.com/hmac-generator.html) tool used to create X-Hub-Signature-256.
    
    In [`HMAC`](https://www.freeformatter.com/hmac-generator.html) `string` is the *body payload ex:* `{"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git"}}`
    and `secretKey` is the *given secretToken ex:* `1234567`.

--- a/examples/v1beta1/custom-resource/curl.sh
+++ b/examples/v1beta1/custom-resource/curl.sh
@@ -1,6 +1,6 @@
 curl -v \
 -H 'X-GitHub-Event: pull_request' \
--H 'X-Hub-Signature: sha1=ba0cdc263b3492a74b601d240c27efe81c4720cb' \
+-H 'X-Hub-Signature-256: sha256=c26dd919ebe335852219c49f74c4b24f1c62c93c77294be3ac6d8f2e4691a023' \
 -H 'Content-Type: application/json' \
 -d '{"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git"}}' \
 http://127.0.0.1:$1 -H "Host: $2"

--- a/examples/v1beta1/embedded-trigger/README.md
+++ b/examples/v1beta1/embedded-trigger/README.md
@@ -53,7 +53,7 @@ run the following command in your shell of choice or using Postman:
 curl -X POST \
   http://localhost:8080 \
   -H 'Content-Type: application/json' \
-  -H 'X-Hub-Signature: sha1=2da37dcb9404ff17b714ee7a505c384758ddeb7b' \
+  -H 'X-Hub-Signature-256: sha256=5bfc4c007697a264f4255882e9fbffe34cbe1cf6040118db7e017e6200f45acd' \
   -d '{
 	"repository":
 	{

--- a/examples/v1beta1/embedded-trigger/curl.sh
+++ b/examples/v1beta1/embedded-trigger/curl.sh
@@ -1,7 +1,7 @@
 curl -X POST \
   http://localhost:8080 \
   -H 'Content-Type: application/json' \
-  -H 'X-Hub-Signature: sha1=2da37dcb9404ff17b714ee7a505c384758ddeb7b' \
+  -H 'X-Hub-Signature-256: sha256=5bfc4c007697a264f4255882e9fbffe34cbe1cf6040118db7e017e6200f45acd' \
   -d '{
 	"repository":
 	{

--- a/examples/v1beta1/eventlistener-tls-connection/README.md
+++ b/examples/v1beta1/eventlistener-tls-connection/README.md
@@ -62,7 +62,7 @@ the EventListener to listen for TLS connections
    ```bash
    curl -v \
    -H 'X-GitHub-Event: pull_request' \
-   -H 'X-Hub-Signature: sha1=ba0cdc263b3492a74b601d240c27efe81c4720cb' \
+   -H 'X-Hub-Signature-256: sha256=c26dd919ebe335852219c49f74c4b24f1c62c93c77294be3ac6d8f2e4691a023' \
    -H 'Content-Type: application/json' \
    -d '{"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git"}}' \
    https://<el-address> --cacert rootCA.crt --key client.key --cert client.crt
@@ -70,7 +70,7 @@ the EventListener to listen for TLS connections
 
    The response status code should be `202 Accepted`
    
-   [`HMAC`](https://www.freeformatter.com/hmac-generator.html) tool used to create X-Hub-Signature.
+   [`HMAC`](https://www.freeformatter.com/hmac-generator.html) tool used to create X-Hub-Signature-256.
    
    In [`HMAC`](https://www.freeformatter.com/hmac-generator.html) `string` is the *body payload ex:* `{"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git"}}`
    and `secretKey` is the *given secretToken ex:* `1234567`.

--- a/examples/v1beta1/github-add-changed-files-pr/README.md
+++ b/examples/v1beta1/github-add-changed-files-pr/README.md
@@ -28,7 +28,7 @@ Creates an EventListener that listens for GitHub webhook events and adds the fil
 
    The response status code should be `202 Accepted`
 
-   [`HMAC`](https://www.freeformatter.com/hmac-generator.html) tool used to create X-Hub-Signature.
+   [`HMAC`](https://www.freeformatter.com/hmac-generator.html) tool used to create X-Hub-Signature-256.
 
    In [`HMAC`](https://www.freeformatter.com/hmac-generator.html) `string` is the *body payload ex:* `{"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git"}}`
    and `secretKey` is the *given secretToken ex:* `1234567`.

--- a/examples/v1beta1/github-add-changed-files-push-cel/README.md
+++ b/examples/v1beta1/github-add-changed-files-push-cel/README.md
@@ -28,7 +28,7 @@ Creates an EventListener that listens for GitHub webhook events and adds the fil
 
    The response status code should be `202 Accepted`
 
-   [`HMAC`](https://www.freeformatter.com/hmac-generator.html) tool used to create X-Hub-Signature.
+   [`HMAC`](https://www.freeformatter.com/hmac-generator.html) tool used to create X-Hub-Signature-256.
 
    In [`HMAC`](https://www.freeformatter.com/hmac-generator.html) `string` is the *body payload ex:* `{"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git"}}`
    and `secretKey` is the *given secretToken ex:* `1234567`.

--- a/examples/v1beta1/github-owners/README.md
+++ b/examples/v1beta1/github-owners/README.md
@@ -21,7 +21,7 @@ Creates an EventListener that listens for `pull_request` or `issue_comment` GitH
    ```bash
    curl -v \
    -H 'X-GitHub-Event: pull_request' \
-   -H 'X-Hub-Signature: sha1=70d0ebf86a7973374898b7711acc0897616e2c93' \
+   -H 'X-Hub-Signature-256: sha256=a7b3a3840860ef271afde557e8b6c89cc69539a396417f93d847e1890d3c8184' \
    -H 'Content-Type: application/json' \
    -d '{"action": "opened","number": 1503,"repository":{"full_name": "tektoncd/triggers", "clone_url": "https://github.com/tektoncd/triggers.git"}, "sender":{"login": "dibyom"}}' \
    http://localhost:8080
@@ -29,7 +29,7 @@ Creates an EventListener that listens for `pull_request` or `issue_comment` GitH
 
    The response status code should be `202 Accepted`
 
-   [`HMAC`](https://www.freeformatter.com/hmac-generator.html) tool used to create X-Hub-Signature.
+   [`HMAC`](https://www.freeformatter.com/hmac-generator.html) tool used to create X-Hub-Signature-256.
 
    In [`HMAC`](https://www.freeformatter.com/hmac-generator.html) `string` is the *body payload ex:* `{"action": "opened","number": 1503,"repository":{"full_name": "tektoncd/triggers", "clone_url": "https://github.com/tektoncd/triggers.git"}, "sender":{"login": "dibyom"}}`
    and `secretKey` is the *given secretToken ex:* `1234567`.

--- a/examples/v1beta1/github-owners/curl.sh
+++ b/examples/v1beta1/github-owners/curl.sh
@@ -1,6 +1,6 @@
 curl -v \
 -H 'X-GitHub-Event: pull_request' \
--H 'X-Hub-Signature: sha1=70d0ebf86a7973374898b7711acc0897616e2c93' \
+-H 'X-Hub-Signature-256: sha256=a7b3a3840860ef271afde557e8b6c89cc69539a396417f93d847e1890d3c8184' \
 -H 'Content-Type: application/json' \
 -d '{"action": "opened","number": 1503,"repository":{"full_name": "tektoncd/triggers", "clone_url": "https://github.com/tektoncd/triggers.git"}, "sender":{"login": "dibyom"}}' \
 http://localhost:8080

--- a/examples/v1beta1/github/README.md
+++ b/examples/v1beta1/github/README.md
@@ -21,7 +21,7 @@ Creates an EventListener that listens for GitHub webhook events.
    ```bash
    curl -v \
    -H 'X-GitHub-Event: pull_request' \
-   -H 'X-Hub-Signature: sha1=ba0cdc263b3492a74b601d240c27efe81c4720cb' \
+   -H 'X-Hub-Signature-256: sha256=c26dd919ebe335852219c49f74c4b24f1c62c93c77294be3ac6d8f2e4691a023' \
    -H 'Content-Type: application/json' \
    -d '{"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git"}}' \
    http://localhost:8080
@@ -29,7 +29,7 @@ Creates an EventListener that listens for GitHub webhook events.
 
    The response status code should be `202 Accepted`
 
-   [`HMAC`](https://www.freeformatter.com/hmac-generator.html) tool used to create X-Hub-Signature.
+   [`HMAC`](https://www.freeformatter.com/hmac-generator.html) tool used to create X-Hub-Signature-256.
 
    In [`HMAC`](https://www.freeformatter.com/hmac-generator.html) `string` is the *body payload ex:* `{"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git"}}`
    and `secretKey` is the *given secretToken ex:* `1234567`.

--- a/examples/v1beta1/github/curl.sh
+++ b/examples/v1beta1/github/curl.sh
@@ -1,6 +1,6 @@
 curl -v \
 -H 'X-GitHub-Event: pull_request' \
--H 'X-Hub-Signature: sha1=ba0cdc263b3492a74b601d240c27efe81c4720cb' \
+-H 'X-Hub-Signature-256: sha256=c26dd919ebe335852219c49f74c4b24f1c62c93c77294be3ac6d8f2e4691a023' \
 -H 'Content-Type: application/json' \
 -d '{"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git"}}' \
 http://localhost:8080

--- a/examples/v1beta1/label-selector/README.md
+++ b/examples/v1beta1/label-selector/README.md
@@ -25,7 +25,7 @@ Creates an EventListener that serve triggers selected via a label selector.
    ```bash
    curl -k -v \
    -H 'X-GitHub-Event: pull_request' \
-   -H 'X-Hub-Signature: sha1=8d7c4d33686fd908394208a07d997b8f5bd70aa6' \
+   -H 'X-Hub-Signature-256: sha256=b6bfbf622a1f9138123646c7b89f3a60092a803dc2f824bd39642bd80d85825a' \
    -H 'Content-Type: application/json' \
    -d '{"head_commit":{"id":"28911bbb5a3e2ea034daf1f6be0a822d50e31e73"},"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git", "url":"https://github.com/tektoncd/triggers.git"}}' \
    http://localhost:8080

--- a/examples/v1beta1/label-selector/curl.sh
+++ b/examples/v1beta1/label-selector/curl.sh
@@ -1,6 +1,6 @@
 curl -k -v \
 -H 'X-GitHub-Event: pull_request' \
--H 'X-Hub-Signature: sha1=8d7c4d33686fd908394208a07d997b8f5bd70aa6' \
+-H 'X-Hub-Signature-256: sha256=b6bfbf622a1f9138123646c7b89f3a60092a803dc2f824bd39642bd80d85825a' \
 -H 'Content-Type: application/json' \
 -d '{"head_commit":{"id":"28911bbb5a3e2ea034daf1f6be0a822d50e31e73"},"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git", "url":"https://github.com/tektoncd/triggers.git"}}' \
 http://localhost:8080

--- a/examples/v1beta1/namespace-selector/README.md
+++ b/examples/v1beta1/namespace-selector/README.md
@@ -25,7 +25,7 @@ Creates an EventListener that serve triggers in multiple namespaces.
    ```bash
        curl -k -v \
        -H 'X-GitHub-Event: pull_request' \
-       -H 'X-Hub-Signature: sha1=8d7c4d33686fd908394208a07d997b8f5bd70aa6' \
+       -H 'X-Hub-Signature-256: sha256=b6bfbf622a1f9138123646c7b89f3a60092a803dc2f824bd39642bd80d85825a' \
        -H 'Content-Type: application/json' \
        -d '{"head_commit":{"id":"28911bbb5a3e2ea034daf1f6be0a822d50e31e73"},"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git", "url":"https://github.com/tektoncd/triggers.git"}}' \
        http://localhost:8080   

--- a/examples/v1beta1/namespace-selector/curl.sh
+++ b/examples/v1beta1/namespace-selector/curl.sh
@@ -1,6 +1,6 @@
     curl -k -v \
     -H 'X-GitHub-Event: pull_request' \
-    -H 'X-Hub-Signature: sha1=8d7c4d33686fd908394208a07d997b8f5bd70aa6' \
+    -H 'X-Hub-Signature-256: sha256=b6bfbf622a1f9138123646c7b89f3a60092a803dc2f824bd39642bd80d85825a' \
     -H 'Content-Type: application/json' \
     -d '{"head_commit":{"id":"28911bbb5a3e2ea034daf1f6be0a822d50e31e73"},"action": "opened", "pull_request":{"head":{"sha": "28911bbb5a3e2ea034daf1f6be0a822d50e31e73"}},"repository":{"clone_url": "https://github.com/tektoncd/triggers.git", "url":"https://github.com/tektoncd/triggers.git"}}' \
     http://localhost:8080   

--- a/pkg/interceptors/github/github.go
+++ b/pkg/interceptors/github/github.go
@@ -153,10 +153,7 @@ func (w *InterceptorImpl) Process(ctx context.Context, r *triggersv1.Interceptor
 		}
 		header := headers.Get("X-Hub-Signature-256")
 		if header == "" {
-			header = headers.Get("X-Hub-Signature")
-		}
-		if header == "" {
-			return interceptors.Fail(codes.FailedPrecondition, "Must set X-Hub-Signature-256 or X-Hub-Signature header")
+			return interceptors.Fail(codes.FailedPrecondition, "no X-Hub-Signature-256 header set")
 		}
 
 		if r.Context == nil {

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -732,8 +732,8 @@ func TestHandleEvent(t *testing.T) {
 		},
 		eventBody: eventBody,
 		headers: map[string][]string{
-			"X-GitHub-Event":  {"pull_request"},
-			"X-Hub-Signature": {test.HMACHeader(t, "secret", eventBody, "sha1")},
+			"X-GitHub-Event":      {"pull_request"},
+			"X-Hub-Signature-256": {test.HMACHeader(t, "secret", eventBody, "sha256")},
 		},
 		want: []pipelinev1.TaskRun{gitCloneTaskRun},
 	}, {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Fixes #1892 
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
The GitHub interceptor now only accepts SHA-256 signatures via the X-Hub-Signature-256 header and no longer supports SHA-1 signatures via X-Hub-Signature. Standard GitHub webhooks are unaffected as GitHub sends both headers by default, but custom webhook implementations must update their HMAC signature generation from SHA-1 to SHA-256 or they will receive "no X-Hub-Signature-256 header set" errors.
```
