### PR TITLE
fix: recompute Content-Length from body in cel-eval and binding-eval

### DIFF
--- a/cmd/binding-eval/cmd/root.go
+++ b/cmd/binding-eval/cmd/root.go
@@ -157,9 +157,21 @@ func readHTTP(path string) (*http.Request, []byte, error) {
 		bodyPart = ""
 	}
 
-	// Auto compute and fill the content length field if it is not present
-	if len(bodyPart) > 0 && !strings.Contains(headerPart, "Content-Length:") {
-		headerPart += fmt.Sprintf("\nContent-Length: %d", len(bodyPart))
+	// Recompute the Content-Length from the actual body instead of trusting
+	// whatever value is in the file: a stale or hand-edited Content-Length
+	// (e.g. from a captured webhook payload that was later modified) makes
+	// http.ReadRequest silently truncate the body, which then fails to
+	// parse as JSON even though the body itself is valid.
+	if len(bodyPart) > 0 {
+		lines := strings.Split(headerPart, "\n")
+		kept := lines[:0]
+		for _, line := range lines {
+			if strings.HasPrefix(strings.ToLower(strings.TrimSpace(line)), "content-length:") {
+				continue
+			}
+			kept = append(kept, line)
+		}
+		headerPart = strings.Join(kept, "\n") + fmt.Sprintf("\nContent-Length: %d", len(bodyPart))
 	}
 
 	// Reconstruct the HTTP request with the Content-Length header

--- a/cmd/binding-eval/cmd/root_test.go
+++ b/cmd/binding-eval/cmd/root_test.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"bytes"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -48,17 +47,26 @@ func TestEvalBindingWithCorrectContentLength(t *testing.T) {
 }
 
 func TestEvalBindingWithWrongContentLength(t *testing.T) {
-	// Test with HTTP file that has wrong content length header - expect to fail
+	// Test with HTTP file that has a wrong (stale) content length header -
+	// the actual length should be recomputed from the body, so this should pass.
 	out := new(bytes.Buffer)
-	err := evalBinding(out, "../testdata/triggerbinding.yaml", "../testdata/http_wrong_content_length.txt")
-	if err == nil {
-		t.Fatal("evalBinding with wrong Content-Length should fail, but it passed")
+	if err := evalBinding(out, "../testdata/triggerbinding.yaml", "../testdata/http_wrong_content_length.txt"); err != nil {
+		t.Fatalf("evalBinding with wrong Content-Length should pass: %v", err)
 	}
 
-	// Verify that the error is related to parsing the body
-	expectedErrorSubstring := "unexpected end of JSON input"
-	if !strings.Contains(err.Error(), expectedErrorSubstring) {
-		t.Errorf("Expected error to contain %q, got: %v", expectedErrorSubstring, err)
+	want := `[
+  {
+    "name": "bar",
+    "value": "tacocat"
+  },
+  {
+    "name": "foo",
+    "value": "body"
+  }
+]
+`
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Errorf("-want +got: %s", diff)
 	}
 }
 

--- a/cmd/cel-eval/cmd/root.go
+++ b/cmd/cel-eval/cmd/root.go
@@ -160,9 +160,21 @@ func readHTTP(path string) (*http.Request, []byte, error) {
 		bodyPart = ""
 	}
 
-	// Auto compute and fill the content length field if it is not present
-	if len(bodyPart) > 0 && !strings.Contains(headerPart, "Content-Length:") {
-		headerPart += fmt.Sprintf("\nContent-Length: %d", len(bodyPart))
+	// Recompute the Content-Length from the actual body instead of trusting
+	// whatever value is in the file: a stale or hand-edited Content-Length
+	// (e.g. from a captured webhook payload that was later modified) makes
+	// http.ReadRequest silently truncate the body, which then fails to
+	// parse as JSON even though the body itself is valid.
+	if len(bodyPart) > 0 {
+		lines := strings.Split(headerPart, "\n")
+		kept := lines[:0]
+		for _, line := range lines {
+			if strings.HasPrefix(strings.ToLower(strings.TrimSpace(line)), "content-length:") {
+				continue
+			}
+			kept = append(kept, line)
+		}
+		headerPart = strings.Join(kept, "\n") + fmt.Sprintf("\nContent-Length: %d", len(bodyPart))
 	}
 
 	// Reconstruct the HTTP request with the Content-Length header

--- a/cmd/cel-eval/cmd/root_test.go
+++ b/cmd/cel-eval/cmd/root_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -22,17 +21,16 @@ func TestEvalCEL(t *testing.T) {
 }
 
 func TestEvalBindingWithWrongContentLength(t *testing.T) {
-	// Test with HTTP file that has wrong content length header - expect to fail
+	// Test with HTTP file that has a wrong (stale) content length header -
+	// the actual length should be recomputed from the body, so this should pass.
 	out := new(bytes.Buffer)
-	err := evalCEL(context.TODO(), out, "../testdata/expression.txt", "../testdata/http_wrong_content_length.txt")
-	if err == nil {
-		t.Fatal("evalBinding with wrong Content-Length should fail, but it passed")
+	if err := evalCEL(context.TODO(), out, "../testdata/expression.txt", "../testdata/http_wrong_content_length.txt"); err != nil {
+		t.Fatalf("evalBinding with wrong Content-Length should pass: %v", err)
 	}
 
-	// Verify that the error is related to parsing the body
-	expectedErrorSubstring := "unexpected end of JSON input"
-	if !strings.Contains(err.Error(), expectedErrorSubstring) {
-		t.Errorf("Expected error to contain %q, got: %v", expectedErrorSubstring, err)
+	want := "true"
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Errorf("-want +got: %s", diff)
 	}
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`cel-eval` and `binding-eval` read a captured HTTP request from a text file
and reconstruct it into an `*http.Request` via `http.ReadRequest`. If the
file's `Content-Length` header doesn't match the actual body (e.g. a
webhook payload was captured, then hand-edited), `http.ReadRequest` trusts
the stale header and silently truncates the body, producing "failed to
parse the body as JSON: unexpected end of JSON input" even though the body
is valid JSON.

A previous fix auto-filled `Content-Length` only when the header was
*missing*. This change makes `readHTTP()` in both tools always recompute
`Content-Length` from the actual parsed body — since the whole file is
already read into memory at that point, the true length is always known
and there is no reason to trust a possibly-stale value from the file.
Updates the two `TestEvalBindingWithWrongContentLength` unit tests (one
per tool), which previously asserted this failure as expected behavior, to
now assert success.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind bug`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix `cel-eval` and `binding-eval` dev CLI tools incorrectly rejecting valid JSON payloads as unparseable when the input HTTP request file has a stale `Content-Length` header.
```

Fixes #1765