### PR TITLE
ci: add CI summary fan-in job for branch protection

### DIFF
--- a/.github/workflows/presubmit-ci.yaml
+++ b/.github/workflows/presubmit-ci.yaml
@@ -192,3 +192,29 @@ jobs:
       - name: Run Build Tests
         working-directory: ${{ github.workspace }}/src/github.com/tektoncd/triggers
         run: ./test/presubmit-tests.sh --build-tests
+
+  ci-summary:
+    # This job serves as a single required check for branch protection rules.
+    # It fans in all CI jobs and reports an overall pass/fail status, treating
+    # both "success" and "skipped" as passing (e.g. when tests are skipped for
+    # non-members without /ok-to-test).
+    name: CI summary
+    if: always()
+    needs:
+      - prepare-pr-check
+      - unit-tests
+      - integration-tests
+      - build-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check results
+        run: |
+          results="${{ needs.prepare-pr-check.result }} ${{ needs.unit-tests.result }} ${{ needs.integration-tests.result }} ${{ needs.build-tests.result }}"
+          echo "Job results: $results"
+          for r in $results; do
+            if [[ "$r" != "success" && "$r" != "skipped" ]]; then
+              echo "One or more jobs failed or were cancelled."
+              exit 1
+            fi
+          done
+          echo "All jobs passed or were skipped."


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add a `ci-summary` fan-in job to the presubmit CI workflow that depends
on all CI jobs (`prepare-pr-check`, `unit-tests`, `integration-tests`,
`build-tests`). This provides a single check for branch protection rules.

The job runs with `if: always()` and treats both `success` and
`skipped` as passing states, so PRs from non-members (where tests are
skipped) or docs-only changes still pass correctly.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```