### PR TITLE
Skip e2e tests when only non-e2e workflow files change

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ jobs:
     outputs:
       non-docs: ${{ steps.detect.outputs.non-docs }}
       yaml: ${{ steps.detect.outputs.yaml }}
+      e2e: ${{ steps.detect.outputs.e2e }}
     steps:
     - name: Get base depth
       id: base-depth
@@ -61,8 +62,26 @@ jobs:
             fi
           done <<< "${CHANGED_FILES}"
 
+          E2E='false'
+          while read -r file; do
+            case "$file" in
+              *.md) ;;
+              .codecov.yaml|codecov.yml) ;;
+              .github/workflows/ci.yaml|.github/workflows/e2e-matrix.yml|.github/workflows/microshift.yaml)
+                E2E='true'
+                break
+                ;;
+              .github/workflows/*) ;;
+              *)
+                E2E='true'
+                break
+                ;;
+            esac
+          done <<< "${CHANGED_FILES}"
+
           echo "non-docs=${NON_DOCS}" | tee -a $GITHUB_OUTPUT
           echo "yaml=${YAML}" | tee -a $GITHUB_OUTPUT
+          echo "e2e=${E2E}" | tee -a $GITHUB_OUTPUT
         fi
 
   build:
@@ -173,7 +192,8 @@ jobs:
           KO_DOCKER_REPO=example.com ko resolve --platform=all --push=false -R -f config 1>/dev/null
           KO_DOCKER_REPO=example.com ko resolve --platform=all --push=false -f config/interceptors 1>/dev/null
   e2e-tests:
-    needs: [build]
+    needs: [changes, build]
+    if: ${{ needs.changes.outputs.e2e == 'true' }}
     uses: ./.github/workflows/e2e-matrix.yml
 
   ci-summary:


### PR DESCRIPTION
Adds change detection logic to categorize whether modified files require e2e testing. Non-e2e workflow files (go-coverage, codeql, dependabot-regen, etc.), codecov config, and docs skip e2e.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
