### PR TITLE
chore: update pipelines for oracle bucket target

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: publish-triggers-release
@@ -22,12 +22,12 @@ spec:
     description: The vX.Y.Z version that the artifacts should be tagged with (including `v`)
   - name: imageRegistry
     description: The target image registry
-    default: gcr.io
+    default: ghcr.io
   - name: imageRegistryPath
     description: The path (project) in the image registry
   - name: imageRegistryRegions
     description: The target image registry regions
-    default: "us eu asia"
+    default: ""
   - name: imageRegistryUser
     description: Username to be used to login to the container registry
     default: "_json_key"

--- a/tekton/release-cheat-sheet.md
+++ b/tekton/release-cheat-sheet.md
@@ -52,17 +52,17 @@ the triggers repo, a terminal window and a text editor.
     ```bash
     tkn --context dogfooding pipeline start triggers-release \
       --param package=github.com/tektoncd/triggers \
+      --param repoName=triggers
       --param imageRegistry=ghcr.io \
       --param imageRegistryPath=tektoncd/triggers \
       --param imageRegistryRegions="" \
       --param imageRegistryUser=tekton-robot \
       --param gitRevision="${TRIGGERS_RELEASE_GIT_SHA}" \
       --param versionTag="${VERSION_TAG}" \
-      --param serviceAccountPath=release.json \
       --param serviceAccountImagesPath=credentials \
-      --param releaseBucket=gs://tekton-releases/triggers \
+      --param releaseBucket=tekton-releases \
       --param koExtraArgs="" \
-      --workspace name=release-secret,secret=release-secret \
+      --workspace name=release-secret,secret=oci-release-secret \
       --workspace name=release-images-secret,secret=ghcr-creds \
       --workspace name=workarea,volumeClaimTemplateFile=workspace-template.yaml
     ```
@@ -79,10 +79,10 @@ the triggers repo, a terminal window and a text editor.
 
    NAME                    VALUE
    commit-sha                 6ea31d92a97420d4b7af94745c45b02447ceaa19
-   release-file               https://storage.googleapis.com/tekton-releases/triggers/previous/v0.13.0/release.yaml
-   release-file-no-tag        https://storage.googleapis.com/tekton-releases/triggers/previous/v0.13.0/release.notag.yaml
-   interceptors-file          https://storage.googleapis.com/tekton-releases/triggers/previous/v0.13.0/interceptors.yaml
-   interceptors-file-no-tag   https://storage.googleapis.com/tekton-releases/triggers/previous/v0.13.0/interceptors.notag.yaml
+   release-file               https://infra.tekton.dev/tekton-releases/triggers/previous/v0.13.0/release.yaml
+   release-file-no-tag        https://infra.tekton.dev/tekton-releases/triggers/previous/v0.13.0/release.notag.yaml
+   interceptors-file          https://infra.tekton.dev/tekton-releases/triggers/previous/v0.13.0/interceptors.yaml
+   interceptors-file-no-tag   https://infra.tekton.dev/tekton-releases/triggers/previous/v0.13.0/interceptors.notag.yaml
 
    (...)
    ```
@@ -102,7 +102,7 @@ the triggers repo, a terminal window and a text editor.
     1. Find the Rekor UUID for the release
 
     ```bash
-    RELEASE_FILE=https://storage.googleapis.com/tekton-releases/triggers/previous/${VERSION_TAG}/release.yaml
+    RELEASE_FILE=https://infra.tekton.dev/tekton-releases/triggers/previous/${VERSION_TAG}/release.yaml
     CONTROLLER_IMAGE_SHA=$(curl $RELEASE_FILE | sed -n 's/"//g;s/.*ghcr\.io.*controller.*@//p;')
     REKOR_UUID=$(rekor-cli search --sha $CONTROLLER_IMAGE_SHA | grep -v Found | head -1)
     echo -e "CONTROLLER_IMAGE_SHA: ${CONTROLLER_IMAGE_SHA}\nREKOR_UUID: ${REKOR_UUID}"
@@ -137,8 +137,8 @@ the triggers repo, a terminal window and a text editor.
          ```
       1. In the section **Attestation**, modify it for inteceptors.yaml also.
          ```bash
-         RELEASE_FILE=https://storage.googleapis.com/tekton-releases/triggers/previous/${VERSION_TAG}/release.yaml
-         INTERCEPTORS_FILE=https://storage.googleapis.com/tekton-releases/triggers/previous/${VERSION_TAG}/interceptors.yaml
+         RELEASE_FILE=https://infra.tekton.dev/tekton-releases/triggers/previous/${VERSION_TAG}/release.yaml
+         INTERCEPTORS_FILE=https://infra.tekton.dev/tekton-releases/triggers/previous/${VERSION_TAG}/interceptors.yaml
          REKOR_UUID=$REKOR_UUID
 
          # Obtains the list of images with sha from the attestation
@@ -168,15 +168,15 @@ the triggers repo, a terminal window and a text editor.
 
     ```bash
     # Test latest
-    kubectl --context my-dev-cluster apply --filename https://storage.googleapis.com/tekton-releases/triggers/latest/release.yaml
-    kubectl --context my-dev-cluster apply --filename https://storage.googleapis.com/tekton-releases/triggers/latest/interceptors.yaml
+    kubectl --context my-dev-cluster apply --filename https://infra.tekton.dev/tekton-releases/triggers/latest/release.yaml
+    kubectl --context my-dev-cluster apply --filename https://infra.tekton.dev/tekton-releases/triggers/latest/interceptors.yaml
     ```
 
     ```bash
     # Test backport
-    kubectl --context my-dev-cluster apply --filename https://storage.googleapis.com/tekton-releases/triggers/previous/v0.12.1/release.yaml
+    kubectl --context my-dev-cluster apply --filename https://infra.tekton.dev/tekton-releases/triggers/previous/v0.12.1/release.yaml
     # NOTE: Some older releases might not have a separate interceptors.yaml as they used to be bundled in release.yaml
-    kubectl --context my-dev-cluster apply --filename https://storage.googleapis.com/tekton-releases/triggers/previous/v0.12.1/interceptors.yaml
+    kubectl --context my-dev-cluster apply --filename https://infra.tekton.dev/tekton-releases/triggers/previous/v0.12.1/interceptors.yaml
     ```
 
 1. For major releases, the [website sync configuration](https://github.com/tektoncd/website/blob/main/sync/config/triggers.yaml)
@@ -192,7 +192,7 @@ Congratulations, you're done!
    [the dogfooding cluster](https://github.com/tektoncd/plumbing/blob/main/docs/dogfooding.md):
 
     ```bash
-    gcloud container clusters get-credentials dogfooding --zone us-central1-a --project tekton-releases
+    oci ce cluster create-kubeconfig --cluster-id <CLUSTER-OCID> --file $HOME/.kube/config --region <CLUSTER-REGION> --token-version 2.0.0  --kube-endpoint PUBLIC_ENDPOINT
     ```
 
 1. Give [the context](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: triggers-release
@@ -8,17 +8,20 @@ spec:
   - name: package
     description: package to release
     default: github.com/tektoncd/triggers
+  - name: repoName
+    description: repository name (e.g., pipeline, triggers, etc.)
+    default: triggers
   - name: gitRevision
     description: the git revision to release
   - name: imageRegistry
     description: The target image registry
-    default: gcr.io
+    default: ghcr.io
   - name: imageRegistryPath
     description: The path (project) in the image registry
     default: tekton-releases
   - name: imageRegistryRegions
     description: The target image registry regions
-    default: "us eu asia"
+    default: ""  # Empty for GHCR, "us eu asia" for GCR
   - name: imageRegistryUser
     description: The user for the image registry credentials
     default: _json_key
@@ -26,7 +29,7 @@ spec:
     description: The X.Y.Z version that the artifacts should be tagged with
   - name: releaseBucket
     description: bucket where the release is stored. The bucket must be project specific.
-    default: gs://tekton-releases-nightly/triggers
+    default: tekton-nightly
   - name: releaseAsLatest
     description: Whether to tag and publish this release as Triggers' latest
     default: "true"
@@ -36,8 +39,6 @@ spec:
   - name: koExtraArgs
     description: Extra args to be passed to ko
     default: "--preserve-import-paths"
-  - name: serviceAccountPath
-    description: The path to the service account file within the release-secret workspace
   - name: serviceAccountImagesPath
     description: The path to the service account file or credentials within the release-images-secret workspace
   - name: runTests
@@ -69,45 +70,47 @@ spec:
   tasks:
   - name: git-clone
     taskRef:
-      resolver: hub
+      resolver: bundles
       params:
+        - name: bundle
+          value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
         - name: name
           value: git-clone
-        - name: version
-          value: "0.7"
+        - name: kind
+          value: task
     workspaces:
-    - name: output
-      workspace: workarea
-      subPath: git
+      - name: output
+        workspace: workarea
+        subPath: git
     params:
-    - name: url
-      value: https://$(params.package)
-    - name: revision
-      value: $(params.gitRevision)
-  - name: prerelease-precheck
+      - name: url
+        value: https://$(params.package)
+      - name: revision
+        value: $(params.gitRevision)
+
+  - name: precheck
     runAfter: [git-clone]
     taskRef:
       resolver: git
       params:
-        - name: repo
-          value: plumbing
-        - name: org
-          value: tektoncd
+        - name: url
+          value: https://github.com/tektoncd/plumbing
         - name: revision
           value: aeed19e5a36f335ebfdc4b96fa78d1ce5bb4f7b8
         - name: pathInRepo
           value: tekton/resources/release/base/prerelease_checks.yaml
     params:
-    - name: package
-      value: $(params.package)
-    - name: versionTag
-      value: $(params.versionTag)
-    - name: releaseBucket
-      value: $(params.releaseBucket)
+      - name: package
+        value: $(params.package)
+      - name: versionTag
+        value: $(params.versionTag)
+      - name: releaseBucket
+        value: $(params.releaseBucket)
     workspaces:
-    - name: source-to-release
-      workspace: workarea
-      subPath: git
+      - name: source-to-release
+        workspace: workarea
+        subPath: git
+
   - name: unit-tests
     runAfter: [prerelease-precheck]
     when:
@@ -130,6 +133,7 @@ spec:
     - name: source
       workspace: workarea
       subPath: git
+
   - name: build
     runAfter: [prerelease-precheck]
     when:
@@ -152,6 +156,7 @@ spec:
     - name: source
       workspace: workarea
       subPath: git
+
   - name: publish-images
     runAfter: [build, unit-tests]
     taskRef:
@@ -195,60 +200,71 @@ spec:
       subPath: bucket
     - name: release-secret
       workspace: release-images-secret
+
   - name: publish-to-bucket
     runAfter: [publish-images]
     taskRef:
       resolver: bundles
       params:
         - name: bundle
-          value: ghcr.io/tektoncd/catalog/upstream/tasks/gcs-upload:0.3
+          value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.1
         - name: name
-          value: gcs-upload
+          value: oracle-cloud-storage-upload
         - name: kind
           value: task
     workspaces:
-    - name: credentials
-      workspace: release-secret
-    - name: source
-      workspace: workarea
-      subPath: bucket
+      - name: credentials
+        workspace: release-secret
+      - name: source
+        workspace: workarea
+        subPath: bucket
     params:
-    - name: location
-      value: $(params.releaseBucket)/previous/$(params.versionTag)
-    - name: path
-      value: $(params.versionTag)
-    - name: serviceAccountPath
-      value: $(params.serviceAccountPath)
+      - name: path
+        value: $(params.versionTag)
+      - name: bucketName
+        value: $(params.releaseBucket)
+      - name: objectPrefix
+        value: $(params.repoName)/previous/$(params.versionTag)/
+      - name: replaceExistingFiles
+        value: "true"
+      - name: recursive
+        value: "true"
+
   - name: publish-to-bucket-latest
     runAfter: [publish-images]
     when:
-    - input: "$(params.releaseAsLatest)"
-      operator: in
-      values: ["true"]
+      - input: "$(params.releaseAsLatest)"
+        operator: in
+        values: ["true"]
     taskRef:
       resolver: bundles
       params:
         - name: bundle
-          value: ghcr.io/tektoncd/catalog/upstream/tasks/gcs-upload:0.3
+          value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.1
         - name: name
-          value: gcs-upload
+          value: oracle-cloud-storage-upload
         - name: kind
           value: task
     workspaces:
-    - name: credentials
-      workspace: release-secret
-    - name: source
-      workspace: workarea
-      subPath: bucket
+      - name: credentials
+        workspace: release-secret
+      - name: source
+        workspace: workarea
+        subPath: bucket
     params:
-    - name: location
-      value: $(params.releaseBucket)/latest
-    - name: path
-      value: $(params.versionTag)
-    - name: serviceAccountPath
-      value: $(params.serviceAccountPath)
-    - name: deleteExtraFiles
-      value: "true"  # Uses rsync to copy content into latest
+      - name: path
+        value: $(params.versionTag)
+      - name: bucketName
+        value: $(params.releaseBucket)
+      - name: objectPrefix
+        value: $(params.repoName)/latest/
+      - name: replaceExistingFiles
+        value: "true"
+      - name: recursive
+        value: "true"
+      - name: deleteExtraFiles
+        value: "true"  # Uses sync to copy content into latest
+
   - name: report-bucket
     runAfter: [publish-to-bucket]
     params:
@@ -277,10 +293,12 @@ spec:
             value: $(params.releaseBucket)
           - name: VERSION_TAG
             value: $(params.versionTag)
+          - name: REPO_NAME
+            value: $(params.repoName)
         script: |
-          BASE_URL=$(echo "${RELEASE_BUCKET}/previous/${VERSION_TAG}")
-          # If the bucket is in the gs:// return the corresponding public https URL
-          BASE_URL=$(echo ${BASE_URL} | sed 's,gs://,https://storage.googleapis.com/,g')
+          # Oracle Cloud Storage: Construct public URL
+          # Format: https://infra.tekton.dev/<releaseBucket>/<repoName>/previous/<versionTag>
+          BASE_URL="https://infra.tekton.dev/${RELEASE_BUCKET}/${REPO_NAME}/previous/${VERSION_TAG}"
           echo "${BASE_URL}/release.yaml" > $(results.release.path)
           echo "${BASE_URL}/release.notags.yaml" > $(results.release-no-tag.path)
           echo "${BASE_URL}/interceptors.yaml" > $(results.interceptors.path)


### PR DESCRIPTION
# Changes

This pull request updates the Tekton Triggers release pipeline and documentation to migrate publishing from Google Cloud Storage (GCS) to Oracle Cloud Infrastructure (OCI) Object Storage, It also updates the pipeline to use new OCI-compatible upload tasks, updates URLs throughout the documentation, and makes several parameter and task improvements for consistency and clarity.

* Changed default image registry from `gcr.io` to `ghcr.io` and default image registry regions from `"us eu asia"` to `""` in both `tekton/publish.yaml` and `tekton/release-pipeline.yaml`.
* Updated release bucket and public artifact URLs from GCS (`gs://tekton-releases...` and `https://storage.googleapis.com/...`) to OCI (`tekton-releases`, `https://infra.tekton.dev/...`) and updated all relevant documentation and scripts to use the new URLs.
* Replaced GCS upload tasks with OCI upload tasks (
* Added a `repoName` parameter to the pipeline to support new task mandates
* Removed or updated obsolete parameters (e.g., `serviceAccountPath`) and clarified parameter defaults and descriptions for the new cloud environment.
* Updated Tekton API versions from `v1beta1` to `v1` for both `Task` and `Pipeline` resources to use the latest stable APIs. 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
/kind misc