### PR TITLE
fix: don't pre-parse url-encoded body for webhook-first interceptor chains

### DIFF
--- a/pkg/sink/sink.go
+++ b/pkg/sink/sink.go
@@ -483,7 +483,11 @@ func (r Sink) ExecuteInterceptors(trInt []*triggersv1.TriggerInterceptor, in *ht
 	parsedQuery, _ := net.ParseQuery(request.Body)
 
 	// parse form-data payload
-	if v := in.Header.Get("Content-Type"); v == "application/x-www-form-urlencoded" && len(parsedQuery) > 1 {
+	// Skip this when the chain starts with a deprecated webhook interceptor: that
+	// interceptor forwards the request body verbatim to an external URL, so it
+	// must receive the original body rather than a pre-parsed JSON representation.
+	if v := in.Header.Get("Content-Type"); v == "application/x-www-form-urlencoded" && len(parsedQuery) > 1 &&
+		(len(trInt) == 0 || trInt[0].Webhook == nil) {
 		// Convert the map into a JSON string
 		jsonString, err := json.Marshal(parsedQuery)
 		if err != nil {

--- a/pkg/sink/sink.go
+++ b/pkg/sink/sink.go
@@ -483,15 +483,18 @@ func (r Sink) ExecuteInterceptors(trInt []*triggersv1.TriggerInterceptor, in *ht
 	parsedQuery, _ := net.ParseQuery(request.Body)
 
 	// parse form-data payload
-	// Skip this when the chain starts with a deprecated webhook interceptor: that
-	// interceptor forwards the request body verbatim to an external URL, so it
-	// must receive the original body rather than a pre-parsed JSON representation.
+	// Skip this when the chain starts with a deprecated webhook interceptor and there
+	// are no extensions to merge into the body: that interceptor forwards the request
+	// body verbatim to an external URL, so it must receive the original body rather
+	// than a pre-parsed JSON representation. If extensions are present, they still
+	// need to be merged in below via extendBodyWithExtensions, which requires a JSON
+	// body, so the conversion must happen.
 	if v := in.Header.Get("Content-Type"); v == "application/x-www-form-urlencoded" && len(parsedQuery) > 1 &&
-		(len(trInt) == 0 || trInt[0].Webhook == nil) {
+		(trInt[0].Webhook == nil || len(request.Extensions) > 0) {
 		// Convert the map into a JSON string
 		jsonString, err := json.Marshal(parsedQuery)
 		if err != nil {
-			log.Errorf("Error converting map to JSON:", err)
+			log.Errorf("Error converting map to JSON: %v", err)
 			return nil, nil, nil, err
 		}
 		request.Body = string(jsonString)

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -1727,6 +1728,65 @@ func TestExecuteInterceptor_ExtensionChaining(t *testing.T) {
 
 	if diff := cmp.Diff(iresp.Extensions, wantExtensions); diff != "" {
 		t.Errorf("Extensions: -want +got: %s", diff)
+	}
+}
+
+// rawBodyInterceptor stores the raw request body and Content-Type header it received.
+type rawBodyInterceptor struct {
+	body        []byte
+	contentType string
+}
+
+func (f *rawBodyInterceptor) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(err.Error()))
+		return
+	}
+	defer r.Body.Close()
+	f.body = body
+	f.contentType = r.Header.Get("Content-Type")
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{}`))
+}
+
+// TestExecuteInterceptor_WebhookFirstGetsRawURLEncodedBody tests that a
+// deprecated webhook interceptor placed first in the chain receives the
+// original url-encoded request body rather than a pre-parsed JSON
+// representation. See https://github.com/tektoncd/triggers/issues/1886.
+func TestExecuteInterceptor_WebhookFirstGetsRawURLEncodedBody(t *testing.T) {
+	webhookInterceptorName := "foo"
+	rawServer := &rawBodyInterceptor{}
+	s, _ := getSinkAssets(t, test.Resources{}, "", rawServer)
+
+	trigger := triggersv1beta1.Trigger{
+		Spec: triggersv1beta1.TriggerSpec{
+			Interceptors: []*triggersv1beta1.EventInterceptor{{
+				Webhook: &triggersv1beta1.WebhookInterceptor{
+					ObjectRef: &corev1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "Service",
+						Name:       webhookInterceptorName,
+					},
+				},
+			}},
+		},
+	}
+
+	rawBody := "token=abc&user_id=123&text=hello+world"
+	req, err := http.NewRequest(http.MethodPost, "/", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	if _, _, _, err := s.ExecuteTriggerInterceptors(trigger, req, []byte(rawBody), s.Logger, eventID, map[string]interface{}{}); err != nil {
+		t.Fatalf("executeInterceptors: %v", err)
+	}
+
+	if got := string(rawServer.body); got != rawBody {
+		t.Errorf("Webhook interceptor body: want %q got %q", rawBody, got)
 	}
 }
 

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -1790,6 +1790,63 @@ func TestExecuteInterceptor_WebhookFirstGetsRawURLEncodedBody(t *testing.T) {
 	}
 }
 
+// TestExecuteInterceptor_WebhookFirstWithExtensionsGetsJSONBody tests that when
+// extensions (e.g. from a preceding TriggerGroup interceptor) are present, the
+// url-encoded body is still converted to JSON before being sent to a webhook-first
+// interceptor, since merging extensions into the body requires a JSON body.
+func TestExecuteInterceptor_WebhookFirstWithExtensionsGetsJSONBody(t *testing.T) {
+	webhookInterceptorName := "foo"
+	rawServer := &rawBodyInterceptor{}
+	s, _ := getSinkAssets(t, test.Resources{}, "", rawServer)
+
+	trigger := triggersv1beta1.Trigger{
+		Spec: triggersv1beta1.TriggerSpec{
+			Interceptors: []*triggersv1beta1.EventInterceptor{{
+				Webhook: &triggersv1beta1.WebhookInterceptor{
+					ObjectRef: &corev1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "Service",
+						Name:       webhookInterceptorName,
+					},
+				},
+			}},
+		},
+	}
+
+	rawBody := "token=abc&user_id=123&text=hello+world"
+	req, err := http.NewRequest(http.MethodPost, "/", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	extensions := map[string]interface{}{"added_field": "val1"}
+	if _, _, _, err := s.ExecuteTriggerInterceptors(trigger, req, []byte(rawBody), s.Logger, eventID, extensions); err != nil {
+		t.Fatalf("executeInterceptors: %v", err)
+	}
+
+	var gotBody map[string]interface{}
+	if err := json.Unmarshal(rawServer.body, &gotBody); err != nil {
+		t.Fatalf("expected webhook interceptor to receive JSON body when extensions are present, got %q: %v", rawServer.body, err)
+	}
+
+	// The original form fields must survive the JSON conversion: sjson.SetRawBytes
+	// silently builds a fresh JSON object from a non-JSON base, so a naive fix that
+	// skips the conversion (but still calls extendBodyWithExtensions) would lose them
+	// rather than error out.
+	wantBody := map[string]interface{}{
+		"token":   []interface{}{"abc"},
+		"user_id": []interface{}{"123"},
+		"text":    []interface{}{"hello world"},
+		"extensions": map[string]interface{}{
+			"added_field": "val1",
+		},
+	}
+	if diff := cmp.Diff(wantBody, gotBody); diff != "" {
+		t.Errorf("body: -want +got: %s", diff)
+	}
+}
+
 func TestExtendBodyWithExtensions(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
/kind bug

Motivation:

EventListener.ExecuteInterceptors() converts a url-encoded request body
(Content-Type: application/x-www-form-urlencoded) into a JSON string
(map[string][]string) before running any interceptor in the trigger's
chain. This conversion was added to let ref-style interceptors (CEL, the
built-in Slack ClusterInterceptor) address form fields as `body.<field>`.

However the conversion runs unconditionally, so it also applies when the
first interceptor in the chain is a deprecated `webhook` interceptor
(Interceptor.Webhook, an arbitrary external URL called directly by the
sink). That interceptor type is documented to forward the request body
to an external service, and users writing custom webhook interceptors to
parse form-encoded payloads themselves (e.g. Slack slash commands)
reasonably expect to receive the original raw body.

As reported in #1886, after upgrading Triggers a custom webhook
interceptor started receiving a pre-parsed JSON body with every field
value wrapped in a single-element array (e.g. `"token":["abc"]`) instead
of the original url-encoded string, breaking the interceptor's own
parsing logic. User-visible behavior for the built-in Slack/CEL
interceptor path is unchanged; this only affects the deprecated
`webhook` interceptor when it is the first interceptor in the chain and
the request Content-Type is application/x-www-form-urlencoded.

Approach:

Skip the url-encoded-to-JSON pre-conversion when the first interceptor
in the trigger's interceptor chain is a `webhook`-type interceptor, so
it receives the original, unmodified body. Ref-style interceptors
(ClusterInterceptor/Interceptor, including CEL and the built-in Slack
interceptor) are unaffected when they are first in the chain.

Validation:

  go test ./pkg/sink/...

...passed, including a new regression test
(TestExecuteInterceptor_WebhookFirstGetsRawURLEncodedBody) verifying a
webhook interceptor placed first in the chain receives the raw
url-encoded body. Confirmed the new test fails without this change
(receives the pre-parsed JSON body instead) and passes with it.

```release-note
Fix a bug where a `webhook`-type interceptor placed first in a trigger's
interceptor chain would receive a pre-parsed JSON body instead of the
original request body for `application/x-www-form-urlencoded` requests
(e.g. Slack slash commands), breaking custom interceptors that parse the
raw form-encoded payload themselves.
```

Fixes #1886

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>