### PR TITLE
Change precheck in release pipeline to OCI infra

### DIFF
--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -96,9 +96,9 @@ spec:
         - name: url
           value: https://github.com/tektoncd/plumbing
         - name: revision
-          value: aeed19e5a36f335ebfdc4b96fa78d1ce5bb4f7b8
+          value: b5d215c1d28fa64a89c568fac38f88f5c62d7e96
         - name: pathInRepo
-          value: tekton/resources/release/base/prerelease_checks.yaml
+          value: tekton/resources/release/base/prerelease_checks_oci.yaml
     params:
       - name: package
         value: $(params.package)
@@ -110,6 +110,8 @@ spec:
       - name: source-to-release
         workspace: workarea
         subPath: git
+      - name: oci-credentials
+        workspace: release-secret
 
   - name: unit-tests
     runAfter: [precheck]


### PR DESCRIPTION
Precheck in release pipeline was based on gcs. This move it to OCI infra.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
