### PR TITLE
Update Release Cheat Sheet for release-draft-oci pipeline

### DIFF
--- a/tekton/release-cheat-sheet.md
+++ b/tekton/release-cheat-sheet.md
@@ -108,24 +108,33 @@ the triggers repo, a terminal window and a text editor.
     echo -e "CONTROLLER_IMAGE_SHA: ${CONTROLLER_IMAGE_SHA}\nREKOR_UUID: ${REKOR_UUID}"
     ```
 
+    1. Create a pod template file to ensure correct permissions for OCI CLI:
+
+    ```bash
+    cat <<EOF > pod-template.yaml
+    securityContext:
+      fsGroup: 65532
+      runAsNonRoot: true
+      runAsUser: 65532
+    EOF
+    ```
+
     1. Execute the Draft Release task.
 
     ```bash
     tkn --context dogfooding pipeline start \
         --workspace name=shared,volumeClaimTemplateFile=workspace-template.yaml \
         --workspace name=credentials,secret=oci-release-secret \
+        --pod-template pod-template.yaml \
         -p package="${TEKTON_PACKAGE}" \
+        -p repo-name="triggers" \
         -p git-revision="${TRIGGERS_RELEASE_GIT_SHA}" \
         -p release-tag="${VERSION_TAG}" \
         -p previous-release-tag="${TRIGGERS_OLD_VERSION}" \
         -p release-name="Tekton Triggers" \
-        -p bucket="tekton-releases/triggers" \
+        -p bucket="tekton-releases" \
         -p rekor-uuid="$REKOR_UUID" \
-        release-draft
-    ```
-    ```bash
-    NOTE: `release-draft` pipeline is for GCS we need to replace this with the OCI pipeline once its present on the Oracle cluster
-    TODO #savita will change this as soon as Pipeline is available and update the readme and remove this note       
+        release-draft-oci
     ```
 
     1. Watch logs of create-draft-release


### PR DESCRIPTION
This updates the document to use release-draft-oci instead of older release-draft (gcs).

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
