### PR TITLE
ci: Fix zizmor security findings in GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     labels:
     - "ok-to-test"
     - "dependencies"
@@ -22,6 +24,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     labels:
     - "ok-to-test"
     - "dependencies"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,6 @@ defaults:
 
 permissions:
   contents: read
-  checks: write # Used to annotate code in the PR
 
 jobs:
   changes:
@@ -24,16 +23,23 @@ jobs:
     steps:
     - name: Get base depth
       id: base-depth
-      run: echo "base-depth=$(expr ${{ github.event.pull_request.commits }} + 1)" >> $GITHUB_OUTPUT
+      env:
+        PR_COMMITS: ${{ github.event.pull_request.commits }}
+      run: echo "base-depth=$(expr "${PR_COMMITS}" + 1)" >> $GITHUB_OUTPUT
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: ${{ steps.base-depth.outputs.base-depth }}
+        persist-credentials: false
     - name: detect
       id: detect
+      env:
+        GITHUB_BASE_REF_NAME: ${{ github.base_ref }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
-        git fetch origin ${{ github.base_ref }}
-        CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} | tr ' ' '\n')
+        git fetch origin "${GITHUB_BASE_REF_NAME}"
+        CHANGED_FILES=$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" | tr ' ' '\n')
 
         echo -e "Changed files:\n${CHANGED_FILES}"
 
@@ -66,6 +72,8 @@ jobs:
     if: ${{ needs.changes.outputs.non-docs == 'true' }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        persist-credentials: false
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
       with:
         go-version-file: "go.mod"
@@ -76,10 +84,14 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     needs: [changes]
+    permissions:
+      contents: read
+      checks: write # Used by golangci-lint-action to annotate code in the PR
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         fetch-depth: 0
+        persist-credentials: false
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
       with:
         go-version-file: "go.mod"
@@ -113,6 +125,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        persist-credentials: false
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
       with:
         go-version-file: "go.mod"
@@ -125,6 +139,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        persist-credentials: false
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
       with:
         go-version-file: "go.mod"
@@ -139,6 +155,8 @@ jobs:
       KOCACHE: /tmp/ko-cache
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        persist-credentials: false
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
       with:
         go-version-file: "go.mod"
@@ -165,14 +183,21 @@ jobs:
     if: always()
     steps:
     - name: Check CI results
+      env:
+        BUILD: ${{ needs.build.result }}
+        LINTING: ${{ needs.linting.result }}
+        TESTS: ${{ needs.tests.result }}
+        GENERATED: ${{ needs.generated.result }}
+        MULTI_ARCH_BUILD: ${{ needs.multi-arch-build.result }}
+        E2E_TESTS: ${{ needs.e2e-tests.result }}
       run: |
         results=(
-          "build=${{ needs.build.result }}"
-          "linting=${{ needs.linting.result }}"
-          "tests=${{ needs.tests.result }}"
-          "generated=${{ needs.generated.result }}"
-          "multi-arch-build=${{ needs.multi-arch-build.result }}"
-          "e2e-tests=${{ needs.e2e-tests.result }}"
+          "build=${BUILD}"
+          "linting=${LINTING}"
+          "tests=${TESTS}"
+          "generated=${GENERATED}"
+          "multi-arch-build=${MULTI_ARCH_BUILD}"
+          "e2e-tests=${E2E_TESTS}"
         )
         failed=0
         for r in "${results[@]}"; do

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,14 +20,20 @@ on:
   schedule:
     - cron: '30 20 * * 2'
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
-      actions: read
+      actions: read # Required by CodeQL to read workflow information
       contents: read
-      security-events: write
+      security-events: write # Required to upload CodeQL SARIF results
 
     strategy:
       fail-fast: false
@@ -39,6 +45,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -24,6 +24,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
@@ -55,7 +57,7 @@ jobs:
         run: |
           ./test/setup-kind.sh \
             --registry-url $(echo ${KO_DOCKER_REPO} | cut -d'/' -f 1) \
-            --cluster-suffix c${{ github.run_id }}.local \
+            --cluster-suffix "${CLUSTER_DOMAIN}" \
             --nodes 3 \
             --k8s-version v1.29.x \
             --e2e-script ./test/gh-e2e-tests.sh \

--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -26,7 +26,7 @@ jobs:
     name: Go coverage
     runs-on: ubuntu-24.04
     permissions:
-      pull-requests: write
+      pull-requests: write # Required by go-coverage-report to comment on PRs
 
     steps:
       - name: Harden runner
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: ${{ github.workspace }}/src/github.com/tektoncd/triggers
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0

--- a/.github/workflows/microshift.yaml
+++ b/.github/workflows/microshift.yaml
@@ -2,7 +2,6 @@ name: Integration Tests on microshift
 
 permissions:
   contents: read
-  packages: write
 
 on:
   push:
@@ -42,10 +41,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: ${{ github.workspace }}/src/github.com/tektoncd/triggers
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
+          cache: false
           cache-dependency-path: "${{ github.workspace }}/src/github.com/tektoncd/triggers/go.sum"
           go-version-file: "${{ github.workspace }}/src/github.com/tektoncd/triggers/go.mod"
 
@@ -88,7 +89,7 @@ jobs:
           curl https://infra.tekton.dev/tekton-releases/pipeline/latest/release.yaml | yq 'del(.spec.template.spec.containers[]?.securityContext.runAsUser, .spec.template.spec.containers[]?.securityContext.runAsGroup)' > release
           export RELEASE_YAML=$(realpath release)
 
-          ${{ github.workspace }}/src/github.com/tektoncd/triggers/test/gh-e2e-tests.sh
+          "${GOPATH}/src/github.com/tektoncd/triggers/test/gh-e2e-tests.sh"
 
       - name: Upload test results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,28 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required to upload SARIF results
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

Fix security findings reported by [zizmor](https://docs.zizmor.sh/) v1.24.1,
a static analysis tool for GitHub Actions, and add zizmor as a CI check.

Ref: [tektoncd/pipeline#9667](https://github.com/tektoncd/pipeline/pull/9667).

Closes #1982

- Add `.github/workflows/zizmor.yaml` that runs on pushes to main and all PRs
- Uses `zizmorcore/zizmor-action` to upload SARIF results to GitHub Advanced Security


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
