### PR TITLE
Return clear error for unsupported interceptor kind in sink

### DIFF
--- a/pkg/sink/sink.go
+++ b/pkg/sink/sink.go
@@ -563,6 +563,8 @@ func (r Sink) ExecuteInterceptors(trInt []*triggersv1.TriggerInterceptor, in *ht
 			if err != nil {
 				return nil, nil, nil, fmt.Errorf("could not resolve nameSpacedinterceptor URL: %w", err)
 			}
+		} else {
+			return nil, nil, nil, fmt.Errorf("unsupported interceptor kind %q for interceptor %s", i.Ref.Kind, i.GetName())
 		}
 
 		interceptorResponse, err := interceptors.Execute(context.Background(), r.HTTPClient, &request, url.String())

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -1642,9 +1642,9 @@ func TestExecuteInterceptor_UnsupportedKind(t *testing.T) {
 			}}},
 	}
 	url, _ := url.Parse("http://example.com")
-	_, _, _, err := s.ExecuteTriggerInterceptors(trigger, &http.Request{URL: url}, json.RawMessage(`{"head": "blah"}`), s.Logger, "eventID", map[string]interface{}{})
+	resp, _, _, err := s.ExecuteTriggerInterceptors(trigger, &http.Request{URL: url}, json.RawMessage(`{"head": "blah"}`), s.Logger, "eventID", map[string]interface{}{})
 	if err == nil {
-		t.Fatalf("ExecuteInterceptor() expected an error for an unsupported interceptor kind, got none")
+		t.Fatalf("ExecuteInterceptor() expected an error for an unsupported interceptor kind, got none: %+v", resp)
 	}
 }
 

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -1646,6 +1646,9 @@ func TestExecuteInterceptor_UnsupportedKind(t *testing.T) {
 	if err == nil {
 		t.Fatalf("ExecuteInterceptor() expected an error for an unsupported interceptor kind, got none: %+v", resp)
 	}
+	if !strings.Contains(err.Error(), "unsupported interceptor kind") {
+		t.Fatalf("ExecuteInterceptor() expected error to contain %q, got: %v", "unsupported interceptor kind", err)
+	}
 }
 
 // echoInterceptor stores and returns the body back

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -1626,6 +1626,28 @@ func TestExecuteInterceptor_NotContinue(t *testing.T) {
 	}
 }
 
+func TestExecuteInterceptor_UnsupportedKind(t *testing.T) {
+	resources := test.Resources{
+		ClusterInterceptors: []*triggersv1alpha1.ClusterInterceptor{cel},
+	}
+	s, _ := getSinkAssets(t, resources, "el-name", nil)
+	trigger := triggersv1beta1.Trigger{
+		Spec: triggersv1beta1.TriggerSpec{
+			Interceptors: []*triggersv1beta1.EventInterceptor{{
+				Ref: triggersv1beta1.InterceptorRef{Name: "cel", Kind: "UnknownInterceptorKind"},
+				Params: []triggersv1beta1.InterceptorParams{{
+					Name:  "filter",
+					Value: test.ToV1JSON(t, `body.head == "abcde"`),
+				}},
+			}}},
+	}
+	url, _ := url.Parse("http://example.com")
+	_, _, _, err := s.ExecuteTriggerInterceptors(trigger, &http.Request{URL: url}, json.RawMessage(`{"head": "blah"}`), s.Logger, "eventID", map[string]interface{}{})
+	if err == nil {
+		t.Fatalf("ExecuteInterceptor() expected an error for an unsupported interceptor kind, got none")
+	}
+}
+
 // echoInterceptor stores and returns the body back
 type echoInterceptor struct {
 	body map[string]interface{}


### PR DESCRIPTION
# Changes

Fixes a confusing error surfaced by the eventlistener sink when a `TriggerInterceptor`'s `Ref.Kind` is neither `ClusterInterceptor` nor `NamespacedInterceptor` (for example, when a `Trigger` is created before the admission webhook has defaulted the interceptor kind, as seen in ArgoCD-managed clusters). Previously, `Sink.ExecuteInterceptors` left the local `url` variable `nil` in this case and passed it straight to `interceptors.Execute`, resulting in the sink POSTing to an empty URL and surfacing Go's raw transport error `Post "": unsupported protocol scheme ""` instead of a message identifying the actual problem.

This adds the missing `else` branch alongside the existing `Kind` checks in `ExecuteInterceptors` (`pkg/sink/sink.go`) so an unrecognized/unset `Ref.Kind` returns a clear, immediate error naming the offending interceptor kind and name, and fails fast rather than after an HTTP round-trip attempt. This does not change the outcome for the request (the interceptor still cannot run and the trigger still will not fire either way) — it only replaces the cryptic low-level HTTP error with an actionable one.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
The eventlistener sink now returns a clear error when a TriggerInterceptor has an unsupported or unset Ref.Kind, instead of a cryptic `Post "": unsupported protocol scheme ""` error.
```

---
AI assistance: this change was drafted with Claude Code.

Fixes #1772