### PR TITLE
Fix intermittent panic in Test_UpdateCACertToClusterInterceptorCRD

### DIFF
--- a/pkg/interceptors/server/server_test.go
+++ b/pkg/interceptors/server/server_test.go
@@ -416,7 +416,7 @@ func Test_UpdateCACertToClusterInterceptorCRD(t *testing.T) {
 		t.Error(err)
 	}
 
-	stopFunc := UpdateCACertToClusterInterceptorCRD(ctx, server, faketriggersclient.Get(ctx).TriggersV1alpha1(), logger.Sugar(), time.Second)
+	stopFunc := UpdateCACertToClusterInterceptorCRD(ctx, server, faketriggersclient.Get(ctx).TriggersV1alpha1(), zap.NewNop().Sugar(), time.Second)
 	defer stopFunc()
 
 	time.Sleep(10 * time.Second)


### PR DESCRIPTION
The background goroutine in UpdateCACertToClusterInterceptorCRD could log after the test completed, since stopFunc() closes the done channel without waiting for the goroutine to exit. Go 1.25 panics when a goroutine logs to a zaptest logger after its test has finished.

Fix by passing zap.NewNop() to the function so post-test logging from the background goroutine is a no-op.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
