### PR TITLE
Don't require a ClusterInterceptor to exist before EventListeners can start

### DIFF
--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -170,7 +170,7 @@ func (s *sinker) getCertFromInterceptor(certPool *x509.CertPool) error {
 			}
 		}
 
-		if httpsCILen == 0 || httpsCILen != count {
+		if httpsCILen != count {
 			return false, errors.New("empty caBundle in clusterInterceptor spec")
 		}
 

--- a/pkg/adapter/adapter_test.go
+++ b/pkg/adapter/adapter_test.go
@@ -32,7 +32,7 @@ import (
 	"knative.dev/pkg/logging"
 )
 
-func TestGetHTTPClientEmptyCaBundle(t *testing.T) {
+func TestGetHTTPClientNoClusterInterceptors(t *testing.T) {
 	recorder, err := sink.NewRecorder()
 	if err != nil {
 		log.Fatal(err.Error())
@@ -50,14 +50,11 @@ func TestGetHTTPClientEmptyCaBundle(t *testing.T) {
 	}
 
 	c, err := s.getHTTPClient()
-	if err != nil && !strings.Contains(err.Error(), "empty caBundle in clusterInterceptor spec") {
-		t.Fatal(err)
+	if err != nil {
+		t.Fatalf("getHTTPClient() should not fail when no ClusterInterceptors exist, got error: %v", err)
 	}
-	if err == nil {
-		t.Fatalf("test should fail as clusterinterceptor spec cabundle is empty")
-	}
-	if diff := cmp.Diff(c, &http.Client{}); diff != "" {
-		t.Errorf("Diff: -want +got: %s", cmp.Diff(c, &http.Client{}))
+	if c == nil {
+		t.Fatal("expected a non-nil http.Client")
 	}
 }
 
@@ -109,5 +106,76 @@ func TestGetHTTPClient(t *testing.T) {
 	}
 	if diff := cmp.Diff(c, &http.Client{}); diff != "" {
 		t.Errorf("Diff: -want +got: %s", cmp.Diff(c, http.Client{}))
+	}
+}
+
+func TestGetHTTPClientPartialCaBundleMismatch(t *testing.T) {
+	recorder, err := sink.NewRecorder()
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	ctx, _ := pkgtesting.SetupFakeContext(t)
+	s := sinker{
+		Logger:    logging.FromContext(ctx),
+		Namespace: "",
+		Args:      sink.Args{},
+		Clients: sink.Clients{
+			TriggersClient: faketriggersclient.Get(ctx),
+		},
+		Recorder: recorder,
+		injCtx:   ctx,
+	}
+
+	icInformer := fakeClusterInterceptorinformer.Get(ctx)
+
+	withBundle := &v1alpha1.ClusterInterceptor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "github",
+			Labels: map[string]string{"server/type": "https"},
+		},
+		Spec: v1alpha1.ClusterInterceptorSpec{ClientConfig: v1alpha1.ClientConfig{
+			CaBundle: []byte(`-----BEGIN CERTIFICATE-----
+MIIC9zCCAp2gAwIBAgIRAKP/YbJQxCc9craVPO2Hk+EwCgYIKoZIzj0EAwIwVzEU
+MBIGA1UEChMLa25hdGl2ZS5kZXYxPzA9BgNVBAMTNnRla3Rvbi10cmlnZ2Vycy1j
+b3JlLWludGVyY2VwdG9ycy50ZWt0b24tcGlwZWxpbmVzLnN2YzAgFw0yMjA2MjIx
+NjExMTVaGA8yMTIyMDUyOTE2MTExNVowVzEUMBIGA1UEChMLa25hdGl2ZS5kZXYx
+PzA9BgNVBAMTNnRla3Rvbi10cmlnZ2Vycy1jb3JlLWludGVyY2VwdG9ycy50ZWt0
+b24tcGlwZWxpbmVzLnN2YzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABDuUpM+D
+UneJ3cQbx74pJGLh2Mi1DG5eNa6dmHnLxxaBvWMLN9zwcgKwbv4uIWHl+djoiZUh
+4QQhIFPO/KCmRrajggFGMIIBQjAOBgNVHQ8BAf8EBAMCAoQwHQYDVR0lBBYwFAYI
+KwYBBQUHAwEGCCsGAQUFBwMCMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFJW+
+7Q9RbfZ7P1AcIWtB6rCS9kgxMIHgBgNVHREEgdgwgdWCIXRla3Rvbi10cmlnZ2Vy
+cy1jb3JlLWludGVyY2VwdG9yc4IydGVrdG9uLXRyaWdnZXJzLWNvcmUtaW50ZXJj
+ZXB0b3JzLnRla3Rvbi1waXBlbGluZXOCNnRla3Rvbi10cmlnZ2Vycy1jb3JlLWlu
+dGVyY2VwdG9ycy50ZWt0b24tcGlwZWxpbmVzLnN2Y4JEdGVrdG9uLXRyaWdnZXJz
+LWNvcmUtaW50ZXJjZXB0b3JzLnRla3Rvbi1waXBlbGluZXMuc3ZjLmNsdXN0ZXIu
+bG9jYWwwCgYIKoZIzj0EAwIDSAAwRQIhAN8NR10IKHxaKWkJ4pUuwyc4Zfdn+57z
+ze7tgKNtoxVDAiAdaBV/2TCy+gWkcPTxpz7hOu0vzlffx8sWFwZNWvUXPA==
+-----END CERTIFICATE-----
+`),
+		}},
+	}
+	withoutBundle := &v1alpha1.ClusterInterceptor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "gitlab",
+			Labels: map[string]string{"server/type": "https"},
+		},
+	}
+	if err := icInformer.Informer().GetIndexer().Add(withBundle); err != nil {
+		t.Fatal(err)
+	}
+	if err := icInformer.Informer().GetIndexer().Add(withoutBundle); err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := s.getHTTPClient()
+	if err == nil {
+		t.Fatal("test should fail as one https ClusterInterceptor has an empty caBundle")
+	}
+	if !strings.Contains(err.Error(), "empty caBundle in clusterInterceptor spec") {
+		t.Fatalf("expected 'empty caBundle in clusterInterceptor spec' error, got: %v", err)
+	}
+	if diff := cmp.Diff(c, &http.Client{}); diff != "" {
+		t.Errorf("Diff: -want +got: %s", diff)
 	}
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`getCertFromInterceptor()` in `pkg/adapter/adapter.go` builds the TLS cert pool
the EventListener sink uses to call interceptors. Before accepting the pool as
ready, it required BOTH "at least one ClusterInterceptor labeled
`server/type: https` exists" AND "every such ClusterInterceptor has a non-empty
caBundle." The first requirement is unnecessary: if zero https-labeled
ClusterInterceptors exist, there's nothing to validate, so startup should not
be blocked. In practice this meant every EventListener pod in the cluster
would crash-loop with `empty caBundle in clusterInterceptor spec` whenever no
https-labeled ClusterInterceptor existed cluster-wide (e.g. a minimal install
without the core-interceptors manifest, or a custom ClusterInterceptor created
without the `server/type` label) -- even for EventListeners whose triggers use
no interceptors at all.

This drops the `httpsCILen == 0` requirement, leaving only the genuine
mismatch check: some https-labeled ClusterInterceptor exists but lacks a
caBundle. The equivalent loop over `Interceptor` resources a few lines below
never had this extra requirement, so this brings the `ClusterInterceptor` loop
in line with it.

Validated with `go build ./pkg/...` and `go test ./pkg/adapter/... -v
-count=10` (all pass, no flakiness). `TestGetHTTPClientNoClusterInterceptors`
reproduces the reported crash path with a fake clientset/informer holding zero
ClusterInterceptors and confirms `getHTTPClient()` now succeeds instead of
erroring. `TestGetHTTPClientPartialCaBundleMismatch` confirms a genuine
caBundle mismatch is still correctly rejected.

This does not address the issue's other two named root causes (defaulting
only applying the `server/type` label during upgrade-via-defaulting, and a
claim about `disallowUnknownFields` rejecting `caBundle`) -- those are
independent of this code path.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind bug`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix EventListener pods crash-looping with "empty caBundle in clusterInterceptor spec" when no ClusterInterceptor labeled `server/type: https` exists in the cluster, even when the EventListener's triggers use no interceptors.
```

Fixes #2034