### PR TITLE
Add PAC release automation

### DIFF
--- a/.github/workflows/patch-release.yaml
+++ b/.github/workflows/patch-release.yaml
@@ -1,0 +1,192 @@
+name: Patch Release
+
+"on":
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Release branch (e.g. release-v0.36.x)"
+        required: true
+        type: string
+      version:
+        description: "Version to release (e.g. v0.36.1)"
+        required: true
+        type: string
+      release_as_latest:
+        description: "Publish as latest release"
+        required: false
+        type: boolean
+        default: true
+  schedule:
+    # Weekly on Thursday at 10:00 UTC
+    - cron: "0 10 * * 4"
+
+permissions: {}
+
+env:
+  PAC_CONTROLLER_URL: "https://pac.infra.tekton.dev"
+  PAC_REPOSITORY_NAME: "tektoncd-triggers"
+  # Ignore release branches older than this (major.minor)
+  MIN_RELEASE_VERSION: "0.26"
+
+jobs:
+  scan-release-branches:
+    name: Scan for unreleased commits
+    if: github.event_name == 'schedule' && github.repository_owner == 'tektoncd'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.scan.outputs.matrix }}
+      has_releases: ${{ steps.scan.outputs.has_releases }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Scan release branches for new commits
+        id: scan
+        run: |
+          # Determine which release branch is the latest (highest version)
+          latest_branch=""
+          latest_major=0
+          latest_minor=0
+          for ref in $(git branch -r --list 'origin/release-v*'); do
+            branch="${ref#origin/}"
+            # Extract major.minor from release-vX.Y.x
+            if [[ "$branch" =~ release-v([0-9]+)\.([0-9]+)\.x ]]; then
+              major="${BASH_REMATCH[1]}"
+              minor="${BASH_REMATCH[2]}"
+              if [ "$major" -gt "$latest_major" ] || { [ "$major" -eq "$latest_major" ] && [ "$minor" -gt "$latest_minor" ]; }; then
+                latest_major=$major
+                latest_minor=$minor
+                latest_branch=$branch
+              fi
+            fi
+          done
+          echo "::notice::Latest release branch: ${latest_branch}"
+
+          MIN_MAJOR="${MIN_RELEASE_VERSION%%.*}"
+          MIN_MINOR="${MIN_RELEASE_VERSION##*.}"
+
+          releases=()
+          for ref in $(git branch -r --list 'origin/release-v*'); do
+            branch="${ref#origin/}"
+
+            # Skip branches older than MIN_RELEASE_VERSION
+            if [[ "$branch" =~ release-v([0-9]+)\.([0-9]+)\.x ]]; then
+              major="${BASH_REMATCH[1]}"
+              minor="${BASH_REMATCH[2]}"
+              if [ "$major" -lt "$MIN_MAJOR" ] || { [ "$major" -eq "$MIN_MAJOR" ] && [ "$minor" -lt "$MIN_MINOR" ]; }; then
+                echo "::notice::Branch ${branch} is older than v${MIN_RELEASE_VERSION} — skipping"
+                continue
+              fi
+            fi
+
+            # Find the latest tag on this branch
+            last_tag=$(git describe --tags --abbrev=0 --match 'v*' "$ref" 2>/dev/null || echo "")
+            if [ -z "$last_tag" ]; then
+              echo "::notice::Branch ${branch} has no tags — skipping (initial release handled by branch creation)"
+              continue
+            fi
+
+            # Count commits since last tag
+            new_commits=$(git rev-list "${last_tag}..${ref}" --count)
+            if [ "$new_commits" -eq 0 ]; then
+              echo "::notice::Branch ${branch} has no new commits since ${last_tag}"
+              continue
+            fi
+
+            # Calculate next patch version: v0.36.0 → v0.36.1
+            next_version=$(echo "$last_tag" | awk -F. '{printf "%s.%s.%d", $1, $2, $3+1}')
+
+            # Only the latest release branch publishes as latest
+            is_latest="false"
+            if [ "$branch" = "$latest_branch" ]; then
+              is_latest="true"
+            fi
+
+            echo "::notice::Branch ${branch}: ${new_commits} new commits since ${last_tag} → ${next_version} (latest=${is_latest})"
+            releases+=("{\"branch\":\"${branch}\",\"version\":\"${next_version}\",\"release_as_latest\":\"${is_latest}\"}")
+          done
+
+          if [ ${#releases[@]} -eq 0 ]; then
+            echo "matrix=[]" >> "$GITHUB_OUTPUT"
+            echo "has_releases=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "matrix=[$(IFS=,; echo "${releases[*]}")]" >> "$GITHUB_OUTPUT"
+            echo "has_releases=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  trigger-scanned-releases:
+    name: "Trigger ${{ matrix.release.version }} (${{ matrix.release.branch }})"
+    needs: scan-release-branches
+    if: needs.scan-release-branches.outputs.has_releases == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        release: ${{ fromJson(needs.scan-release-branches.outputs.matrix) }}
+      max-parallel: 1
+    steps:
+      - name: Trigger PAC incoming webhook
+        env:
+          PAC_INCOMING_SECRET: ${{ secrets.PAC_INCOMING_SECRET }}
+          RELEASE_BRANCH: ${{ matrix.release.branch }}
+          RELEASE_VERSION: ${{ matrix.release.version }}
+          RELEASE_AS_LATEST: ${{ matrix.release.release_as_latest }}
+        run: |
+          echo "::notice::Triggering release ${RELEASE_VERSION} on ${RELEASE_BRANCH} (latest=${RELEASE_AS_LATEST})"
+          curl -sf -X POST "${PAC_CONTROLLER_URL}/incoming" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "repository": "'"${PAC_REPOSITORY_NAME}"'",
+              "branch": "'"${RELEASE_BRANCH}"'",
+              "pipelinerun": "release-patch",
+              "secret": "'"${PAC_INCOMING_SECRET}"'",
+              "params": {
+                "version": "'"${RELEASE_VERSION}"'",
+                "release_as_latest": "'"${RELEASE_AS_LATEST}"'"
+              }
+            }'
+          echo "✅ Release triggered successfully"
+
+  trigger-manual-release:
+    name: "Trigger ${{ inputs.version }} (${{ inputs.branch }})"
+    if: github.event_name == 'workflow_dispatch' && github.repository_owner == 'tektoncd'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate inputs
+        env:
+          INPUT_BRANCH: ${{ inputs.branch }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          # Validate branch format
+          if [[ ! "${INPUT_BRANCH}" =~ ^release-v[0-9]+\.[0-9]+\.x$ ]]; then
+            echo "::error::Invalid branch format: ${INPUT_BRANCH}. Expected: release-vX.Y.x"
+            exit 1
+          fi
+          # Validate version format
+          if [[ ! "${INPUT_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format: ${INPUT_VERSION}. Expected: vX.Y.Z"
+            exit 1
+          fi
+
+      - name: Trigger PAC incoming webhook
+        env:
+          PAC_INCOMING_SECRET: ${{ secrets.PAC_INCOMING_SECRET }}
+          INPUT_BRANCH: ${{ inputs.branch }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_RELEASE_AS_LATEST: ${{ inputs.release_as_latest }}
+        run: |
+          echo "::notice::Triggering release ${INPUT_VERSION} on ${INPUT_BRANCH} (latest=${INPUT_RELEASE_AS_LATEST})"
+          curl -sf -X POST "${PAC_CONTROLLER_URL}/incoming" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "repository": "'"${PAC_REPOSITORY_NAME}"'",
+              "branch": "'"${INPUT_BRANCH}"'",
+              "pipelinerun": "release-patch",
+              "secret": "'"${PAC_INCOMING_SECRET}"'",
+              "params": {
+                "version": "'"${INPUT_VERSION}"'",
+                "release_as_latest": "'"${INPUT_RELEASE_AS_LATEST}"'"
+              }
+            }'
+          echo "✅ Release triggered successfully"

--- a/.tekton/release-patch.yaml
+++ b/.tekton/release-patch.yaml
@@ -1,0 +1,81 @@
+# Copyright 2026 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This PipelineRun is triggered via PAC incoming webhooks for patch
+# releases on existing release branches. It is invoked either manually
+# (via GitHub Actions workflow_dispatch) or on a cron schedule when
+# new commits are detected on a release branch since the last tag.
+#
+# The version and release_as_latest parameters are passed dynamically
+# through the incoming webhook payload.
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: release-patch
+  annotations:
+    pipelinesascode.tekton.dev/on-event: "[incoming]"
+    pipelinesascode.tekton.dev/on-target-branch: "[release-v*]"
+    pipelinesascode.tekton.dev/pipeline: "tekton/release-pipeline.yaml"
+    pipelinesascode.tekton.dev/max-keep-runs: "5"
+spec:
+  taskRunTemplate:
+    serviceAccountName: release
+  pipelineRef:
+    name: triggers-release
+  params:
+    - name: package
+      value: github.com/tektoncd/triggers
+    - name: repoName
+      value: triggers
+    - name: gitRevision
+      value: "{{ revision }}"
+    - name: imageRegistry
+      value: ghcr.io
+    - name: imageRegistryPath
+      value: tektoncd/triggers
+    - name: imageRegistryRegions
+      value: ""
+    - name: imageRegistryUser
+      value: tekton-robot
+    - name: versionTag
+      value: "{{ version }}"
+    - name: releaseBucket
+      value: tekton-releases
+    - name: releaseAsLatest
+      value: "{{ release_as_latest }}"
+    - name: platforms
+      value: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,windows/amd64
+    - name: koExtraArgs
+      value: "--preserve-import-paths"
+    - name: serviceAccountImagesPath
+      value: credentials
+    - name: runTests
+      value: "true"
+  timeouts:
+    pipeline: 3h0m0s
+  workspaces:
+    - name: workarea
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+    - name: release-secret
+      secret:
+        secretName: oci-release-secret
+    - name: release-images-secret
+      secret:
+        secretName: ghcr-creds

--- a/.tekton/release.yaml
+++ b/.tekton/release.yaml
@@ -1,0 +1,90 @@
+# Copyright 2026 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This PipelineRun is triggered by Pipelines-as-Code when a release
+# branch (release-v*) is first created. It runs the triggers release
+# pipeline defined in tekton/release-pipeline.yaml.
+#
+# The release pipeline builds, publishes multi-arch images, uploads
+# artifacts to the release bucket, and reports the release URLs.
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: release-pipeline
+  annotations:
+    # Trigger on push events to release branches, but ONLY when the branch
+    # is first created (body.created == true). This means it fires exactly
+    # once per release branch, not on every commit pushed to it.
+    # NOTE: on-cel-expression takes precedence over on-event/on-target-branch,
+    # so the branch filter MUST be included in the CEL expression.
+    pipelinesascode.tekton.dev/on-event: "[push]"
+    pipelinesascode.tekton.dev/on-target-branch: "[refs/heads/release-v*]"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" && has(body.created) && body.created == true &&
+      target_branch.startsWith("release-v")
+    pipelinesascode.tekton.dev/pipeline: "tekton/release-pipeline.yaml"
+    pipelinesascode.tekton.dev/max-keep-runs: "5"
+spec:
+  taskRunTemplate:
+    serviceAccountName: release
+  pipelineRef:
+    name: triggers-release
+  params:
+    - name: package
+      value: github.com/tektoncd/triggers
+    - name: repoName
+      value: triggers
+    - name: gitRevision
+      value: "{{ revision }}"
+    - name: imageRegistry
+      value: ghcr.io
+    - name: imageRegistryPath
+      value: tektoncd/triggers
+    - name: imageRegistryRegions
+      value: ""
+    - name: imageRegistryUser
+      value: tekton-robot
+    # For initial releases, the version is derived from the branch name:
+    # release-v0.26.x → v0.26.0
+    - name: versionTag
+      value: '{{ cel: pac.target_branch.replace("release-", "").replace(".x", ".0") }}'
+    - name: releaseBucket
+      value: tekton-releases
+    - name: releaseAsLatest
+      value: "true"
+    - name: platforms
+      value: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,windows/amd64
+    - name: koExtraArgs
+      value: "--preserve-import-paths"
+    - name: serviceAccountImagesPath
+      value: credentials
+    - name: runTests
+      value: "true"
+  timeouts:
+    pipeline: 3h0m0s
+  workspaces:
+    - name: workarea
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+    - name: release-secret
+      secret:
+        secretName: oci-release-secret
+    - name: release-images-secret
+      secret:
+        secretName: ghcr-creds

--- a/releases.md
+++ b/releases.md
@@ -32,9 +32,14 @@ Manifests are published to cloud object-storage as well as
 verified through the [public key][chains-public-key] hosted by the Tekton Chains
 project.
 
+Releases are automated using [Pipelines-as-Code][pac]. The release PipelineRuns
+are defined in the [`.tekton/`][tekton-dir] directory and triggered automatically
+on release branch creation (initial releases) or via a weekly cron /
+manual `workflow_dispatch` (patch releases).
+
 Further documentation available:
 
-- The Tekton Triggers [release process][tekton-releases-docs]
+- The Tekton Triggers [release cheat sheet][tekton-releases-docs]
 - [Installing Tekton][tekton-installation]
 - Standard for [release notes][release-notes-standards]
 
@@ -91,10 +96,12 @@ Older releases are EOL and available on [GitHub][tekton-triggers-releases].
 [tekton-chains]: https://github.com/tektoncd/chains
 [tekton-triggers-releases]: https://github.com/tektoncd/triggers/releases
 [chains-public-key]: https://github.com/tektoncd/chains/blob/main/tekton.pub
-[tekton-releases-docs]: tekton/README.md
+[tekton-releases-docs]: tekton/release-cheat-sheet.md
 [tekton-installation]: docs/install.md
 [release-notes-standards]:
     https://github.com/tektoncd/community/blob/main/standards.md#release-notes
+[pac]: https://pipelinesascode.com
+[tekton-dir]: .tekton/
 
 [v0-27-0]: https://github.com/tektoncd/triggers/releases/tag/v0.27.0
 [v0-27-0-docs]: https://github.com/tektoncd/triggers/tree/v0.27.0/docs#tekton-triggers


### PR DESCRIPTION
## Summary

Adds `.tekton/release.yaml` and `.tekton/release-patch.yaml` to automate releases using Pipelines-as-Code, following the exact pattern already merged in:

- tektoncd/pipeline#9671
- tektoncd/chains#1656
- tektoncd/pruner#246
- tektoncd/operator#3322

The `.tekton/release.yaml` PipelineRun fires once when a `release-v*` branch is first created (CEL guard: `body.created == true`). The `.tekton/release-patch.yaml` is triggered via PAC incoming webhooks for patch releases, receiving `version` and `release_as_latest` as payload params.

The companion plumbing PR to add the `Repository` CR in tektoncd/plumbing will follow.

Closes #2061