### PR TITLE
Fix e2e failure due to owners file change

### DIFF
--- a/examples/v1beta1/github-owners/curl.sh
+++ b/examples/v1beta1/github-owners/curl.sh
@@ -1,6 +1,6 @@
 curl -v \
 -H 'X-GitHub-Event: pull_request' \
--H 'X-Hub-Signature-256: sha256=a7b3a3840860ef271afde557e8b6c89cc69539a396417f93d847e1890d3c8184' \
+-H 'X-Hub-Signature-256: sha256=407de896d43ea3605e0e897112493c5f81eb052bff0b48783f7dfa264e3dceae' \
 -H 'Content-Type: application/json' \
--d '{"action": "opened","number": 1503,"repository":{"full_name": "tektoncd/triggers", "clone_url": "https://github.com/tektoncd/triggers.git"}, "sender":{"login": "dibyom"}}' \
+-d '{"action": "opened","number": 1503,"repository":{"full_name": "tektoncd/triggers", "clone_url": "https://github.com/tektoncd/triggers.git"}, "sender":{"login": "khrm"}}' \
 http://localhost:8080


### PR DESCRIPTION
The GitHub owner's example test is failing due to a change in owner.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
