### PR TITLE
ci(.github/workflows): enable Codecov coverage reporting

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,32 @@
+coverage:
+  # Commit status https://docs.codecov.io/docs/commit-status are used
+  # to block PR based on coverage threshold.
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+    patch:
+      # Disable the coverage threshold of the patch, so that PRs are
+      # only failing because of overall project coverage threshold.
+      # See https://docs.codecov.io/docs/commit-status#disabling-a-status.
+      default: false
+
+ignore:
+  # Auto-generated client code.
+  - "pkg/client/clientset/**"
+  - "pkg/client/informers/**"
+  - "pkg/client/listers/**"
+  - "pkg/client/injection/**"
+  # Auto-generated deepcopy/openapi code.
+  - "pkg/apis/config/zz_generated.deepcopy.go"
+  - "pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go"
+  - "pkg/apis/triggers/v1beta1/zz_generated.deepcopy.go"
+  - "pkg/apis/triggers/v1beta1/openapi_generated.go"
+  - "examples/**"
+  - "hack/**"
+  - "test/**"
+  - "config/**"
+  - "tekton/**"
+  - "docs/**"
+  - "vendor/**"

--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       pull-requests: write # Required by go-coverage-report to comment on PRs
+      id-token: write # Required to upload coverage to Codecov via OIDC
 
     steps:
       - name: Harden runner
@@ -48,14 +49,14 @@ jobs:
       - name: Generate coverage
         working-directory: ${{ github.workspace }}/src/github.com/tektoncd/triggers
         run: |
-          go test -cover -coverprofile=coverage.txt ./... || true
+          go test -coverprofile=coverage.out -covermode=atomic ./... || true
           echo "Generated coverage profile"
 
       - name: Archive coverage results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: code-coverage
-          path: ${{ github.workspace }}/src/github.com/tektoncd/triggers/coverage.txt
+          path: ${{ github.workspace }}/src/github.com/tektoncd/triggers/coverage.out
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'
@@ -63,4 +64,13 @@ jobs:
         continue-on-error: true # This may fail if artifact on main branch does not exist (first run or expired)
         with:
           coverage-artifact-name: "code-coverage"
-          coverage-file-name: "coverage.txt"
+          coverage-file-name: "coverage.out"
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
+        continue-on-error: true # job still "succeeds" even if this step fails
+        with:
+          files: ${{ github.workspace }}/src/github.com/tektoncd/triggers/coverage.out
+          flags: unit-tests
+          use_oidc: true
+          fail_ci_if_error: false


### PR DESCRIPTION
Add .codecov.yaml with coverage thresholds and an ignore list for non-source directories, following the same change made in tekton pruner. Upload coverage to Codecov via OIDC alongside the existing artifact upload and PR-comment step.

Assisted-by: Claude Sonnet 5 (via Claude Code)

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

/kind misc

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
