### PR TITLE
Change release pipeline to use 'release-draft-oci'

### DIFF
--- a/tekton/release-cheat-sheet.md
+++ b/tekton/release-cheat-sheet.md
@@ -134,15 +134,7 @@ the triggers repo, a terminal window and a text editor.
         -p release-name="Tekton Triggers" \
         -p bucket="tekton-releases" \
         -p rekor-uuid="$REKOR_UUID" \
-<<<<<<< HEAD
         release-draft-oci
-=======
-        release-draft
-    ```
-    ```bash
-    NOTE: `release-draft` pipeline is for GCS we need to replace this with the OCI pipeline once its present on the Oracle cluster
-    TODO #savita will change this as soon as Pipeline is available and update the readme and remove this note
->>>>>>> c0600bdf (fix: doc typos)
     ```
 
     1. Watch logs of create-draft-release


### PR DESCRIPTION
Updated the release pipeline from 'release-draft' to 'release-draft-oci' and removed the related note about GCS.

This was re-added due to commit:  https://github.com/tektoncd/triggers/commit/88493b0e9ce4957737587268dd9f7597cb814b57

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
