### PR TITLE
Warn on unresolved TriggerTemplate params

### DIFF
--- a/cmd/binding-eval/cmd/root.go
+++ b/cmd/binding-eval/cmd/root.go
@@ -83,7 +83,7 @@ func evalBinding(w io.Writer, bindingPath, httpPath string) error {
 		BindingParams: bindingParams,
 	}
 
-	params, err := template.ResolveParams(t, body, r.Header, map[string]interface{}{}, template.NewTriggerContext(""))
+	params, _, err := template.ResolveParams(t, body, r.Header, map[string]interface{}{}, template.NewTriggerContext(""))
 	if err != nil {
 		return fmt.Errorf("error resolving params: %w", err)
 	}

--- a/cmd/triggerrun/cmd/root.go
+++ b/cmd/triggerrun/cmd/root.go
@@ -229,7 +229,7 @@ func processTriggerSpec(kubeClient kubernetes.Interface, client triggersclientse
 	if iresp != nil && iresp.Extensions != nil {
 		extensions = iresp.Extensions
 	}
-	params, err := template.ResolveParams(rt, finalPayload, header, extensions, template.NewTriggerContext(eventID))
+	params, _, err := template.ResolveParams(rt, finalPayload, header, extensions, template.NewTriggerContext(eventID))
 	if err != nil {
 		log.Error("Failed to resolve parameters", err)
 		return nil, err

--- a/pkg/sink/sink.go
+++ b/pkg/sink/sink.go
@@ -432,10 +432,13 @@ func (r Sink) processTrigger(t triggersv1.Trigger, el *triggersv1.EventListener,
 	if iresp != nil && iresp.Extensions != nil {
 		extensions = iresp.Extensions
 	}
-	params, err := template.ResolveParams(rt, finalPayload, header, extensions, template.NewTriggerContext(eventID))
+	params, unresolved, err := template.ResolveParams(rt, finalPayload, header, extensions, template.NewTriggerContext(eventID))
 	if err != nil {
 		log.Error(err)
 		return
+	}
+	if len(unresolved) > 0 {
+		log.Warnf("Trigger %q has TriggerTemplate params with no value or default: %v; rendered resources may retain literal $(tt.params.<name>) references and be rejected", t.Name, unresolved)
 	}
 
 	log.Infof("ResolvedParams : %+v", params)

--- a/pkg/sink/sink_test.go
+++ b/pkg/sink/sink_test.go
@@ -1434,6 +1434,80 @@ func TestHandleEvent_Error(t *testing.T) {
 	}
 }
 
+// TestHandleEvent_UnresolvedParamsWarning verifies the sink logs a warning when a
+// TriggerTemplate declares a param with no binding value and no default, and stays
+// silent when every declared param is resolved.
+func TestHandleEvent_UnresolvedParamsWarning(t *testing.T) {
+	eventBody := []byte(`{"head_commit": {"id": "testrevision"}, "repository": {"url": "testurl"}, "foo": "bar"}`)
+	const elName = "test-el"
+	bindings := []*triggersv1beta1.EventListenerBinding{
+		{Name: "url", Value: ptr.String("$(body.repository.url)")},
+		{Name: "revision", Value: ptr.String("$(body.head_commit.id)")},
+		{Name: "name", Value: ptr.String("git-clone-run")},
+		{Name: "app", Value: ptr.String("$(body.foo)")},
+		{Name: "type", Value: ptr.String("$(header.Content-Type)")},
+	}
+	resolvedTTSpec := makeGitCloneTTSpec(t, "git-clone-run")
+	unresolvedTTSpec := makeGitCloneTTSpec(t, "git-clone-run")
+	// MESSAGE has no default and no matching binding -> unresolved.
+	unresolvedTTSpec.Params = append(unresolvedTTSpec.Params, triggersv1beta1.ParamSpec{Name: "MESSAGE"})
+
+	const warnMsg = "has TriggerTemplate params with no value or default"
+	for _, tc := range []struct {
+		name     string
+		ttSpec   *triggersv1beta1.TriggerTemplateSpec
+		wantWarn bool
+	}{
+		{name: "unresolved param logs warning", ttSpec: unresolvedTTSpec, wantWarn: true},
+		{name: "resolved params log no warning", ttSpec: resolvedTTSpec, wantWarn: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res := test.Resources{
+				EventListeners: []*triggersv1beta1.EventListener{{
+					ObjectMeta: metav1.ObjectMeta{Name: elName, Namespace: namespace, UID: types.UID(elUID)},
+					Spec: triggersv1beta1.EventListenerSpec{
+						Triggers: []triggersv1beta1.EventListenerTrigger{{
+							Name:     "git-clone-trigger",
+							Bindings: bindings,
+							Template: &triggersv1beta1.EventListenerTemplate{Spec: tc.ttSpec},
+						}},
+					},
+				}},
+			}
+			sink, _ := getSinkAssets(t, res, elName, nil)
+
+			core, logs := observer.New(zapcore.DebugLevel)
+			sink.Logger = zaptest.NewLogger(t, zaptest.WrapOptions(zap.WrapCore(func(zapcore.Core) zapcore.Core { return core }))).Sugar()
+
+			for _, el := range res.EventListeners {
+				el.Status.SetCondition(&apis.Condition{Type: apis.ConditionReady, Status: corev1.ConditionTrue, Message: "EventListener is Ready"})
+			}
+
+			ts := httptest.NewServer(http.HandlerFunc(sink.HandleEvent))
+			defer ts.Close()
+			req, err := http.NewRequest(http.MethodPost, ts.URL, bytes.NewReader(eventBody))
+			if err != nil {
+				t.Fatalf("error creating request: %s", err)
+			}
+			req.Header.Add("Content-Type", "application/json")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("error sending request: %s", err)
+			}
+			resp.Body.Close()
+			sink.WGProcessTriggers.Wait()
+
+			matches := logs.FilterMessageSnippet(warnMsg)
+			switch {
+			case tc.wantWarn && matches.Len() == 0:
+				t.Errorf("expected a warning containing %q, got logs: %v", warnMsg, logs.All())
+			case !tc.wantWarn && matches.Len() > 0:
+				t.Errorf("expected no unresolved-param warning, got: %v", matches.All())
+			}
+		})
+	}
+}
+
 // sequentialInterceptor is a HTTP server that will return sequential responses.
 // It expects a request of the form `{"i": n}`.
 // The response body will always return with the next value set, whereas the

--- a/pkg/template/event.go
+++ b/pkg/template/event.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,18 +47,20 @@ func NewTriggerContext(eventID string) TriggerContext {
 
 // ResolveParams takes given triggerbindings and produces the resulting
 // resource params.
-func ResolveParams(rt ResolvedTrigger, body []byte, header http.Header, extensions map[string]interface{}, triggerContext TriggerContext) ([]triggersv1.Param, error) {
+// The returned string slice lists declared params that got no value (no binding
+// value and no default), leaving literal $(tt.params.<name>) refs.
+func ResolveParams(rt ResolvedTrigger, body []byte, header http.Header, extensions map[string]interface{}, triggerContext TriggerContext) ([]triggersv1.Param, []string, error) {
 	var ttParams []triggersv1.ParamSpec
 	if rt.TriggerTemplate != nil {
 		ttParams = rt.TriggerTemplate.Spec.Params
 	}
 
-	out, err := applyEventValuesToParams(rt.BindingParams, body, header, extensions, ttParams, triggerContext)
+	out, unresolved, err := applyEventValuesToParams(rt.BindingParams, body, header, extensions, ttParams, triggerContext)
 	if err != nil {
-		return nil, fmt.Errorf("failed to ApplyEventValuesToParams: %w", err)
+		return nil, nil, fmt.Errorf("failed to ApplyEventValuesToParams: %w", err)
 	}
 
-	return out, nil
+	return out, unresolved, nil
 }
 
 // ResolveResources resolves a templated resource by replacing params with their values.
@@ -107,16 +110,19 @@ func newEvent(body []byte, headers http.Header, extensions map[string]interface{
 // with values from the event body, headers, and extensions.
 func applyEventValuesToParams(params []triggersv1.Param, body []byte, header http.Header, extensions map[string]interface{},
 	defaults []triggersv1.ParamSpec,
-	triggerContext TriggerContext) ([]triggersv1.Param, error) {
+	triggerContext TriggerContext) ([]triggersv1.Param, []string, error) {
 	event, err := newEvent(body, header, extensions, triggerContext)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal event: %w", err)
+		return nil, nil, fmt.Errorf("failed to marshal event: %w", err)
 	}
 
 	allParamsMap := map[string]string{}
+	unresolved := map[string]struct{}{}
 	for _, paramSpec := range defaults {
 		if paramSpec.Default != nil {
 			allParamsMap[paramSpec.Name] = *paramSpec.Default
+		} else {
+			unresolved[paramSpec.Name] = struct{}{}
 		}
 	}
 
@@ -135,11 +141,18 @@ func applyEventValuesToParams(params []triggersv1.Param, body []byte, header htt
 				}
 			}
 			if err != nil {
-				return nil, fmt.Errorf("failed to replace JSONPath value for param %s: %s: %w", p.Name, p.Value, err)
+				return nil, nil, fmt.Errorf("failed to replace JSONPath value for param %s: %s: %w", p.Name, p.Value, err)
 			}
 			pValue = strings.ReplaceAll(pValue, originals[i], val)
 		}
 		allParamsMap[p.Name] = pValue
+		delete(unresolved, p.Name)
 	}
-	return convertParamMapToArray(allParamsMap), nil
+
+	names := make([]string, 0, len(unresolved))
+	for n := range unresolved {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return convertParamMapToArray(allParamsMap), names, nil
 }

--- a/pkg/template/event_test.go
+++ b/pkg/template/event_test.go
@@ -130,7 +130,7 @@ func TestApplyEventValuesMergeInDefaultParams(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := applyEventValuesToParams(tt.args.params, nil, nil, nil, tt.args.paramSpecs, context)
+			got, _, err := applyEventValuesToParams(tt.args.params, nil, nil, nil, tt.args.paramSpecs, context)
 			if err != nil {
 				t.Errorf("applyEventValuesToParams(): unexpected error: %s", err.Error())
 			}
@@ -306,7 +306,7 @@ func TestApplyEventValuesToParams(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := applyEventValuesToParams(tt.params, tt.body, tt.header, tt.extensions, nil, context)
+			got, _, err := applyEventValuesToParams(tt.params, tt.body, tt.header, tt.extensions, nil, context)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -350,7 +350,7 @@ func TestApplyEventValuesToParams_Error(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := applyEventValuesToParams(tt.params, tt.body, tt.header, tt.extensions, nil, context)
+			got, _, err := applyEventValuesToParams(tt.params, tt.body, tt.header, tt.extensions, nil, context)
 			if err == nil {
 				t.Errorf("did not get expected error - got: %v", got)
 			}
@@ -477,7 +477,7 @@ func TestResolveParams(t *testing.T) {
 				TriggerTemplate: tt.template,
 			}
 
-			params, err := ResolveParams(rt, tt.body, map[string][]string{}, tt.extensions, NewTriggerContext(eventID))
+			params, _, err := ResolveParams(rt, tt.body, map[string][]string{}, tt.extensions, NewTriggerContext(eventID))
 			if err != nil {
 				t.Fatalf("ResolveParams() returned unexpected error: %s", err)
 			}
@@ -511,11 +511,40 @@ func TestResolveParams_Error(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			params, err := ResolveParams(ResolvedTrigger{BindingParams: tt.bindingParams}, tt.body, map[string][]string{}, tt.extensions, NewTriggerContext(eventID))
+			params, _, err := ResolveParams(ResolvedTrigger{BindingParams: tt.bindingParams}, tt.body, map[string][]string{}, tt.extensions, NewTriggerContext(eventID))
 			if err == nil {
 				t.Errorf("did not get expected error - got: %v", params)
 			}
 		})
+	}
+}
+
+func TestResolveParams_Unresolved(t *testing.T) {
+	rt := ResolvedTrigger{
+		BindingParams: []triggersv1.Param{
+			// "message" (lower-case) does not match declared "MESSAGE".
+			{Name: "message", Value: "hi"},
+			// "revision" exactly matches a declared param with no default.
+			{Name: "revision", Value: "abc123"},
+		},
+		TriggerTemplate: &triggersv1.TriggerTemplate{
+			Spec: triggersv1.TriggerTemplateSpec{
+				Params: []triggersv1.ParamSpec{
+					{Name: "MESSAGE"},
+					{Name: "gitrevision"},
+					{Name: "revision"},
+					{Name: "withDefault", Default: ptr.String("d")},
+				},
+			},
+		},
+	}
+	_, unresolved, err := ResolveParams(rt, nil, map[string][]string{}, nil, NewTriggerContext("1"))
+	if err != nil {
+		t.Fatalf("ResolveParams() returned unexpected error: %s", err)
+	}
+	want := []string{"MESSAGE", "gitrevision"}
+	if diff := cmp.Diff(want, unresolved); diff != "" {
+		t.Errorf("unresolved params -want +got: %s", diff)
 	}
 }
 


### PR DESCRIPTION
ResolveParams now reports declared params with no binding value and no default. The sink logs a warning instead of silently emitting literal $(tt.params.<name>) refs, which the pipeline webhook now rejects.

/kind bug

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
The Eventlistener now logs a warning instead of silently emitting literal $(tt.params.<name>) refs.

```
