### PR TITLE
fix: release cheat sheet doc typos

### DIFF
--- a/tekton/release-cheat-sheet.md
+++ b/tekton/release-cheat-sheet.md
@@ -80,9 +80,9 @@ the triggers repo, a terminal window and a text editor.
    NAME                    VALUE
    commit-sha                 6ea31d92a97420d4b7af94745c45b02447ceaa19
    release-file               https://infra.tekton.dev/tekton-releases/triggers/previous/v0.13.0/release.yaml
-   release-file-no-tag        https://infra.tekton.dev/tekton-releases/triggers/previous/v0.13.0/release.notag.yaml
+   release-file-no-tag        https://infra.tekton.dev/tekton-releases/triggers/previous/v0.13.0/release.notags.yaml
    interceptors-file          https://infra.tekton.dev/tekton-releases/triggers/previous/v0.13.0/interceptors.yaml
-   interceptors-file-no-tag   https://infra.tekton.dev/tekton-releases/triggers/previous/v0.13.0/interceptors.notag.yaml
+   interceptors-file-no-tag   https://infra.tekton.dev/tekton-releases/triggers/previous/v0.13.0/interceptors.notags.yaml
 
    (...)
    ```
@@ -134,7 +134,15 @@ the triggers repo, a terminal window and a text editor.
         -p release-name="Tekton Triggers" \
         -p bucket="tekton-releases" \
         -p rekor-uuid="$REKOR_UUID" \
+<<<<<<< HEAD
         release-draft-oci
+=======
+        release-draft
+    ```
+    ```bash
+    NOTE: `release-draft` pipeline is for GCS we need to replace this with the OCI pipeline once its present on the Oracle cluster
+    TODO #savita will change this as soon as Pipeline is available and update the readme and remove this note
+>>>>>>> c0600bdf (fix: doc typos)
     ```
 
     1. Watch logs of create-draft-release
@@ -144,7 +152,7 @@ the triggers repo, a terminal window and a text editor.
       1. Double-check that the list of commits here matches your expectations
          for the release. You might need to remove incorrect commits or copy/paste commits
          from the release branch. Refer to previous releases to confirm the expected format.
-      1. In the section **Installation one-liner**, add the install instruction for interceptors also. 
+      1. In the section **Installation one-liner**, add the install instruction for interceptors also.
          ```bash
             kubectl apply -f https://infra.tekton.dev/tekton-releases/triggers/previous/${VERSION_TAG}/interceptors.yaml
          ```


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
fixed typo  in `release-cheat-sheet.md` and removed unnecessary indentations.
OLD: "notag"
NEW: "notags"
the old "notag" is a typo that simply leads nowhere, as the path `https://infra.tekton.dev/tekton-releases/chains/previous/v0.13.0/release.notag.yaml` simply doesn't exist

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
