### PR TITLE
feat: add cherry-pick slash command workflow

### DIFF
--- a/.github/workflows/cherry-pick-command.yaml
+++ b/.github/workflows/cherry-pick-command.yaml
@@ -1,0 +1,32 @@
+# Cherry Pick Command Workflow
+#
+# This workflow is triggered by the /cherry-pick slash command from the slash.yml workflow.
+# It automatically cherry-picks merged PRs to the specified target branches.
+#
+# Usage: Comment `/cherry-pick <target-branch> [<target-branch> ...]` on a merged pull request
+# Example: `/cherry-pick release-v0.34.x`
+# Example: `/cherry-pick release-v0.34.x release-v0.35.x`
+#
+# Security Notes:
+# - Only users with "write" permission can trigger this command (enforced in slash.yml)
+# - Works safely with PRs from forks because it only cherry-picks already-merged commits
+# - Uses CHATOPS_TOKEN to create PRs and push to branches
+# - The action creates a new branch from the target branch, not from the fork
+
+name: Cherry Pick Command
+
+on:
+  repository_dispatch:
+    types: [cherry-pick-command]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  cherry-pick:
+    name: Cherry Pick Actions
+    uses: tektoncd/plumbing/.github/workflows/_cherry-pick-command.yaml@4b57443b85569e5bb7d9ee440bf5cae99cb642cb
+    secrets:
+      CHATOPS_TOKEN: ${{ secrets.CHATOPS_TOKEN }}

--- a/.github/workflows/slash.yml
+++ b/.github/workflows/slash.yml
@@ -13,5 +13,5 @@ jobs:
     permissions:
       issues: write # for peter-evans/slash-command-dispatch to create issue reaction
       pull-requests: write # for peter-evans/slash-command-dispatch to create PR reaction
-    uses: tektoncd/plumbing/.github/workflows/_slash.yml@48c53b4e7f1e0bb206575b80eb9fcf07b5854907
+    uses: tektoncd/plumbing/.github/workflows/_slash.yml@4b57443b85569e5bb7d9ee440bf5cae99cb642cb
     secrets: inherit


### PR DESCRIPTION
# Changes

This PR adds the cherry-pick slash command workflow to triggers (addresses tektoncd/plumbing#3004).

**What's included:**
- New `slash.yml` workflow to enable slash commands on PRs
- New `cherry-pick-command.yaml` workflow using the centralized plumbing reusable workflow
- Enables `/cherry-pick <branch>` command for easier backports to release branches

**Benefits:**
- Streamlines cherry-picking to release branches with simple slash command
- Uses centralized, well-tested logic from tektoncd/plumbing
- Consistent behavior with other tektoncd repositories
- Reduces manual cherry-pick errors

**Usage:**
Comment `/cherry-pick release-v0.34.x` on a merged PR to automatically create a cherry-pick PR to that branch.

# Submitter Checklist

- [x] Includes tests (N/A - workflow files only)
- [x] Includes docs (comprehensive inline documentation in workflow files)
- [x] Commit messages follow commit message best practices

# Release Notes

```release-note
NONE
```