### PR TITLE
Fix codecov ignore patterns to align with coverage dashboard

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -13,20 +13,19 @@ coverage:
       default: false
 
 ignore:
+  # Entry-point binaries — not unit-testable.
+  - "cmd"
   # Auto-generated client code.
-  - "pkg/client/clientset/**"
-  - "pkg/client/informers/**"
-  - "pkg/client/listers/**"
-  - "pkg/client/injection/**"
+  - "pkg/client/"
+  # CLI bootstrap utility — not unit-testable.
+  - "pkg/bootstrap/"
   # Auto-generated deepcopy/openapi code.
-  - "pkg/apis/config/zz_generated.deepcopy.go"
-  - "pkg/apis/triggers/v1alpha1/zz_generated.deepcopy.go"
-  - "pkg/apis/triggers/v1beta1/zz_generated.deepcopy.go"
-  - "pkg/apis/triggers/v1beta1/openapi_generated.go"
-  - "examples/**"
-  - "hack/**"
-  - "test/**"
-  - "config/**"
-  - "tekton/**"
-  - "docs/**"
-  - "vendor/**"
+  - "**/zz_generated.deepcopy.go"
+  - "**/openapi_generated.go"
+  - "examples"
+  - "hack"
+  - "test"
+  - "config"
+  - "tekton"
+  - "docs"
+  - "vendor"

--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -49,7 +49,11 @@ jobs:
       - name: Generate coverage
         working-directory: ${{ github.workspace }}/src/github.com/tektoncd/triggers
         run: |
-          go test -coverprofile=coverage.out -covermode=atomic ./... || true
+          PACKAGES=$(go list ./... | grep -vE '/cmd(/|$)|/vendor(/|$)|/hack(/|$)|/test(/|$)|/fake(/|$)|/pkg/client(/|$)|/examples(/|$)|/pkg/bootstrap(/|$)')
+          COVERPKG=$(echo $PACKAGES | tr ' ' ',')
+          go test -coverprofile=coverage_raw.out -covermode=atomic -coverpkg="$COVERPKG" $PACKAGES || true
+          grep -vE 'zz_generated\.deepcopy\.go|openapi_generated\.go|metrics/provider\.go' coverage_raw.out > coverage.out
+          rm -f coverage_raw.out
           echo "Generated coverage profile"
 
       - name: Archive coverage results
@@ -74,3 +78,4 @@ jobs:
           flags: unit-tests
           use_oidc: true
           fail_ci_if_error: false
+          disable_search: true


### PR DESCRIPTION
The codecov report showed ~27-32% coverage while the coverage dashboard [1] reported ~76% for the same codebase. The gap was caused by missing and broken ignore patterns:

- Add cmd/ to ignore list (untestable entry-point binaries, ~1926 lines)
- Consolidate pkg/client/ subdirectory patterns into a single entry
- Use glob patterns for generated files (zz_generated.deepcopy.go, openapi_generated.go) to auto-catch new API versions
- Use bare directory names instead of folder/** globs to fix pattern matching (e.g. examples/v1alpha1/webhook-interceptors was not excluded)

[1] https://openshift-pipelines.github.io/coverage-dashboard/

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
