### PR TITLE
fix: pass --insecure-registry to ko for plain-HTTP KinD registry

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -21,6 +21,9 @@ jobs:
       CLUSTER_DOMAIN: c${{ github.run_id }}.local
       ARTIFACTS: ${{ github.workspace }}/artifacts
       KOCACHE: /tmp/ko-cache
+      # registry.local:5000 is a plain-HTTP KinD registry; tell ko to skip TLS
+      # so that both image pushes and SBOM writes (ko >=v0.19) use plain HTTP.
+      KO_FLAGS: --insecure-registry
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -54,7 +54,7 @@ function install_triggers_crd() {
   echo ">> Deploying Tekton Triggers"
   rel=$(mktemp)
   release=$(mktemp)
-  ko resolve -f config/ > "${rel}" || fail_test "Tekton Triggers build failed"
+  ko resolve ${KO_FLAGS:-} -f config/ > "${rel}" || fail_test "Tekton Triggers build failed"
 
   if [ "${SKIP_SECURITY_CTX}" == "true" ]; then
       yq 'del(.spec.template.spec.containers[]?.securityContext.runAsUser, .spec.template.spec.containers[]?.securityContext.runAsGroup)' "${rel}" > "${release}"
@@ -66,7 +66,7 @@ function install_triggers_crd() {
 
   # Wait for the Interceptors CRD to be available before adding the core-interceptors
   kubectl wait --for=condition=Established --timeout=30s crds/clusterinterceptors.triggers.tekton.dev
-  ko resolve -f config/interceptors > "${rel}" || fail_test "Core interceptors build failed"
+  ko resolve ${KO_FLAGS:-} -f config/interceptors > "${rel}" || fail_test "Core interceptors build failed"
 
   if [ "${SKIP_SECURITY_CTX}" == "true" ]; then
       kubectl patch configmap config-defaults-triggers -n tekton-pipelines --type='merge' -p='{"data":{"default-run-as-user":"","default-fs-group":"", "default-run-as-group":""}}'


### PR DESCRIPTION
ko >=v0.19 writes SBOMs to the registry over HTTPS by default, which fails against the plain-HTTP KinD registry (registry.local:5000) with: "http: server gave HTTP response to HTTPS client"

Set KO_FLAGS=--insecure-registry in the e2e workflow and thread it through ko resolve calls in e2e-common.sh.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
